### PR TITLE
Use Java Verifier in jbmc-regression benchmarks

### DIFF
--- a/java/MinePump/spec1-5_product1.yml
+++ b/java/MinePump/spec1-5_product1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product1/
+input_files:
+  - ../common/
+  - spec1-5_product1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product10.yml
+++ b/java/MinePump/spec1-5_product10.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product10/
+input_files:
+  - ../common/
+  - spec1-5_product10/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product11.yml
+++ b/java/MinePump/spec1-5_product11.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product11/
+input_files:
+  - ../common/
+  - spec1-5_product11/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product12.yml
+++ b/java/MinePump/spec1-5_product12.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product12/
+input_files:
+  - ../common/
+  - spec1-5_product12/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product13.yml
+++ b/java/MinePump/spec1-5_product13.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product13/
+input_files:
+  - ../common/
+  - spec1-5_product13/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product14.yml
+++ b/java/MinePump/spec1-5_product14.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product14/
+input_files:
+  - ../common/
+  - spec1-5_product14/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product15.yml
+++ b/java/MinePump/spec1-5_product15.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product15/
+input_files:
+  - ../common/
+  - spec1-5_product15/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product16.yml
+++ b/java/MinePump/spec1-5_product16.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product16/
+input_files:
+  - ../common/
+  - spec1-5_product16/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product17.yml
+++ b/java/MinePump/spec1-5_product17.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product17/
+input_files:
+  - ../common/
+  - spec1-5_product17/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product18.yml
+++ b/java/MinePump/spec1-5_product18.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product18/
+input_files:
+  - ../common/
+  - spec1-5_product18/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product19.yml
+++ b/java/MinePump/spec1-5_product19.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product19/
+input_files:
+  - ../common/
+  - spec1-5_product19/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product2.yml
+++ b/java/MinePump/spec1-5_product2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product2/
+input_files:
+  - ../common/
+  - spec1-5_product2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product20.yml
+++ b/java/MinePump/spec1-5_product20.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product20/
+input_files:
+  - ../common/
+  - spec1-5_product20/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product21.yml
+++ b/java/MinePump/spec1-5_product21.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product21/
+input_files:
+  - ../common/
+  - spec1-5_product21/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product22.yml
+++ b/java/MinePump/spec1-5_product22.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product22/
+input_files:
+  - ../common/
+  - spec1-5_product22/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product23.yml
+++ b/java/MinePump/spec1-5_product23.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product23/
+input_files:
+  - ../common/
+  - spec1-5_product23/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product24.yml
+++ b/java/MinePump/spec1-5_product24.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product24/
+input_files:
+  - ../common/
+  - spec1-5_product24/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product25.yml
+++ b/java/MinePump/spec1-5_product25.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product25/
+input_files:
+  - ../common/
+  - spec1-5_product25/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product26.yml
+++ b/java/MinePump/spec1-5_product26.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product26/
+input_files:
+  - ../common/
+  - spec1-5_product26/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product27.yml
+++ b/java/MinePump/spec1-5_product27.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product27/
+input_files:
+  - ../common/
+  - spec1-5_product27/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product28.yml
+++ b/java/MinePump/spec1-5_product28.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product28/
+input_files:
+  - ../common/
+  - spec1-5_product28/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product29.yml
+++ b/java/MinePump/spec1-5_product29.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product29/
+input_files:
+  - ../common/
+  - spec1-5_product29/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product3.yml
+++ b/java/MinePump/spec1-5_product3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product3/
+input_files:
+  - ../common/
+  - spec1-5_product3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product30.yml
+++ b/java/MinePump/spec1-5_product30.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product30/
+input_files:
+  - ../common/
+  - spec1-5_product30/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product31.yml
+++ b/java/MinePump/spec1-5_product31.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product31/
+input_files:
+  - ../common/
+  - spec1-5_product31/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product32.yml
+++ b/java/MinePump/spec1-5_product32.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product32/
+input_files:
+  - ../common/
+  - spec1-5_product32/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product33.yml
+++ b/java/MinePump/spec1-5_product33.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product33/
+input_files:
+  - ../common/
+  - spec1-5_product33/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product34.yml
+++ b/java/MinePump/spec1-5_product34.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product34/
+input_files:
+  - ../common/
+  - spec1-5_product34/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product35.yml
+++ b/java/MinePump/spec1-5_product35.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product35/
+input_files:
+  - ../common/
+  - spec1-5_product35/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product36.yml
+++ b/java/MinePump/spec1-5_product36.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product36/
+input_files:
+  - ../common/
+  - spec1-5_product36/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product37.yml
+++ b/java/MinePump/spec1-5_product37.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product37/
+input_files:
+  - ../common/
+  - spec1-5_product37/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product38.yml
+++ b/java/MinePump/spec1-5_product38.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product38/
+input_files:
+  - ../common/
+  - spec1-5_product38/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product39.yml
+++ b/java/MinePump/spec1-5_product39.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product39/
+input_files:
+  - ../common/
+  - spec1-5_product39/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product4.yml
+++ b/java/MinePump/spec1-5_product4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product4/
+input_files:
+  - ../common/
+  - spec1-5_product4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product40.yml
+++ b/java/MinePump/spec1-5_product40.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product40/
+input_files:
+  - ../common/
+  - spec1-5_product40/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product41.yml
+++ b/java/MinePump/spec1-5_product41.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product41/
+input_files:
+  - ../common/
+  - spec1-5_product41/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product42.yml
+++ b/java/MinePump/spec1-5_product42.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product42/
+input_files:
+  - ../common/
+  - spec1-5_product42/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product43.yml
+++ b/java/MinePump/spec1-5_product43.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product43/
+input_files:
+  - ../common/
+  - spec1-5_product43/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product44.yml
+++ b/java/MinePump/spec1-5_product44.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product44/
+input_files:
+  - ../common/
+  - spec1-5_product44/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product45.yml
+++ b/java/MinePump/spec1-5_product45.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product45/
+input_files:
+  - ../common/
+  - spec1-5_product45/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product46.yml
+++ b/java/MinePump/spec1-5_product46.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product46/
+input_files:
+  - ../common/
+  - spec1-5_product46/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product47.yml
+++ b/java/MinePump/spec1-5_product47.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product47/
+input_files:
+  - ../common/
+  - spec1-5_product47/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product48.yml
+++ b/java/MinePump/spec1-5_product48.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product48/
+input_files:
+  - ../common/
+  - spec1-5_product48/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product49.yml
+++ b/java/MinePump/spec1-5_product49.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product49/
+input_files:
+  - ../common/
+  - spec1-5_product49/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product5.yml
+++ b/java/MinePump/spec1-5_product5.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product5/
+input_files:
+  - ../common/
+  - spec1-5_product5/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product50.yml
+++ b/java/MinePump/spec1-5_product50.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product50/
+input_files:
+  - ../common/
+  - spec1-5_product50/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product51.yml
+++ b/java/MinePump/spec1-5_product51.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product51/
+input_files:
+  - ../common/
+  - spec1-5_product51/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product52.yml
+++ b/java/MinePump/spec1-5_product52.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product52/
+input_files:
+  - ../common/
+  - spec1-5_product52/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product53.yml
+++ b/java/MinePump/spec1-5_product53.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product53/
+input_files:
+  - ../common/
+  - spec1-5_product53/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product54.yml
+++ b/java/MinePump/spec1-5_product54.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product54/
+input_files:
+  - ../common/
+  - spec1-5_product54/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product55.yml
+++ b/java/MinePump/spec1-5_product55.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product55/
+input_files:
+  - ../common/
+  - spec1-5_product55/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product56.yml
+++ b/java/MinePump/spec1-5_product56.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product56/
+input_files:
+  - ../common/
+  - spec1-5_product56/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product57.yml
+++ b/java/MinePump/spec1-5_product57.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product57/
+input_files:
+  - ../common/
+  - spec1-5_product57/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product58.yml
+++ b/java/MinePump/spec1-5_product58.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product58/
+input_files:
+  - ../common/
+  - spec1-5_product58/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product59.yml
+++ b/java/MinePump/spec1-5_product59.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product59/
+input_files:
+  - ../common/
+  - spec1-5_product59/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product6.yml
+++ b/java/MinePump/spec1-5_product6.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product6/
+input_files:
+  - ../common/
+  - spec1-5_product6/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product60.yml
+++ b/java/MinePump/spec1-5_product60.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product60/
+input_files:
+  - ../common/
+  - spec1-5_product60/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product61.yml
+++ b/java/MinePump/spec1-5_product61.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product61/
+input_files:
+  - ../common/
+  - spec1-5_product61/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product62.yml
+++ b/java/MinePump/spec1-5_product62.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product62/
+input_files:
+  - ../common/
+  - spec1-5_product62/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product63.yml
+++ b/java/MinePump/spec1-5_product63.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product63/
+input_files:
+  - ../common/
+  - spec1-5_product63/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product64.yml
+++ b/java/MinePump/spec1-5_product64.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product64/
+input_files:
+  - ../common/
+  - spec1-5_product64/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/MinePump/spec1-5_product7.yml
+++ b/java/MinePump/spec1-5_product7.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product7/
+input_files:
+  - ../common/
+  - spec1-5_product7/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product8.yml
+++ b/java/MinePump/spec1-5_product8.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product8/
+input_files:
+  - ../common/
+  - spec1-5_product8/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/MinePump/spec1-5_product9.yml
+++ b/java/MinePump/spec1-5_product9.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: spec1-5_product9/
+input_files:
+  - ../common/
+  - spec1-5_product9/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/Ackermann01.yml
+++ b/java/jayhorn-recursive/Ackermann01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Ackermann01/
+input_files:
+  - ../common/
+  - Ackermann01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/Addition.yml
+++ b/java/jayhorn-recursive/Addition.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Addition/
+input_files:
+  - ../common/
+  - Addition/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/InfiniteLoop.yml
+++ b/java/jayhorn-recursive/InfiniteLoop.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: InfiniteLoop/
+input_files:
+  - ../common/
+  - InfiniteLoop/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/SatAckermann01.yml
+++ b/java/jayhorn-recursive/SatAckermann01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatAckermann01/
+input_files:
+  - ../common/
+  - SatAckermann01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatAckermann02.yml
+++ b/java/jayhorn-recursive/SatAckermann02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatAckermann02/
+input_files:
+  - ../common/
+  - SatAckermann02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatAckermann03.yml
+++ b/java/jayhorn-recursive/SatAckermann03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatAckermann03/
+input_files:
+  - ../common/
+  - SatAckermann03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatAddition01.yml
+++ b/java/jayhorn-recursive/SatAddition01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatAddition01/
+input_files:
+  - ../common/
+  - SatAddition01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatEvenOdd01.yml
+++ b/java/jayhorn-recursive/SatEvenOdd01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatEvenOdd01/
+input_files:
+  - ../common/
+  - SatEvenOdd01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatFibonacci01.yml
+++ b/java/jayhorn-recursive/SatFibonacci01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatFibonacci01/
+input_files:
+  - ../common/
+  - SatFibonacci01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatFibonacci02.yml
+++ b/java/jayhorn-recursive/SatFibonacci02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatFibonacci02/
+input_files:
+  - ../common/
+  - SatFibonacci02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatFibonacci03.yml
+++ b/java/jayhorn-recursive/SatFibonacci03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatFibonacci03/
+input_files:
+  - ../common/
+  - SatFibonacci03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatGcd.yml
+++ b/java/jayhorn-recursive/SatGcd.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatGcd/
+input_files:
+  - ../common/
+  - SatGcd/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatHanoi01.yml
+++ b/java/jayhorn-recursive/SatHanoi01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatHanoi01/
+input_files:
+  - ../common/
+  - SatHanoi01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatMccarthy91.yml
+++ b/java/jayhorn-recursive/SatMccarthy91.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatMccarthy91/
+input_files:
+  - ../common/
+  - SatMccarthy91/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatMultCommutative01.yml
+++ b/java/jayhorn-recursive/SatMultCommutative01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatMultCommutative01/
+input_files:
+  - ../common/
+  - SatMultCommutative01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/SatPrimes01.yml
+++ b/java/jayhorn-recursive/SatPrimes01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SatPrimes01/
+input_files:
+  - ../common/
+  - SatPrimes01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jayhorn-recursive/UnsatAckermann01.yml
+++ b/java/jayhorn-recursive/UnsatAckermann01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatAckermann01/
+input_files:
+  - ../common/
+  - UnsatAckermann01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatAddition01.yml
+++ b/java/jayhorn-recursive/UnsatAddition01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatAddition01/
+input_files:
+  - ../common/
+  - UnsatAddition01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatAddition02.yml
+++ b/java/jayhorn-recursive/UnsatAddition02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatAddition02/
+input_files:
+  - ../common/
+  - UnsatAddition02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatEvenOdd01.yml
+++ b/java/jayhorn-recursive/UnsatEvenOdd01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatEvenOdd01/
+input_files:
+  - ../common/
+  - UnsatEvenOdd01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatFibonacci01.yml
+++ b/java/jayhorn-recursive/UnsatFibonacci01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatFibonacci01/
+input_files:
+  - ../common/
+  - UnsatFibonacci01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatFibonacci02.yml
+++ b/java/jayhorn-recursive/UnsatFibonacci02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatFibonacci02/
+input_files:
+  - ../common/
+  - UnsatFibonacci02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jayhorn-recursive/UnsatMccarthy91.yml
+++ b/java/jayhorn-recursive/UnsatMccarthy91.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: UnsatMccarthy91/
+input_files:
+  - ../common/
+  - UnsatMccarthy91/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArithmeticException1.yml
+++ b/java/jbmc-regression/ArithmeticException1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArithmeticException1/
+input_files:
+  - ../common/
+  - ArithmeticException1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArithmeticException1/Main.java
+++ b/java/jbmc-regression/ArithmeticException1/Main.java
@@ -6,10 +6,12 @@
  *     directory: regression/cbmc-java/ArithmeticException1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
     public static void  main(String args[]) {
         try {
-            int i=args.length;
+            int i = Verifier.nondetInt();
             int j=10/i;
         }
         catch(ArithmeticException exc) {

--- a/java/jbmc-regression/ArithmeticException5.yml
+++ b/java/jbmc-regression/ArithmeticException5.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArithmeticException5/
+input_files:
+  - ../common/
+  - ArithmeticException5/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/ArithmeticException6.yml
+++ b/java/jbmc-regression/ArithmeticException6.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArithmeticException6/
+input_files:
+  - ../common/
+  - ArithmeticException6/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArithmeticException6/Main.java
+++ b/java/jbmc-regression/ArithmeticException6/Main.java
@@ -6,9 +6,11 @@
  *     directory: regression/cbmc-java/ArithmeticException6
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
     public static void  main(String[] args) {
-        int denom = args.length - 5;
+        int denom = Verifier.nondetInt();
         try {
             int j=10/denom;
         }

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException1.yml
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArrayIndexOutOfBoundsException1/
+input_files:
+  - ../common/
+  - ArrayIndexOutOfBoundsException1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException1/Main.java
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException1/Main.java
@@ -6,11 +6,16 @@
  *     directory: regression/cbmc-java/ArrayIndexOutOfBoundsException1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
   public static void main(String args[]) {
+      int size = Verifier.nondetInt();
+      if (size < 0)
+        return;
       try {
           int[] a=new int[4];
-          a[args.length]=0;
+          a[size]=0;
       }
       catch (ArrayIndexOutOfBoundsException exc) {
           assert false;

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException2.yml
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArrayIndexOutOfBoundsException2/
+input_files:
+  - ../common/
+  - ArrayIndexOutOfBoundsException2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException2/Main.java
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException2/Main.java
@@ -6,11 +6,16 @@
  *     directory: regression/cbmc-java/ArrayIndexOutOfBoundsException2
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
   public static void main(String args[]) {
+      int size = Verifier.nondetInt();
+      if (size < 0)
+        return;
       try {
           int[] a=new int[4];
-          int i=a[args.length];
+          int i=a[size];
       }
       catch (ArrayIndexOutOfBoundsException exc) {
           assert false;

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException3.yml
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ArrayIndexOutOfBoundsException3/
+input_files:
+  - ../common/
+  - ArrayIndexOutOfBoundsException3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ArrayIndexOutOfBoundsException3/Main.java
+++ b/java/jbmc-regression/ArrayIndexOutOfBoundsException3/Main.java
@@ -6,11 +6,13 @@
  *     directory: regression/cbmc-java/ArrayIndexOutOfBoundsException3
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
   public static void main(String args[]) {
       try {
           int[] a=new int[4];
-          a[args.length]=0;
+          a[Verifier.nondetInt()]=0;
       }
       catch (Exception exc) {
           assert false;

--- a/java/jbmc-regression/BufferedReaderReadLine.yml
+++ b/java/jbmc-regression/BufferedReaderReadLine.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: BufferedReaderReadLine/
+input_files:
+  - ../common/
+  - BufferedReaderReadLine/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/BufferedReaderReadLine/Main.java
+++ b/java/jbmc-regression/BufferedReaderReadLine/Main.java
@@ -7,7 +7,8 @@
  * The benchmark was taken from the repo: 24 January 2018
  */
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.StringReader;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
@@ -17,11 +18,12 @@ public class Main {
         }
 
     public static void main(String[] args) {
+        String arg = Verifier.nondetString();
         String thisLine = null;
         int numLines = 0;
 
         try {
-            BufferedReader br = new BufferedReader(new FileReader(args[1]));
+            BufferedReader br = new BufferedReader(new StringReader(arg));
             String line = check(br);
             while ((thisLine = check(br)) != null) {
                 System.out.println(thisLine);

--- a/java/jbmc-regression/CharSequenceBug.yml
+++ b/java/jbmc-regression/CharSequenceBug.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: CharSequenceBug/
+input_files:
+  - ../common/
+  - CharSequenceBug/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/CharSequenceBug/Main.java
+++ b/java/jbmc-regression/CharSequenceBug/Main.java
@@ -6,11 +6,11 @@
  *     directory: regression/jbmc-strings-test-gen/CharSequenceBug
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
     public static void main(String[] args) {
-        if (args.length < 1)
-            return;
-        String s = args[0];
+        String s = Verifier.nondetString();
         CharSequence target = "b";
         String replaced = "";
         if (target.length() == 1)

--- a/java/jbmc-regression/CharSequenceToString.yml
+++ b/java/jbmc-regression/CharSequenceToString.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: CharSequenceToString/
+input_files:
+  - ../common/
+  - CharSequenceToString/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/CharSequenceToString/Main.java
+++ b/java/jbmc-regression/CharSequenceToString/Main.java
@@ -6,13 +6,14 @@
  *     directory: regression/jbmc-strings-test-gen/CharSequenceToString
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
     public static void main(String[] args)
     {
-        if (args.length<1)
-            return;
-        CharSequence cs = (CharSequence)args[0];
+        String arg = Verifier.nondetString();
+        CharSequence cs = (CharSequence)arg;
         String s = cs.toString();
         int i = -1;
         if(s.equals("case1"))

--- a/java/jbmc-regression/ClassCastException1.yml
+++ b/java/jbmc-regression/ClassCastException1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ClassCastException1/
+input_files:
+  - ../common/
+  - ClassCastException1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/ClassCastException2.yml
+++ b/java/jbmc-regression/ClassCastException2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ClassCastException2/
+input_files:
+  - ../common/
+  - ClassCastException2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/ClassCastException3.yml
+++ b/java/jbmc-regression/ClassCastException3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ClassCastException3/
+input_files:
+  - ../common/
+  - ClassCastException3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/Class_method1.yml
+++ b/java/jbmc-regression/Class_method1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Class_method1/
+input_files:
+  - ../common/
+  - Class_method1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/Inheritance1.yml
+++ b/java/jbmc-regression/Inheritance1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Inheritance1/
+input_files:
+  - ../common/
+  - Inheritance1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/NegativeArraySizeException1.yml
+++ b/java/jbmc-regression/NegativeArraySizeException1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NegativeArraySizeException1/
+input_files:
+  - ../common/
+  - NegativeArraySizeException1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/NegativeArraySizeException2.yml
+++ b/java/jbmc-regression/NegativeArraySizeException2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NegativeArraySizeException2/
+input_files:
+  - ../common/
+  - NegativeArraySizeException2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/NullPointerException1.yml
+++ b/java/jbmc-regression/NullPointerException1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NullPointerException1/
+input_files:
+  - ../common/
+  - NullPointerException1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/NullPointerException2.yml
+++ b/java/jbmc-regression/NullPointerException2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NullPointerException2/
+input_files:
+  - ../common/
+  - NullPointerException2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/NullPointerException3.yml
+++ b/java/jbmc-regression/NullPointerException3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NullPointerException3/
+input_files:
+  - ../common/
+  - NullPointerException3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/NullPointerException4.yml
+++ b/java/jbmc-regression/NullPointerException4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: NullPointerException4/
+input_files:
+  - ../common/
+  - NullPointerException4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/RegexMatches01.yml
+++ b/java/jbmc-regression/RegexMatches01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: RegexMatches01/
+input_files:
+  - ../common/
+  - RegexMatches01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/RegexMatches02.yml
+++ b/java/jbmc-regression/RegexMatches02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: RegexMatches02/
+input_files:
+  - ../common/
+  - RegexMatches02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/RegexMatches02/Main.java
+++ b/java/jbmc-regression/RegexMatches02/Main.java
@@ -8,18 +8,16 @@
  */
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
       Pattern expression =
          Pattern.compile("W.*\\d[0-35-9]-\\d\\d-\\d\\d");
 
-      String string1 = args[0];
+      String string1 = Verifier.nondetString();
 
       Matcher matcher = expression.matcher(string1);
 

--- a/java/jbmc-regression/RegexSubstitution01.yml
+++ b/java/jbmc-regression/RegexSubstitution01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: RegexSubstitution01/
+input_files:
+  - ../common/
+  - RegexSubstitution01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/RegexSubstitution02.yml
+++ b/java/jbmc-regression/RegexSubstitution02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: RegexSubstitution02/
+input_files:
+  - ../common/
+  - RegexSubstitution02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/RegexSubstitution02/Main.java
+++ b/java/jbmc-regression/RegexSubstitution02/Main.java
@@ -7,16 +7,14 @@
  * The benchmark was taken from the repo: 24 January 2018
  */
 import java.util.Arrays;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
-
-      String firstString = args[0];
-      String secondString = args[1];
+      String firstString = Verifier.nondetString();
+      String secondString = Verifier.nondetString();
 
       firstString = firstString.replaceAll("\\*", "^");
 

--- a/java/jbmc-regression/RegexSubstitution03.yml
+++ b/java/jbmc-regression/RegexSubstitution03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: RegexSubstitution03/
+input_files:
+  - ../common/
+  - RegexSubstitution03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StaticCharMethods01.yml
+++ b/java/jbmc-regression/StaticCharMethods01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods01/
+input_files:
+  - ../common/
+  - StaticCharMethods01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StaticCharMethods02.yml
+++ b/java/jbmc-regression/StaticCharMethods02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods02/
+input_files:
+  - ../common/
+  - StaticCharMethods02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StaticCharMethods02/Main.java
+++ b/java/jbmc-regression/StaticCharMethods02/Main.java
@@ -6,13 +6,16 @@
  *     directory: regression/jbmc-strings/StaticCharMethods02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
+      String arg = Verifier.nondetString();
+      if(arg.length() < 1)
         return;
-      char c = args[0].charAt(0);
+      char c = arg.charAt(0);
       assert Character.toUpperCase(c)!=Character.toLowerCase(c);
    }
 }

--- a/java/jbmc-regression/StaticCharMethods03.yml
+++ b/java/jbmc-regression/StaticCharMethods03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods03/
+input_files:
+  - ../common/
+  - StaticCharMethods03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StaticCharMethods03/Main.java
+++ b/java/jbmc-regression/StaticCharMethods03/Main.java
@@ -6,13 +6,17 @@
  *     directory: regression/jbmc-strings/StaticCharMethods03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
+      String arg = Verifier.nondetString();
+      if(arg.length() < 1)
         return;
-      char c = args[0].charAt(0);
+
+      char c = arg.charAt(0);
       assert Character.isDefined(c)==false;
    }
 }

--- a/java/jbmc-regression/StaticCharMethods04.yml
+++ b/java/jbmc-regression/StaticCharMethods04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods04/
+input_files:
+  - ../common/
+  - StaticCharMethods04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StaticCharMethods04/Main.java
+++ b/java/jbmc-regression/StaticCharMethods04/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/jbmc-strings/StaticCharMethods04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
-        return;
-      char c = args[0].charAt(0);
-      assert Character.isLetter(c)==true;
+      char c = Verifier.nondetChar();
+      assert Character.isLetter(c);
    }
 }

--- a/java/jbmc-regression/StaticCharMethods05.yml
+++ b/java/jbmc-regression/StaticCharMethods05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods05/
+input_files:
+  - ../common/
+  - StaticCharMethods05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StaticCharMethods05/Main.java
+++ b/java/jbmc-regression/StaticCharMethods05/Main.java
@@ -7,12 +7,13 @@
  * The benchmark was taken from the repo: 24 January 2018
  */
 import java.util.Scanner;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main
 {
    public static void main(String[] args)
    {
-      Scanner scanner = new Scanner(System.in);
+      Scanner scanner = new Scanner(Verifier.nondetString());
 
       int radix = scanner.nextInt();
 
@@ -25,8 +26,8 @@ public class Main
             System.out.println("Enter a digit:");
             int digit = scanner.nextInt();
             System.out.printf("Convert digit to character: %s\n",
-               Character.forDigit(digit, radix));
-	    char tmp=Character.forDigit(digit, radix);
+              Character.forDigit(digit, radix));
+            char tmp=Character.forDigit(digit, radix);
             assert tmp=='t';
             break;
 

--- a/java/jbmc-regression/StaticCharMethods06.yml
+++ b/java/jbmc-regression/StaticCharMethods06.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StaticCharMethods06/
+input_files:
+  - ../common/
+  - StaticCharMethods06/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StaticCharMethods06/Main.java
+++ b/java/jbmc-regression/StaticCharMethods06/Main.java
@@ -6,14 +6,17 @@
  *     directory: regression/jbmc-strings/StaticCharMethods06
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
+      String arg = Verifier.nondetString();
+      if(arg.length() < 1)
         return;
 
-      char c = args[0].charAt(0);
+      char c = arg.charAt(0);
       Character c1 = c;
       Character c2 = c;
 

--- a/java/jbmc-regression/StringBuilderAppend01.yml
+++ b/java/jbmc-regression/StringBuilderAppend01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderAppend01/
+input_files:
+  - ../common/
+  - StringBuilderAppend01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringBuilderAppend02.yml
+++ b/java/jbmc-regression/StringBuilderAppend02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderAppend02/
+input_files:
+  - ../common/
+  - StringBuilderAppend02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderAppend02/Main.java
+++ b/java/jbmc-regression/StringBuilderAppend02/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringBuilderAppend02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
-
-      Object objectRef = args[0];
-      String string = args[1];
+      Object objectRef = Verifier.nondetString();
+      String string = Verifier.nondetString();
       char[] charArray = {'v', 'e', 'r', 'i', 'f', 'i', 'c', 'a', 't', 'i', 'o', 'n'};
       boolean booleanValue = true;
       char characterValue = 'Z';

--- a/java/jbmc-regression/StringBuilderCapLen01.yml
+++ b/java/jbmc-regression/StringBuilderCapLen01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderCapLen01/
+input_files:
+  - ../common/
+  - StringBuilderCapLen01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringBuilderCapLen02.yml
+++ b/java/jbmc-regression/StringBuilderCapLen02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderCapLen02/
+input_files:
+  - ../common/
+  - StringBuilderCapLen02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderCapLen02/Main.java
+++ b/java/jbmc-regression/StringBuilderCapLen02/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderCapLen02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       assert buffer.toString().equals("Diffblue  is leader in automatic test case generation");
    }
 }

--- a/java/jbmc-regression/StringBuilderCapLen03.yml
+++ b/java/jbmc-regression/StringBuilderCapLen03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderCapLen03/
+input_files:
+  - ../common/
+  - StringBuilderCapLen03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderCapLen03/Main.java
+++ b/java/jbmc-regression/StringBuilderCapLen03/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderCapLen03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       assert buffer.length()==51;
    }
 }

--- a/java/jbmc-regression/StringBuilderCapLen04.yml
+++ b/java/jbmc-regression/StringBuilderCapLen04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderCapLen04/
+input_files:
+  - ../common/
+  - StringBuilderCapLen04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderCapLen04/Main.java
+++ b/java/jbmc-regression/StringBuilderCapLen04/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderCapLen04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       assert buffer.capacity()==69;
    }
 }

--- a/java/jbmc-regression/StringBuilderChars01.yml
+++ b/java/jbmc-regression/StringBuilderChars01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars01/
+input_files:
+  - ../common/
+  - StringBuilderChars01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringBuilderChars02.yml
+++ b/java/jbmc-regression/StringBuilderChars02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars02/
+input_files:
+  - ../common/
+  - StringBuilderChars02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderChars02/Main.java
+++ b/java/jbmc-regression/StringBuilderChars02/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderChars02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       assert buffer.toString().equals("DiffBlue Limitted");
    }
 }

--- a/java/jbmc-regression/StringBuilderChars03.yml
+++ b/java/jbmc-regression/StringBuilderChars03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars03/
+input_files:
+  - ../common/
+  - StringBuilderChars03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderChars03/Main.java
+++ b/java/jbmc-regression/StringBuilderChars03/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderChars03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       assert buffer.charAt(0)==buffer.charAt(4);
    }
 }

--- a/java/jbmc-regression/StringBuilderChars04.yml
+++ b/java/jbmc-regression/StringBuilderChars04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars04/
+input_files:
+  - ../common/
+  - StringBuilderChars04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderChars04/Main.java
+++ b/java/jbmc-regression/StringBuilderChars04/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderChars04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
 
       char[] charArray = new char[buffer.length()];
       buffer.getChars(0, buffer.length(), charArray, 0);

--- a/java/jbmc-regression/StringBuilderChars05.yml
+++ b/java/jbmc-regression/StringBuilderChars05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars05/
+input_files:
+  - ../common/
+  - StringBuilderChars05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderChars05/Main.java
+++ b/java/jbmc-regression/StringBuilderChars05/Main.java
@@ -6,14 +6,15 @@
  *     directory: regression/jbmc-strings/StringBuilderChars05
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
+      String arg = Verifier.nondetString();
 
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(arg);
       buffer.setCharAt(0, 'H');
       buffer.setCharAt(6, 'T');
       assert buffer.toString().equals("HiffBllTe Limited");

--- a/java/jbmc-regression/StringBuilderChars06.yml
+++ b/java/jbmc-regression/StringBuilderChars06.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderChars06/
+input_files:
+  - ../common/
+  - StringBuilderChars06/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderChars06/Main.java
+++ b/java/jbmc-regression/StringBuilderChars06/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringBuilderChars06
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer = new StringBuilder(args[0]);
+      StringBuilder buffer = new StringBuilder(Verifier.nondetString());
       buffer.reverse();
       assert buffer.toString().equals("detimiL eTlBffiiH");
    }

--- a/java/jbmc-regression/StringBuilderConstructors01.yml
+++ b/java/jbmc-regression/StringBuilderConstructors01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderConstructors01/
+input_files:
+  - ../common/
+  - StringBuilderConstructors01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringBuilderConstructors01/Main.java
+++ b/java/jbmc-regression/StringBuilderConstructors01/Main.java
@@ -6,16 +6,19 @@
  *     directory: regression/jbmc-strings/StringBuilderConstructors01
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
+      String arg = Verifier.nondetString();
+      if(arg.length() < 1)
         return;
 
       StringBuilder buffer1 = new StringBuilder();
       StringBuilder buffer2 = new StringBuilder(10);
-      StringBuilder buffer3 = new StringBuilder(args[0]);
+      StringBuilder buffer3 = new StringBuilder(arg);
 
       assert buffer1.length()==0;
       assert buffer2.length()==0;

--- a/java/jbmc-regression/StringBuilderConstructors02.yml
+++ b/java/jbmc-regression/StringBuilderConstructors02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderConstructors02/
+input_files:
+  - ../common/
+  - StringBuilderConstructors02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderConstructors02/Main.java
+++ b/java/jbmc-regression/StringBuilderConstructors02/Main.java
@@ -6,14 +6,14 @@
  *     directory: regression/jbmc-strings/StringBuilderConstructors02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder buffer3 = new StringBuilder(args[0]);
-      assert buffer3.equals(args[0]);
+      String arg = Verifier.nondetString();
+      StringBuilder buffer3 = new StringBuilder(arg);
+      assert buffer3.equals(arg);
    }
 }

--- a/java/jbmc-regression/StringBuilderInsertDelete01.yml
+++ b/java/jbmc-regression/StringBuilderInsertDelete01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderInsertDelete01/
+input_files:
+  - ../common/
+  - StringBuilderInsertDelete01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringBuilderInsertDelete02.yml
+++ b/java/jbmc-regression/StringBuilderInsertDelete02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderInsertDelete02/
+input_files:
+  - ../common/
+  - StringBuilderInsertDelete02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderInsertDelete02/Main.java
+++ b/java/jbmc-regression/StringBuilderInsertDelete02/Main.java
@@ -6,46 +6,45 @@
  *     directory: regression/jbmc-strings/StringBuilderInsertDelete02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
-   public static void main(String[] args)
-   {
-      if(args.length < 1 || args[0] == null || args[1] == null)
-        return;
+  public static void main(String[] args)
+  {
+    Object objectRef = Verifier.nondetString();
+    String string = Verifier.nondetString();
+    char[] charArray = {'v', 'e', 'r', 'i', 'f', 'i', 'c', 'a', 't', 'i', 'o', 'n'};
+    boolean booleanValue = true;
+    char characterValue = 'K';
+    int integerValue = 7;
+    long longValue = 10000000;
+    float floatValue = 2.5f;
+    double doubleValue = 33.333;
 
-      Object objectRef = args[0];
-      String string = args[1];
-      char[] charArray = {'v', 'e', 'r', 'i', 'f', 'i', 'c', 'a', 't', 'i', 'o', 'n'};
-      boolean booleanValue = true;
-      char characterValue = 'K';
-      int integerValue = 7;
-      long longValue = 10000000;
-      float floatValue = 2.5f;
-      double doubleValue = 33.333;
+    StringBuilder buffer = new StringBuilder();
 
-      StringBuilder buffer = new StringBuilder();
+    buffer.insert(0, objectRef)
+          .insert(0, "-")
+          .insert(0, string)
+          .insert(0, "-")
+          .insert(0, charArray)
+          .insert(0, "-")
+          .insert(0, charArray, 3, 3)
+          .insert(0, "-")
+          .insert(0, booleanValue)
+          .insert(0, "-")
+          .insert(0, characterValue)
+          .insert(0, "-")
+          .insert(0, integerValue)
+          .insert(0, "-")
+          .insert(0, longValue)
+          .insert(0, "-")
+          .insert(0, floatValue)
+          .insert(0, "-")
+          .insert(0, doubleValue);
 
-      buffer.insert(0, objectRef)
-            .insert(0, "-")
-            .insert(0, string)
-            .insert(0, "-")
-            .insert(0, charArray)
-            .insert(0, "-")
-            .insert(0, charArray, 3, 3)
-            .insert(0, "-")
-            .insert(0, booleanValue)
-            .insert(0, "-")
-            .insert(0, characterValue)
-            .insert(0, "-")
-            .insert(0, integerValue)
-            .insert(0, "-")
-            .insert(0, longValue)
-            .insert(0, "-")
-            .insert(0, floatValue)
-            .insert(0, "-")
-            .insert(0, doubleValue);
-
-      String tmp=buffer.toString();
-      assert tmp.equals("33.333-2.5-10000000-7-K-true-ifi-verification-test--diffblue");
-   }
+    String tmp=buffer.toString();
+    assert tmp.equals("33.333-2.5-10000000-7-K-true-ifi-verification-test--diffblue");
+  }
 }

--- a/java/jbmc-regression/StringBuilderInsertDelete03.yml
+++ b/java/jbmc-regression/StringBuilderInsertDelete03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringBuilderInsertDelete03/
+input_files:
+  - ../common/
+  - StringBuilderInsertDelete03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringBuilderInsertDelete03/Main.java
+++ b/java/jbmc-regression/StringBuilderInsertDelete03/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringBuilderInsertDelete03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[1] == null)
-        return;
-
-      Object objectRef = args[0];
-      String string = args[1];
+      Object objectRef = Verifier.nondetString();
+      String string = Verifier.nondetString();
       char[] charArray = {'v', 'e', 'r', 'i', 'f', 'i', 'c', 'a', 't', 'i', 'o', 'n'};
       boolean booleanValue = true;
       char characterValue = 'K';

--- a/java/jbmc-regression/StringCompare01.yml
+++ b/java/jbmc-regression/StringCompare01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringCompare01/
+input_files:
+  - ../common/
+  - StringCompare01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringCompare02.yml
+++ b/java/jbmc-regression/StringCompare02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringCompare02/
+input_files:
+  - ../common/
+  - StringCompare02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringCompare02/Main.java
+++ b/java/jbmc-regression/StringCompare02/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringCompare02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[1] == null)
-        return;
-
-      String s3 = args[0];
-      String s4 = args[1];
+      String s3 = Verifier.nondetString();
+      String s4 = Verifier.nondetString();
 
       // test regionMatches (case sensitive)
       if (s3.regionMatches(0, s4, 0, 5)) //false

--- a/java/jbmc-regression/StringCompare03.yml
+++ b/java/jbmc-regression/StringCompare03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringCompare03/
+input_files:
+  - ../common/
+  - StringCompare03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringCompare03/Main.java
+++ b/java/jbmc-regression/StringCompare03/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringCompare03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[1] == null)
-        return;
-
-      String s3 = args[0];
-      String s4 = args[1];
+      String s3 = Verifier.nondetString();
+      String s4 = Verifier.nondetString();
 
       // test regionMatches (ignore case)
       if (!s3.regionMatches(true, 0, s4, 0, 5)) //false

--- a/java/jbmc-regression/StringCompare04.yml
+++ b/java/jbmc-regression/StringCompare04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringCompare04/
+input_files:
+  - ../common/
+  - StringCompare04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringCompare04/Main.java
+++ b/java/jbmc-regression/StringCompare04/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringCompare04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[1] == null)
-        return;
-
-      String s1 = new String(args[0]);
-      String s2 = args[1];
+      String s1 = new String(Verifier.nondetString());
+      String s2 = Verifier.nondetString();
       assert s2.compareTo(s1)==13; //false
    }
 }

--- a/java/jbmc-regression/StringCompare05.yml
+++ b/java/jbmc-regression/StringCompare05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringCompare05/
+input_files:
+  - ../common/
+  - StringCompare05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringCompare05/Main.java
+++ b/java/jbmc-regression/StringCompare05/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/jbmc-strings/StringCompare05
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-      String string = args[0];
+      String string = Verifier.nondetString();
 
       String s1 = new String(string);
       if (s1 == string)  // false; they are not the same object

--- a/java/jbmc-regression/StringConcatenation01.yml
+++ b/java/jbmc-regression/StringConcatenation01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConcatenation01/
+input_files:
+  - ../common/
+  - StringConcatenation01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringConcatenation01/Main.java
+++ b/java/jbmc-regression/StringConcatenation01/Main.java
@@ -6,12 +6,15 @@
  *     directory: regression/jbmc-strings/StringConcatenation01
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
+      args = new String[2];
+      args[0] = Verifier.nondetString();
+      args[1] = Verifier.nondetString();
 
       String s1 = args[0];
       String s2 = args[1];

--- a/java/jbmc-regression/StringConcatenation02.yml
+++ b/java/jbmc-regression/StringConcatenation02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConcatenation02/
+input_files:
+  - ../common/
+  - StringConcatenation02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConcatenation02/Main.java
+++ b/java/jbmc-regression/StringConcatenation02/Main.java
@@ -6,12 +6,15 @@
  *     directory: regression/jbmc-strings/StringConcatenation02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
+      args = new String[2];
+      args[0] = Verifier.nondetString();
+      args[1] = Verifier.nondetString();
 
       String s1 = args[0];
       String s2 = args[1];

--- a/java/jbmc-regression/StringConcatenation03.yml
+++ b/java/jbmc-regression/StringConcatenation03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConcatenation03/
+input_files:
+  - ../common/
+  - StringConcatenation03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConcatenation03/Main.java
+++ b/java/jbmc-regression/StringConcatenation03/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringConcatenation03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
-
-      String s1 = args[0];
-      String s2 = args[1];
+      String s1 = Verifier.nondetString();
+      String s2 = Verifier.nondetString();
 
       System.out.printf(
          "Result of s1.concat(s2) = %s\n", s1.concat(s2));

--- a/java/jbmc-regression/StringConcatenation04.yml
+++ b/java/jbmc-regression/StringConcatenation04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConcatenation04/
+input_files:
+  - ../common/
+  - StringConcatenation04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConcatenation04/Main.java
+++ b/java/jbmc-regression/StringConcatenation04/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringConcatenation04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String s1 = args[0];
+      String s1 = Verifier.nondetString();
       String tmp=s1;
       System.out.printf("s1 after concatenation = %s\n", s1);
       assert tmp.equals("Happy  at");

--- a/java/jbmc-regression/StringConstructors01.yml
+++ b/java/jbmc-regression/StringConstructors01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConstructors01/
+input_files:
+  - ../common/
+  - StringConstructors01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringConstructors02.yml
+++ b/java/jbmc-regression/StringConstructors02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConstructors02/
+input_files:
+  - ../common/
+  - StringConstructors02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConstructors02/Main.java
+++ b/java/jbmc-regression/StringConstructors02/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringConstructors02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main 
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
       String s1 = new String();
-      assert s1.equals(args[0]);
+      assert s1.equals(Verifier.nondetString());
    } 
 }
 

--- a/java/jbmc-regression/StringConstructors03.yml
+++ b/java/jbmc-regression/StringConstructors03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConstructors03/
+input_files:
+  - ../common/
+  - StringConstructors03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConstructors03/Main.java
+++ b/java/jbmc-regression/StringConstructors03/Main.java
@@ -6,16 +6,18 @@
  *     directory: regression/jbmc-strings/StringConstructors03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
+      args = new String[2];
+      args[0] = Verifier.nondetString();
+      args[1] = Verifier.nondetString();
 
       String s = new String(args[0]);
       String s2 = new String(s);
       assert s2.equals(args[1]);
-   } 
+   }
 }
-

--- a/java/jbmc-regression/StringConstructors04.yml
+++ b/java/jbmc-regression/StringConstructors04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConstructors04/
+input_files:
+  - ../common/
+  - StringConstructors04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConstructors04/Main.java
+++ b/java/jbmc-regression/StringConstructors04/Main.java
@@ -6,16 +6,16 @@
  *     directory: regression/jbmc-strings/StringConstructors04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
+      String arg = Verifier.nondetString();
 
       char[] charArray = {'d', 'i', 'f', 'f', 'b', 'l', 'u', 'e'};
       String s4 = new String(charArray, 4, 4);
-      assert s4.equals(args[0]);
-   } 
+      assert s4.equals(arg);
+   }
 }
-

--- a/java/jbmc-regression/StringConstructors05.yml
+++ b/java/jbmc-regression/StringConstructors05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringConstructors05/
+input_files:
+  - ../common/
+  - StringConstructors05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringConstructors05/Main.java
+++ b/java/jbmc-regression/StringConstructors05/Main.java
@@ -6,16 +6,14 @@
  *     directory: regression/jbmc-strings/StringConstructors05
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
       char[] charArray = {'d', 'i', 'f', 'f', 'b', 'l', 'u', 'e'};
       String s3 = new String(charArray);
-      assert s3.equals(args[0]);
+      assert s3.equals(Verifier.nondetString());
    } 
 }
-

--- a/java/jbmc-regression/StringContains01.yml
+++ b/java/jbmc-regression/StringContains01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringContains01/
+input_files:
+  - ../common/
+  - StringContains01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringContains01/Main.java
+++ b/java/jbmc-regression/StringContains01/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringContains01
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
     public static void main(String[] args)
     {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
-
-        String ab = args[0];
-        String s = args[1];
+        String ab = Verifier.nondetString();
+        String s = Verifier.nondetString();
         assert(ab.contains(s));
     }
 }

--- a/java/jbmc-regression/StringContains02.yml
+++ b/java/jbmc-regression/StringContains02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringContains02/
+input_files:
+  - ../common/
+  - StringContains02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringContains02/Main.java
+++ b/java/jbmc-regression/StringContains02/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/jbmc-strings/StringContains02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
     public static void main(String[] args)
     {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-        assert(args[0].contains("Hello"));
+        String arg = Verifier.nondetString();
+        assert(arg.contains("Hello"));
     }
 }

--- a/java/jbmc-regression/StringIndexMethods01.yml
+++ b/java/jbmc-regression/StringIndexMethods01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringIndexMethods01/
+input_files:
+  - ../common/
+  - StringIndexMethods01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringIndexMethods02.yml
+++ b/java/jbmc-regression/StringIndexMethods02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringIndexMethods02/
+input_files:
+  - ../common/
+  - StringIndexMethods02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringIndexMethods02/Main.java
+++ b/java/jbmc-regression/StringIndexMethods02/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringIndexMethods02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       assert letters.indexOf('a', 1)==6;
    }
 }

--- a/java/jbmc-regression/StringIndexMethods03.yml
+++ b/java/jbmc-regression/StringIndexMethods03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringIndexMethods03/
+input_files:
+  - ../common/
+  - StringIndexMethods03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringIndexMethods03/Main.java
+++ b/java/jbmc-regression/StringIndexMethods03/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringIndexMethods03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       assert letters.lastIndexOf('$')==1;
    }
 }

--- a/java/jbmc-regression/StringIndexMethods04.yml
+++ b/java/jbmc-regression/StringIndexMethods04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringIndexMethods04/
+input_files:
+  - ../common/
+  - StringIndexMethods04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringIndexMethods04/Main.java
+++ b/java/jbmc-regression/StringIndexMethods04/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringIndexMethods04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       assert letters.indexOf("diffblue")==28;
    }
 }

--- a/java/jbmc-regression/StringIndexMethods05.yml
+++ b/java/jbmc-regression/StringIndexMethods05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringIndexMethods05/
+input_files:
+  - ../common/
+  - StringIndexMethods05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringIndexMethods05/Main.java
+++ b/java/jbmc-regression/StringIndexMethods05/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringIndexMethods05
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       assert letters.lastIndexOf("diffblue", 25)==1;
    }
 }

--- a/java/jbmc-regression/StringMiscellaneous01.yml
+++ b/java/jbmc-regression/StringMiscellaneous01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringMiscellaneous01/
+input_files:
+  - ../common/
+  - StringMiscellaneous01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringMiscellaneous02.yml
+++ b/java/jbmc-regression/StringMiscellaneous02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringMiscellaneous02/
+input_files:
+  - ../common/
+  - StringMiscellaneous02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringMiscellaneous02/Main.java
+++ b/java/jbmc-regression/StringMiscellaneous02/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringMiscellaneous02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String s1 = args[0];
+      String s1 = Verifier.nondetString();
       assert s1.length()==24;
    }
 }

--- a/java/jbmc-regression/StringMiscellaneous03.yml
+++ b/java/jbmc-regression/StringMiscellaneous03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringMiscellaneous03/
+input_files:
+  - ../common/
+  - StringMiscellaneous03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringMiscellaneous03/Main.java
+++ b/java/jbmc-regression/StringMiscellaneous03/Main.java
@@ -6,15 +6,14 @@
  *     directory: regression/jbmc-strings/StringMiscellaneous03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 2 || args[0] == null || args[1] == null)
-        return;
-
-      String s1 = args[0];
-      String s2 = args[1];
+      String s1 = Verifier.nondetString();
+      String s2 = Verifier.nondetString();
       char[] charArray = new char[5];
       int i=0;
       for (int count = s1.length() - 1; count >= 0; count--)

--- a/java/jbmc-regression/StringMiscellaneous04.yml
+++ b/java/jbmc-regression/StringMiscellaneous04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringMiscellaneous04/
+input_files:
+  - ../common/
+  - StringMiscellaneous04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringStartEnd01.yml
+++ b/java/jbmc-regression/StringStartEnd01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringStartEnd01/
+input_files:
+  - ../common/
+  - StringStartEnd01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringStartEnd02.yml
+++ b/java/jbmc-regression/StringStartEnd02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringStartEnd02/
+input_files:
+  - ../common/
+  - StringStartEnd02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringStartEnd02/Main.java
+++ b/java/jbmc-regression/StringStartEnd02/Main.java
@@ -6,14 +6,17 @@
  *     directory: regression/jbmc-strings/StringStartEnd02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 4 || args[0] == null || args[1] == null || args[2] == null || args[3] == null)
-        return;
-
-      String[] strings = {args[0], args[1], args[2], args[3]};
+      String[] strings = new String[4];
+      strings[0] = Verifier.nondetString();
+      strings[1] = Verifier.nondetString();
+      strings[2] = Verifier.nondetString();
+      strings[3] = Verifier.nondetString();
 
       int i=0;
       for (String string : strings)

--- a/java/jbmc-regression/StringStartEnd03.yml
+++ b/java/jbmc-regression/StringStartEnd03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringStartEnd03/
+input_files:
+  - ../common/
+  - StringStartEnd03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringStartEnd03/Main.java
+++ b/java/jbmc-regression/StringStartEnd03/Main.java
@@ -6,14 +6,17 @@
  *     directory: regression/jbmc-strings/StringStartEnd03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 4 || args[0] == null || args[1] == null || args[2] == null || args[3] == null)
-        return;
-
-      String[] strings = {args[0], args[1], args[2], args[3]};
+      String[] strings = new String[4];
+      strings[0] = Verifier.nondetString();
+      strings[1] = Verifier.nondetString();
+      strings[2] = Verifier.nondetString();
+      strings[3] = Verifier.nondetString();
 
       int i=0;
       for (String string : strings)

--- a/java/jbmc-regression/StringValueOf01.yml
+++ b/java/jbmc-regression/StringValueOf01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf01/
+input_files:
+  - ../common/
+  - StringValueOf01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/StringValueOf02.yml
+++ b/java/jbmc-regression/StringValueOf02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf02/
+input_files:
+  - ../common/
+  - StringValueOf02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf02/Main.java
+++ b/java/jbmc-regression/StringValueOf02/Main.java
@@ -6,14 +6,14 @@
  *     directory: regression/jbmc-strings/StringValueOf02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 8)
-        return;
-
-      char[] charArray = {args[0].charAt(0), args[0].charAt(1), args[0].charAt(2), args[0].charAt(3), args[0].charAt(4), args[0].charAt(5), args[0].charAt(6), args[0].charAt(7)};
+      String arg = Verifier.nondetString();
+      char[] charArray = {arg.charAt(0), arg.charAt(1), arg.charAt(2), arg.charAt(3), arg.charAt(4), arg.charAt(5), arg.charAt(6), arg.charAt(7)};
       String tmp=String.valueOf(charArray);
       assert tmp.equals("difffblue");
    }

--- a/java/jbmc-regression/StringValueOf03.yml
+++ b/java/jbmc-regression/StringValueOf03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf03/
+input_files:
+  - ../common/
+  - StringValueOf03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf03/Main.java
+++ b/java/jbmc-regression/StringValueOf03/Main.java
@@ -6,13 +6,14 @@
  *     directory: regression/jbmc-strings/StringValueOf03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 8)
-        return;
-
+      args = new String[1];
+      args[0] = Verifier.nondetString();
       char[] charArray = {args[0].charAt(0), args[0].charAt(1), args[0].charAt(2), args[0].charAt(3), args[0].charAt(4), args[0].charAt(5), args[0].charAt(6), args[0].charAt(7)};
       String tmp=String.valueOf(charArray, 3, 3);
       assert tmp.equals("fbbl");

--- a/java/jbmc-regression/StringValueOf04.yml
+++ b/java/jbmc-regression/StringValueOf04.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf04/
+input_files:
+  - ../common/
+  - StringValueOf04/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf04/Main.java
+++ b/java/jbmc-regression/StringValueOf04/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringValueOf04
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      boolean booleanValue = args[0].length() > 0;
+      boolean booleanValue = Verifier.nondetBoolean();
       String tmp=String.valueOf(booleanValue);
       assert tmp.equals("true");
    }

--- a/java/jbmc-regression/StringValueOf05.yml
+++ b/java/jbmc-regression/StringValueOf05.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf05/
+input_files:
+  - ../common/
+  - StringValueOf05/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf05/Main.java
+++ b/java/jbmc-regression/StringValueOf05/Main.java
@@ -6,11 +6,15 @@
  *     directory: regression/jbmc-strings/StringValueOf05
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null || args[0].length() < 1)
+      args = new String[1];
+      args[0] = Verifier.nondetString();
+      if(args[0].length() < 1)
         return;
 
       char characterValue = args[0].charAt(0);

--- a/java/jbmc-regression/StringValueOf06.yml
+++ b/java/jbmc-regression/StringValueOf06.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf06/
+input_files:
+  - ../common/
+  - StringValueOf06/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf06/Main.java
+++ b/java/jbmc-regression/StringValueOf06/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringValueOf06
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      int integerValue = args[0].length();
+      int integerValue = Verifier.nondetInt();
       String tmp=String.valueOf(integerValue);
       assert tmp.equals("77");
    }

--- a/java/jbmc-regression/StringValueOf07.yml
+++ b/java/jbmc-regression/StringValueOf07.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf07/
+input_files:
+  - ../common/
+  - StringValueOf07/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf07/Main.java
+++ b/java/jbmc-regression/StringValueOf07/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/StringValueOf07
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      long longValue = args[0].length();
+      long longValue = Verifier.nondetLong();
       System.out.printf("long = %s\n", String.valueOf(longValue));
       String tmp=String.valueOf(longValue);
       assert tmp.equals("100000000000");

--- a/java/jbmc-regression/StringValueOf08.yml
+++ b/java/jbmc-regression/StringValueOf08.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf08/
+input_files:
+  - ../common/
+  - StringValueOf08/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf08/Main.java
+++ b/java/jbmc-regression/StringValueOf08/Main.java
@@ -6,14 +6,14 @@
  *     directory: regression/jbmc-strings/StringValueOf08
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      float floatValue = Float.parseFloat(args[0]);
+      String arg = Verifier.nondetString();
+      float floatValue = Float.parseFloat(arg);
       String tmp=String.valueOf(floatValue);
       assert tmp.equals("2.50");
    }

--- a/java/jbmc-regression/StringValueOf09.yml
+++ b/java/jbmc-regression/StringValueOf09.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf09/
+input_files:
+  - ../common/
+  - StringValueOf09/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf09/Main.java
+++ b/java/jbmc-regression/StringValueOf09/Main.java
@@ -6,14 +6,15 @@
  *     directory: regression/jbmc-strings/StringValueOf09
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
+      String arg = Verifier.nondetString();
 
-      double doubleValue = Double.parseDouble(args[0]); // no suffix, double is default
+      double doubleValue = Double.parseDouble(arg); // no suffix, double is default
       String tmp=String.valueOf(doubleValue);
       assert tmp.equals("33.3333");
    }

--- a/java/jbmc-regression/StringValueOf10.yml
+++ b/java/jbmc-regression/StringValueOf10.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: StringValueOf10/
+input_files:
+  - ../common/
+  - StringValueOf10/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/StringValueOf10/Main.java
+++ b/java/jbmc-regression/StringValueOf10/Main.java
@@ -6,15 +6,15 @@
  *     directory: regression/jbmc-strings/StringValueOf10
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      Object objectRef = args[0]; // assign string to an Object reference
+      String arg = Verifier.nondetString();
+      Object objectRef = arg; // assign string to an Object reference
       String tmp=String.valueOf(objectRef);
-      assert tmp.equals(args[0] + "s");
+      assert tmp.equals(arg + "s");
    }
 }

--- a/java/jbmc-regression/SubString01.yml
+++ b/java/jbmc-regression/SubString01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SubString01/
+input_files:
+  - ../common/
+  - SubString01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/SubString02.yml
+++ b/java/jbmc-regression/SubString02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SubString02/
+input_files:
+  - ../common/
+  - SubString02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/SubString02/Main.java
+++ b/java/jbmc-regression/SubString02/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/SubString02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       String tmp=letters.substring(20);
       assert tmp.equals("erationatdifffblue");
    }

--- a/java/jbmc-regression/SubString03.yml
+++ b/java/jbmc-regression/SubString03.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: SubString03/
+input_files:
+  - ../common/
+  - SubString03/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/SubString03/Main.java
+++ b/java/jbmc-regression/SubString03/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/SubString03
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String letters = args[0];
+      String letters = Verifier.nondetString();
       String tmp=letters.substring(9, 13);
       assert tmp.equals("teest");
    }

--- a/java/jbmc-regression/TokenTest01.yml
+++ b/java/jbmc-regression/TokenTest01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: TokenTest01/
+input_files:
+  - ../common/
+  - TokenTest01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/TokenTest02.yml
+++ b/java/jbmc-regression/TokenTest02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: TokenTest02/
+input_files:
+  - ../common/
+  - TokenTest02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/TokenTest02/Main.java
+++ b/java/jbmc-regression/TokenTest02/Main.java
@@ -7,15 +7,13 @@
  * The benchmark was taken from the repo: 24 January 2018
  */
 import java.util.StringTokenizer;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      String sentence = args[0];
+      String sentence = Verifier.nondetString();
       String[] tokens = sentence.split(" ");
  
       int i=0;

--- a/java/jbmc-regression/Validate01.yml
+++ b/java/jbmc-regression/Validate01.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Validate01/
+input_files:
+  - ../common/
+  - Validate01/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/Validate02.yml
+++ b/java/jbmc-regression/Validate02.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: Validate02/
+input_files:
+  - ../common/
+  - Validate02/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/Validate02/Main.java
+++ b/java/jbmc-regression/Validate02/Main.java
@@ -6,18 +6,17 @@
  *     directory: regression/jbmc-strings/Validate02
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 5 || args[0] == null || args[1] == null || args[2] == null || args[3] == null || args[4] == null)
-        return;
-
-      String address = args[0];
-      String city = args[1];
-      String state = args[2];
-      String zip = args[3];
-      String phone = args[4];
+      String address = Verifier.nondetString();
+      String city = Verifier.nondetString();
+      String state = Verifier.nondetString();
+      String zip = Verifier.nondetString();
+      String phone = Verifier.nondetString();
 
       if (!ValidateInput02.validateAddress(address))
          assert false;

--- a/java/jbmc-regression/aastore_aaload1.yml
+++ b/java/jbmc-regression/aastore_aaload1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: aastore_aaload1/
+input_files:
+  - ../common/
+  - aastore_aaload1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/aastore_aaload1/Main.java
+++ b/java/jbmc-regression/aastore_aaload1/Main.java
@@ -6,6 +6,8 @@
  *     directory: regression/cbmc-java/aastore_aaload1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   static class A {
@@ -13,7 +15,9 @@ public class Main
   }
   public static void main(String[] args)
   {
-    int size = args.length;
+    int size = Verifier.nondetInt();
+    if (size < 0)
+      return;
     A[] array = new A[size];
 
     for (int i = 0; i < size; i++) {

--- a/java/jbmc-regression/array1.yml
+++ b/java/jbmc-regression/array1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: array1/
+input_files:
+  - ../common/
+  - array1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/array1/Main.java
+++ b/java/jbmc-regression/array1/Main.java
@@ -6,11 +6,13 @@
  *     directory: regression/cbmc-java/array1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    int size=args.length;
+    int size = Verifier.nondetInt();
     if(size<8)
       return;
     

--- a/java/jbmc-regression/array2.yml
+++ b/java/jbmc-regression/array2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: array2/
+input_files:
+  - ../common/
+  - array2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/array2/Main.java
+++ b/java/jbmc-regression/array2/Main.java
@@ -6,10 +6,12 @@
  *     directory: regression/cbmc-java/array2
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
 
   public static void main(String[] args) {
-    int unknown = args.length;
+    int unknown = Verifier.nondetInt();
     int[] arr;
     if(unknown > 0)
       arr = new int[1];

--- a/java/jbmc-regression/arraylength1.yml
+++ b/java/jbmc-regression/arraylength1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: arraylength1/
+input_files:
+  - ../common/
+  - arraylength1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/arraylength1/Main.java
+++ b/java/jbmc-regression/arraylength1/Main.java
@@ -6,14 +6,16 @@
  *     directory: regression/cbmc-java/arraylength1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    int size=args.length;
+    int size = Verifier.nondetInt();
     int int_array[]=new int[size];
 
-    assert int_array.length == args.length;
+    assert int_array.length == size;
   }
 }
 

--- a/java/jbmc-regression/arrayread1.yml
+++ b/java/jbmc-regression/arrayread1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: arrayread1/
+input_files:
+  - ../common/
+  - arrayread1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/arrayread1/Main.java
+++ b/java/jbmc-regression/arrayread1/Main.java
@@ -6,12 +6,14 @@
  *     directory: regression/cbmc-java/arrayread1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
 
   static Main readback;
 
   public static void main(String[] args) {
-    int c=args.length;
+    int c = Verifier.nondetInt();
     if(c!=1) return;
     Main[] a = new Main[c];
     readback=a[0];

--- a/java/jbmc-regression/assert1.yml
+++ b/java/jbmc-regression/assert1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert1/
+input_files:
+  - ../common/
+  - assert1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/assert1/Main.java
+++ b/java/jbmc-regression/assert1/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/cbmc-java/assert1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
 
     if(i>=10)
       assert i>=10 : "my super assertion"; // should hold

--- a/java/jbmc-regression/assert2.yml
+++ b/java/jbmc-regression/assert2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert2/
+input_files:
+  - ../common/
+  - assert2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/assert2/Main.java
+++ b/java/jbmc-regression/assert2/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/cbmc-java/assert2
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
     
     if(i>=1000)
       assert i>1000 : "i is greater 1000"; // should fail

--- a/java/jbmc-regression/assert3.yml
+++ b/java/jbmc-regression/assert3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert3/
+input_files:
+  - ../common/
+  - assert3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/assert3/Main.java
+++ b/java/jbmc-regression/assert3/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/cbmc-java/assert3
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
     
     if(i>=1000)
       if(!(i>1000))

--- a/java/jbmc-regression/assert4.yml
+++ b/java/jbmc-regression/assert4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert4/
+input_files:
+  - ../common/
+  - assert4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/assert4/Main.java
+++ b/java/jbmc-regression/assert4/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/cbmc-java/assert4
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
     
     if(i>=10)
       assert i>=20 : "my super assertion"; // should hold

--- a/java/jbmc-regression/assert5.yml
+++ b/java/jbmc-regression/assert5.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert5/
+input_files:
+  - ../common/
+  - assert5/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/assert5/Main.java
+++ b/java/jbmc-regression/assert5/Main.java
@@ -6,13 +6,13 @@
  *     directory: regression/cbmc-java/assert5
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
     
     if(i>1000)
       assert i>1000 : "i is greater 1000"; // should hold

--- a/java/jbmc-regression/assert6.yml
+++ b/java/jbmc-regression/assert6.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: assert6/
+input_files:
+  - ../common/
+  - assert6/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/assert6/Main.java
+++ b/java/jbmc-regression/assert6/Main.java
@@ -6,17 +6,16 @@
  *     directory: regression/cbmc-java/assert6
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    int i=random.nextInt();
+    int i = Verifier.nondetInt();
     
     if(i>=1000)
       if(!(i>=1000))
         assert false;
   }
 }
-

--- a/java/jbmc-regression/astore_aload1.yml
+++ b/java/jbmc-regression/astore_aload1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: astore_aload1/
+input_files:
+  - ../common/
+  - astore_aload1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/athrow1.yml
+++ b/java/jbmc-regression/athrow1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: athrow1/
+input_files:
+  - ../common/
+  - athrow1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/basic1.yml
+++ b/java/jbmc-regression/basic1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: basic1/
+input_files:
+  - ../common/
+  - basic1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/bitwise1.yml
+++ b/java/jbmc-regression/bitwise1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: bitwise1/
+input_files:
+  - ../common/
+  - bitwise1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/bitwise1/Main.java
+++ b/java/jbmc-regression/bitwise1/Main.java
@@ -6,12 +6,14 @@
  *     directory: regression/cbmc-java/bitwise1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   static char c;
   public static void main(String[] args)
   {
-    c=(char)(args.length*2 + 1);
+    c = Verifier.nondetChar();
     int i = (c | 2);
     assert (i & 3) == 3;
   }

--- a/java/jbmc-regression/boolean1.yml
+++ b/java/jbmc-regression/boolean1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: boolean1/
+input_files:
+  - ../common/
+  - boolean1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/boolean1/Main.java
+++ b/java/jbmc-regression/boolean1/Main.java
@@ -6,11 +6,13 @@
  *     directory: regression/cbmc-java/boolean1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main {
 
   static public void main(String[] args)
   {
-    boolean my_boolean = args.length > 3;
+    boolean my_boolean = Verifier.nondetBoolean();
     // Boolean shall be either true or false.
     if(my_boolean == true) return;
     if(my_boolean == false) return;

--- a/java/jbmc-regression/boolean2.yml
+++ b/java/jbmc-regression/boolean2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: boolean2/
+input_files:
+  - ../common/
+  - boolean2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/boolean2/Main.java
+++ b/java/jbmc-regression/boolean2/Main.java
@@ -6,11 +6,13 @@
  *     directory: regression/cbmc-java/boolean2
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   public static void main(String[] args)
   {
-    boolean b=args.length > 2;
+    boolean b = Verifier.nondetBoolean();
     boolean result=f(b);
     assert result==!b;
   }

--- a/java/jbmc-regression/bug-test-gen-095.yml
+++ b/java/jbmc-regression/bug-test-gen-095.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: bug-test-gen-095/
+input_files:
+  - ../common/
+  - bug-test-gen-095/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/bug-test-gen-095/Main.java
+++ b/java/jbmc-regression/bug-test-gen-095/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/bug-test-gen-095
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
    public static void main(String[] args)
    {
-      if(args.length < 1 || args[0] == null)
-        return;
-
-      StringBuilder sb = new StringBuilder(args[0]);
+      StringBuilder sb = new StringBuilder(Verifier.nondetString());
       sb.append("Z");
       String s = sb.toString();
       assert(s.equals("fg"));

--- a/java/jbmc-regression/bug-test-gen-119-2.yml
+++ b/java/jbmc-regression/bug-test-gen-119-2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: bug-test-gen-119-2/
+input_files:
+  - ../common/
+  - bug-test-gen-119-2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/bug-test-gen-119.yml
+++ b/java/jbmc-regression/bug-test-gen-119.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: bug-test-gen-119/
+input_files:
+  - ../common/
+  - bug-test-gen-119/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/bug-test-gen-119/Main.java
+++ b/java/jbmc-regression/bug-test-gen-119/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/bug-test-gen-119
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
     public static void main(String[] args)
     {
-        if(args.length < 1 || args[0] == null)
-          return;
-
-        boolean booleanValue = args[0].length() > 0;
+      boolean booleanValue = Verifier.nondetBoolean();
 
         String tmp=String.valueOf(booleanValue);
         if(booleanValue)

--- a/java/jbmc-regression/calc.yml
+++ b/java/jbmc-regression/calc.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: calc/
+input_files:
+  - ../common/
+  - calc/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/calc/Main.java
+++ b/java/jbmc-regression/calc/Main.java
@@ -6,6 +6,8 @@
  *     directory: regression/jbmc-strings-test-gen/calc
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   void do_stuff(String a, String b)
@@ -20,11 +22,15 @@ public class Main
 
   public static void main(String[] args)
   {
-    if(args.length<2)
+    int size = Verifier.nondetInt();
+    if(size < 2)
     {
       System.out.println("need two arguments");
       return;
     }
+    args = new String[size];
+    args[0] = Verifier.nondetString();
+    args[1] = Verifier.nondetString();
     new Main().do_stuff(args[0], args[1]);
   }
 }

--- a/java/jbmc-regression/cast1.yml
+++ b/java/jbmc-regression/cast1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: cast1/
+input_files:
+  - ../common/
+  - cast1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/cast1/Main.java
+++ b/java/jbmc-regression/cast1/Main.java
@@ -6,12 +6,14 @@
  *     directory: regression/cbmc-java/cast1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    int i = args.length;
-    if(args.length<-128 || args.length>127)
+    int i = Verifier.nondetInt();
+    if(i < -128 || i > 127)
       return;
     byte b = (byte) i;
     assert b == i;

--- a/java/jbmc-regression/catch1.yml
+++ b/java/jbmc-regression/catch1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: catch1/
+input_files:
+  - ../common/
+  - catch1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/char1.yml
+++ b/java/jbmc-regression/char1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: char1/
+input_files:
+  - ../common/
+  - char1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/char1/Main.java
+++ b/java/jbmc-regression/char1/Main.java
@@ -6,13 +6,16 @@
  *     directory: regression/cbmc-java/char1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main {
 
   static public void main(String[] args)
   {
-    if (args.length == 0 || args[0].length() == 0)
-        return;
-    char my_char=args[0].charAt(0);
+    String arg = Verifier.nondetString();
+    if(arg.length() < 1)
+      return;
+    char my_char=arg.charAt(0);
     int x=my_char;
     assert x>=0 && x<='\uffff';
 

--- a/java/jbmc-regression/charArray.yml
+++ b/java/jbmc-regression/charArray.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: charArray/
+input_files:
+  - ../common/
+  - charArray/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/charArray/Main.java
+++ b/java/jbmc-regression/charArray/Main.java
@@ -6,6 +6,8 @@
  *     directory: regression/jbmc-strings-test-gen/charArray
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main {
     public static char[] f(char c[]) {
         if (c != null && c.length > 0) {
@@ -15,9 +17,8 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        if(args.length<2 || args[1]==null || args[1].length() != 5)
-            return;
-        char[] c = f(args[1].toCharArray());
+        String arg = Verifier.nondetString();
+        char[] c = f(arg.toCharArray());
         String s = new String("HELLO") + new String(c, 0, c.length);
         assert s.charAt(5) == 's';
     }

--- a/java/jbmc-regression/classtest1.yml
+++ b/java/jbmc-regression/classtest1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: classtest1/
+input_files:
+  - ../common/
+  - classtest1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/const1.yml
+++ b/java/jbmc-regression/const1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: const1/
+input_files:
+  - ../common/
+  - const1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/constructor1.yml
+++ b/java/jbmc-regression/constructor1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: constructor1/
+input_files:
+  - ../common/
+  - constructor1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/enum1.yml
+++ b/java/jbmc-regression/enum1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: enum1/
+input_files:
+  - ../common/
+  - enum1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions1.yml
+++ b/java/jbmc-regression/exceptions1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions1/
+input_files:
+  - ../common/
+  - exceptions1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions10.yml
+++ b/java/jbmc-regression/exceptions10.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions10/
+input_files:
+  - ../common/
+  - exceptions10/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions11.yml
+++ b/java/jbmc-regression/exceptions11.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions11/
+input_files:
+  - ../common/
+  - exceptions11/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions12.yml
+++ b/java/jbmc-regression/exceptions12.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions12/
+input_files:
+  - ../common/
+  - exceptions12/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions13.yml
+++ b/java/jbmc-regression/exceptions13.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions13/
+input_files:
+  - ../common/
+  - exceptions13/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions14.yml
+++ b/java/jbmc-regression/exceptions14.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions14/
+input_files:
+  - ../common/
+  - exceptions14/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions15.yml
+++ b/java/jbmc-regression/exceptions15.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions15/
+input_files:
+  - ../common/
+  - exceptions15/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions15/Main.java
+++ b/java/jbmc-regression/exceptions15/Main.java
@@ -21,7 +21,6 @@ public class Main {
   public static void main(String[] args) {
     try {
       InetAddress address = new InetAddress();
-      int i = args.length;
       String domainName = lookupPtrRecord(reverse(address));
     } catch (Exception e) {
       assert false;

--- a/java/jbmc-regression/exceptions16.yml
+++ b/java/jbmc-regression/exceptions16.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions16/
+input_files:
+  - ../common/
+  - exceptions16/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions16/Main.java
+++ b/java/jbmc-regression/exceptions16/Main.java
@@ -6,13 +6,15 @@
  *     directory: regression/cbmc-java/exceptions16
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class A extends RuntimeException {}
 class B extends A {}
 class C extends B {}
 
 public class Main {
-  static void main (String[] args) {
-    int x = args.length;
+  public static void main (String[] args) {
+    int x = Verifier.nondetInt();
     try {
       x++;
     }

--- a/java/jbmc-regression/exceptions18.yml
+++ b/java/jbmc-regression/exceptions18.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions18/
+input_files:
+  - ../common/
+  - exceptions18/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions2.yml
+++ b/java/jbmc-regression/exceptions2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions2/
+input_files:
+  - ../common/
+  - exceptions2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions3.yml
+++ b/java/jbmc-regression/exceptions3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions3/
+input_files:
+  - ../common/
+  - exceptions3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions4.yml
+++ b/java/jbmc-regression/exceptions4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions4/
+input_files:
+  - ../common/
+  - exceptions4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions5.yml
+++ b/java/jbmc-regression/exceptions5.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions5/
+input_files:
+  - ../common/
+  - exceptions5/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/exceptions6.yml
+++ b/java/jbmc-regression/exceptions6.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions6/
+input_files:
+  - ../common/
+  - exceptions6/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions7.yml
+++ b/java/jbmc-regression/exceptions7.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions7/
+input_files:
+  - ../common/
+  - exceptions7/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions8.yml
+++ b/java/jbmc-regression/exceptions8.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions8/
+input_files:
+  - ../common/
+  - exceptions8/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/exceptions9.yml
+++ b/java/jbmc-regression/exceptions9.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: exceptions9/
+input_files:
+  - ../common/
+  - exceptions9/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/fcmpx_dcmpx1.yml
+++ b/java/jbmc-regression/fcmpx_dcmpx1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: fcmpx_dcmpx1/
+input_files:
+  - ../common/
+  - fcmpx_dcmpx1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/iarith1.yml
+++ b/java/jbmc-regression/iarith1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: iarith1/
+input_files:
+  - ../common/
+  - iarith1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/iarith2.yml
+++ b/java/jbmc-regression/iarith2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: iarith2/
+input_files:
+  - ../common/
+  - iarith2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/if_acmp1.yml
+++ b/java/jbmc-regression/if_acmp1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: if_acmp1/
+input_files:
+  - ../common/
+  - if_acmp1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/if_expr1.yml
+++ b/java/jbmc-regression/if_expr1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: if_expr1/
+input_files:
+  - ../common/
+  - if_expr1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/if_expr1/Main.java
+++ b/java/jbmc-regression/if_expr1/Main.java
@@ -6,11 +6,13 @@
  *     directory: regression/cbmc-java/if_expr1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
-  static public void main(String[] args) throws java.io.IOException
+  public static void main(String[] args)
   {
-    int x=System.in.read();
+    int x = Verifier.nondetInt();
     int y=x==10?11:9;
     if(x==10)
       assert y==11;

--- a/java/jbmc-regression/if_icmp1.yml
+++ b/java/jbmc-regression/if_icmp1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: if_icmp1/
+input_files:
+  - ../common/
+  - if_icmp1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/if_icmp1/Main.java
+++ b/java/jbmc-regression/if_icmp1/Main.java
@@ -6,6 +6,8 @@
  *     directory: regression/cbmc-java/if_icmp1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   private static void f(int i, int j) {
@@ -32,8 +34,9 @@ class Main
 
   public static void main(String[] args)
   {
-    if(args.length+1 < 0)
+    int i = Verifier.nondetInt();
+    if(i + 1 < 0)
       return;
-    f(args.length, args.length+1);
+    f(i, i + 1);
   }
 }

--- a/java/jbmc-regression/ifxx1.yml
+++ b/java/jbmc-regression/ifxx1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ifxx1/
+input_files:
+  - ../common/
+  - ifxx1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof1.yml
+++ b/java/jbmc-regression/instanceof1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof1/
+input_files:
+  - ../common/
+  - instanceof1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof2.yml
+++ b/java/jbmc-regression/instanceof2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof2/
+input_files:
+  - ../common/
+  - instanceof2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof3.yml
+++ b/java/jbmc-regression/instanceof3.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof3/
+input_files:
+  - ../common/
+  - instanceof3/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof4.yml
+++ b/java/jbmc-regression/instanceof4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof4/
+input_files:
+  - ../common/
+  - instanceof4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof5.yml
+++ b/java/jbmc-regression/instanceof5.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof5/
+input_files:
+  - ../common/
+  - instanceof5/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof6.yml
+++ b/java/jbmc-regression/instanceof6.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof6/
+input_files:
+  - ../common/
+  - instanceof6/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof7.yml
+++ b/java/jbmc-regression/instanceof7.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof7/
+input_files:
+  - ../common/
+  - instanceof7/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/instanceof8.yml
+++ b/java/jbmc-regression/instanceof8.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: instanceof8/
+input_files:
+  - ../common/
+  - instanceof8/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/interface1.yml
+++ b/java/jbmc-regression/interface1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: interface1/
+input_files:
+  - ../common/
+  - interface1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/java_append_char.yml
+++ b/java/jbmc-regression/java_append_char.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: java_append_char/
+input_files:
+  - ../common/
+  - java_append_char/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/java_append_char/Main.java
+++ b/java/jbmc-regression/java_append_char/Main.java
@@ -6,14 +6,13 @@
  *     directory: regression/jbmc-strings/java_append_char
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 public class Main
 {
   public static void main(String[] args)
    {
-      if(args.length < 1)
-        return;
-
-      boolean b = args[0].length() > 0;
+      boolean b = Verifier.nondetBoolean();
       char[] diff = {'d', 'i', 'f', 'f'};
       char[] blue = {'b', 'l', 'u', 'e'};
 

--- a/java/jbmc-regression/lazyloading4.yml
+++ b/java/jbmc-regression/lazyloading4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: lazyloading4/
+input_files:
+  - ../common/
+  - lazyloading4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/list1.yml
+++ b/java/jbmc-regression/list1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: list1/
+input_files:
+  - ../common/
+  - list1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/list1/Main.java
+++ b/java/jbmc-regression/list1/Main.java
@@ -6,6 +6,8 @@
  *     directory: regression/cbmc-java/list1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class LinkedListEntry
 {
   public LinkedListEntry Next;
@@ -65,7 +67,7 @@ class Utils_nondet
 {
   public static int nondet_int()
   {
-    return 0;
+    return Verifier.nondetInt();
   }
 }
 

--- a/java/jbmc-regression/long1.yml
+++ b/java/jbmc-regression/long1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: long1/
+input_files:
+  - ../common/
+  - long1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/long1/Main.java
+++ b/java/jbmc-regression/long1/Main.java
@@ -6,13 +6,12 @@
  *     directory: regression/cbmc-java/long1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    java.util.Random random = new java.util.Random(42);
-    
-    //long l=random.nextLong();
     long l=4620693217682128896L;
 
     // conversions

--- a/java/jbmc-regression/lookupswitch1.yml
+++ b/java/jbmc-regression/lookupswitch1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: lookupswitch1/
+input_files:
+  - ../common/
+  - lookupswitch1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/lookupswitch1/Main.java
+++ b/java/jbmc-regression/lookupswitch1/Main.java
@@ -6,14 +6,15 @@
  *     directory: regression/cbmc-java/lookupswitch1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
     int i, j;
-    
-    java.util.Random random = new java.util.Random(42);
-    i=random.nextInt();    
+
+    i = Verifier.nondetInt();
 
     switch(i)
     {

--- a/java/jbmc-regression/multinewarray.yml
+++ b/java/jbmc-regression/multinewarray.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: multinewarray/
+input_files:
+  - ../common/
+  - multinewarray/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/overloading1.yml
+++ b/java/jbmc-regression/overloading1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: overloading1/
+input_files:
+  - ../common/
+  - overloading1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/package1.yml
+++ b/java/jbmc-regression/package1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: package1/
+input_files:
+  - ../common/
+  - package1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/putfield_getfield1.yml
+++ b/java/jbmc-regression/putfield_getfield1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: putfield_getfield1/
+input_files:
+  - ../common/
+  - putfield_getfield1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/putstatic_getstatic1.yml
+++ b/java/jbmc-regression/putstatic_getstatic1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: putstatic_getstatic1/
+input_files:
+  - ../common/
+  - putstatic_getstatic1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/recursion2.yml
+++ b/java/jbmc-regression/recursion2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: recursion2/
+input_files:
+  - ../common/
+  - recursion2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/return1.yml
+++ b/java/jbmc-regression/return1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: return1/
+input_files:
+  - ../common/
+  - return1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/return2.yml
+++ b/java/jbmc-regression/return2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: return2/
+input_files:
+  - ../common/
+  - return2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/return2/Main.java
+++ b/java/jbmc-regression/return2/Main.java
@@ -6,19 +6,15 @@
  *     directory: regression/cbmc-java/return2
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
-    try
-    {
-      int v1=System.in.read();
-      int v2=System.in.read();
-      assert v1==v2; // should be able to fail
-    }
-    catch(java.io.IOException e)
-    {
-    }
+    int v1 = Verifier.nondetInt();
+    int v2 = Verifier.nondetInt();
+    assert v1==v2; // should be able to fail
   }
 }
 

--- a/java/jbmc-regression/store_load1.yml
+++ b/java/jbmc-regression/store_load1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: store_load1/
+input_files:
+  - ../common/
+  - store_load1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/swap1.yml
+++ b/java/jbmc-regression/swap1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: swap1/
+input_files:
+  - ../common/
+  - swap1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/synchronized.yml
+++ b/java/jbmc-regression/synchronized.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: synchronized/
+input_files:
+  - ../common/
+  - synchronized/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/tableswitch1.yml
+++ b/java/jbmc-regression/tableswitch1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: tableswitch1/
+input_files:
+  - ../common/
+  - tableswitch1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/tableswitch1/Main.java
+++ b/java/jbmc-regression/tableswitch1/Main.java
@@ -6,14 +6,15 @@
  *     directory: regression/cbmc-java/tableswitch1
  * The benchmark was taken from the repo: 24 January 2018
  */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
 class Main
 {
   public static void main(String[] args)
   {
     int i, j;
-    
-    java.util.Random random = new java.util.Random(42);
-    i=random.nextInt();    
+
+    i = Verifier.nondetInt();
 
     switch(i)
     {
@@ -32,7 +33,7 @@ class Main
     case 11: j=12; break;
     default: j=1000;
     }
-    
+
     if(i>=-1 && i<=11)
       assert j==i+1;
     else

--- a/java/jbmc-regression/uninitialised1.yml
+++ b/java/jbmc-regression/uninitialised1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: uninitialised1/
+input_files:
+  - ../common/
+  - uninitialised1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/virtual1.yml
+++ b/java/jbmc-regression/virtual1.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: virtual1/
+input_files:
+  - ../common/
+  - virtual1/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/virtual2.yml
+++ b/java/jbmc-regression/virtual2.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: virtual2/
+input_files:
+  - ../common/
+  - virtual2/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jbmc-regression/virtual4.yml
+++ b/java/jbmc-regression/virtual4.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: virtual4/
+input_files:
+  - ../common/
+  - virtual4/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jbmc-regression/virtual_function_unwinding.yml
+++ b/java/jbmc-regression/virtual_function_unwinding.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: virtual_function_unwinding/
+input_files:
+  - ../common/
+  - virtual_function_unwinding/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExDarko_false.yml
+++ b/java/jpf-regression/ExDarko_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExDarko_false/
+input_files:
+  - ../common/
+  - ExDarko_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExDarko_true.yml
+++ b/java/jpf-regression/ExDarko_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExDarko_true/
+input_files:
+  - ../common/
+  - ExDarko_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExException_false.yml
+++ b/java/jpf-regression/ExException_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExException_false/
+input_files:
+  - ../common/
+  - ExException_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExException_true.yml
+++ b/java/jpf-regression/ExException_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExException_true/
+input_files:
+  - ../common/
+  - ExException_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExGenSymExe_false.yml
+++ b/java/jpf-regression/ExGenSymExe_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExGenSymExe_false/
+input_files:
+  - ../common/
+  - ExGenSymExe_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExGenSymExe_true.yml
+++ b/java/jpf-regression/ExGenSymExe_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExGenSymExe_true/
+input_files:
+  - ../common/
+  - ExGenSymExe_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExLazy_false.yml
+++ b/java/jpf-regression/ExLazy_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExLazy_false/
+input_files:
+  - ../common/
+  - ExLazy_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExLazy_true.yml
+++ b/java/jpf-regression/ExLazy_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExLazy_true/
+input_files:
+  - ../common/
+  - ExLazy_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExMIT_false.yml
+++ b/java/jpf-regression/ExMIT_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExMIT_false/
+input_files:
+  - ../common/
+  - ExMIT_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExMIT_true.yml
+++ b/java/jpf-regression/ExMIT_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExMIT_true/
+input_files:
+  - ../common/
+  - ExMIT_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe10_false.yml
+++ b/java/jpf-regression/ExSymExe10_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe10_false/
+input_files:
+  - ../common/
+  - ExSymExe10_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe10_true.yml
+++ b/java/jpf-regression/ExSymExe10_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe10_true/
+input_files:
+  - ../common/
+  - ExSymExe10_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe11_false.yml
+++ b/java/jpf-regression/ExSymExe11_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe11_false/
+input_files:
+  - ../common/
+  - ExSymExe11_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe11_true.yml
+++ b/java/jpf-regression/ExSymExe11_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe11_true/
+input_files:
+  - ../common/
+  - ExSymExe11_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe12_false.yml
+++ b/java/jpf-regression/ExSymExe12_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe12_false/
+input_files:
+  - ../common/
+  - ExSymExe12_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe12_true.yml
+++ b/java/jpf-regression/ExSymExe12_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe12_true/
+input_files:
+  - ../common/
+  - ExSymExe12_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe13_false.yml
+++ b/java/jpf-regression/ExSymExe13_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe13_false/
+input_files:
+  - ../common/
+  - ExSymExe13_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe13_true.yml
+++ b/java/jpf-regression/ExSymExe13_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe13_true/
+input_files:
+  - ../common/
+  - ExSymExe13_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe14_false.yml
+++ b/java/jpf-regression/ExSymExe14_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe14_false/
+input_files:
+  - ../common/
+  - ExSymExe14_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe14_true.yml
+++ b/java/jpf-regression/ExSymExe14_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe14_true/
+input_files:
+  - ../common/
+  - ExSymExe14_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe15_false.yml
+++ b/java/jpf-regression/ExSymExe15_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe15_false/
+input_files:
+  - ../common/
+  - ExSymExe15_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe15_true.yml
+++ b/java/jpf-regression/ExSymExe15_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe15_true/
+input_files:
+  - ../common/
+  - ExSymExe15_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe16_false.yml
+++ b/java/jpf-regression/ExSymExe16_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe16_false/
+input_files:
+  - ../common/
+  - ExSymExe16_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe16_true.yml
+++ b/java/jpf-regression/ExSymExe16_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe16_true/
+input_files:
+  - ../common/
+  - ExSymExe16_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe17_false.yml
+++ b/java/jpf-regression/ExSymExe17_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe17_false/
+input_files:
+  - ../common/
+  - ExSymExe17_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe17_true.yml
+++ b/java/jpf-regression/ExSymExe17_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe17_true/
+input_files:
+  - ../common/
+  - ExSymExe17_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe18_false.yml
+++ b/java/jpf-regression/ExSymExe18_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe18_false/
+input_files:
+  - ../common/
+  - ExSymExe18_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe18_true.yml
+++ b/java/jpf-regression/ExSymExe18_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe18_true/
+input_files:
+  - ../common/
+  - ExSymExe18_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe19_false.yml
+++ b/java/jpf-regression/ExSymExe19_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe19_false/
+input_files:
+  - ../common/
+  - ExSymExe19_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe19_true.yml
+++ b/java/jpf-regression/ExSymExe19_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe19_true/
+input_files:
+  - ../common/
+  - ExSymExe19_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe1_false.yml
+++ b/java/jpf-regression/ExSymExe1_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe1_false/
+input_files:
+  - ../common/
+  - ExSymExe1_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe1_true.yml
+++ b/java/jpf-regression/ExSymExe1_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe1_true/
+input_files:
+  - ../common/
+  - ExSymExe1_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe20_false.yml
+++ b/java/jpf-regression/ExSymExe20_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe20_false/
+input_files:
+  - ../common/
+  - ExSymExe20_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe20_true.yml
+++ b/java/jpf-regression/ExSymExe20_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe20_true/
+input_files:
+  - ../common/
+  - ExSymExe20_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe21_false.yml
+++ b/java/jpf-regression/ExSymExe21_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe21_false/
+input_files:
+  - ../common/
+  - ExSymExe21_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe21_true.yml
+++ b/java/jpf-regression/ExSymExe21_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe21_true/
+input_files:
+  - ../common/
+  - ExSymExe21_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe25_false.yml
+++ b/java/jpf-regression/ExSymExe25_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe25_false/
+input_files:
+  - ../common/
+  - ExSymExe25_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe25_true.yml
+++ b/java/jpf-regression/ExSymExe25_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe25_true/
+input_files:
+  - ../common/
+  - ExSymExe25_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe26_false.yml
+++ b/java/jpf-regression/ExSymExe26_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe26_false/
+input_files:
+  - ../common/
+  - ExSymExe26_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe26_true.yml
+++ b/java/jpf-regression/ExSymExe26_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe26_true/
+input_files:
+  - ../common/
+  - ExSymExe26_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe27_false.yml
+++ b/java/jpf-regression/ExSymExe27_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe27_false/
+input_files:
+  - ../common/
+  - ExSymExe27_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe27_true.yml
+++ b/java/jpf-regression/ExSymExe27_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe27_true/
+input_files:
+  - ../common/
+  - ExSymExe27_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe28_false.yml
+++ b/java/jpf-regression/ExSymExe28_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe28_false/
+input_files:
+  - ../common/
+  - ExSymExe28_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe28_true.yml
+++ b/java/jpf-regression/ExSymExe28_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe28_true/
+input_files:
+  - ../common/
+  - ExSymExe28_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe29_false.yml
+++ b/java/jpf-regression/ExSymExe29_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe29_false/
+input_files:
+  - ../common/
+  - ExSymExe29_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe29_true.yml
+++ b/java/jpf-regression/ExSymExe29_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe29_true/
+input_files:
+  - ../common/
+  - ExSymExe29_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe2_false.yml
+++ b/java/jpf-regression/ExSymExe2_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe2_false/
+input_files:
+  - ../common/
+  - ExSymExe2_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe2_true.yml
+++ b/java/jpf-regression/ExSymExe2_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe2_true/
+input_files:
+  - ../common/
+  - ExSymExe2_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe3_false.yml
+++ b/java/jpf-regression/ExSymExe3_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe3_false/
+input_files:
+  - ../common/
+  - ExSymExe3_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe3_true.yml
+++ b/java/jpf-regression/ExSymExe3_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe3_true/
+input_files:
+  - ../common/
+  - ExSymExe3_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe4_false.yml
+++ b/java/jpf-regression/ExSymExe4_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe4_false/
+input_files:
+  - ../common/
+  - ExSymExe4_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe4_true.yml
+++ b/java/jpf-regression/ExSymExe4_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe4_true/
+input_files:
+  - ../common/
+  - ExSymExe4_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe5_false.yml
+++ b/java/jpf-regression/ExSymExe5_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe5_false/
+input_files:
+  - ../common/
+  - ExSymExe5_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe5_true.yml
+++ b/java/jpf-regression/ExSymExe5_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe5_true/
+input_files:
+  - ../common/
+  - ExSymExe5_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe6_false.yml
+++ b/java/jpf-regression/ExSymExe6_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe6_false/
+input_files:
+  - ../common/
+  - ExSymExe6_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe6_true.yml
+++ b/java/jpf-regression/ExSymExe6_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe6_true/
+input_files:
+  - ../common/
+  - ExSymExe6_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe7_false.yml
+++ b/java/jpf-regression/ExSymExe7_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe7_false/
+input_files:
+  - ../common/
+  - ExSymExe7_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe7_true.yml
+++ b/java/jpf-regression/ExSymExe7_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe7_true/
+input_files:
+  - ../common/
+  - ExSymExe7_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe8_false.yml
+++ b/java/jpf-regression/ExSymExe8_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe8_false/
+input_files:
+  - ../common/
+  - ExSymExe8_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe8_true.yml
+++ b/java/jpf-regression/ExSymExe8_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe8_true/
+input_files:
+  - ../common/
+  - ExSymExe8_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe9_false.yml
+++ b/java/jpf-regression/ExSymExe9_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe9_false/
+input_files:
+  - ../common/
+  - ExSymExe9_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe9_true.yml
+++ b/java/jpf-regression/ExSymExe9_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe9_true/
+input_files:
+  - ../common/
+  - ExSymExe9_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeArrays_false.yml
+++ b/java/jpf-regression/ExSymExeArrays_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeArrays_false/
+input_files:
+  - ../common/
+  - ExSymExeArrays_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeArrays_true.yml
+++ b/java/jpf-regression/ExSymExeArrays_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeArrays_true/
+input_files:
+  - ../common/
+  - ExSymExeArrays_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeBool_false.yml
+++ b/java/jpf-regression/ExSymExeBool_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeBool_false/
+input_files:
+  - ../common/
+  - ExSymExeBool_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeBool_true.yml
+++ b/java/jpf-regression/ExSymExeBool_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeBool_true/
+input_files:
+  - ../common/
+  - ExSymExeBool_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeComplexMath_false.yml
+++ b/java/jpf-regression/ExSymExeComplexMath_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeComplexMath_false/
+input_files:
+  - ../common/
+  - ExSymExeComplexMath_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeComplexMath_true.yml
+++ b/java/jpf-regression/ExSymExeComplexMath_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeComplexMath_true/
+input_files:
+  - ../common/
+  - ExSymExeComplexMath_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeD2I_false.yml
+++ b/java/jpf-regression/ExSymExeD2I_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeD2I_false/
+input_files:
+  - ../common/
+  - ExSymExeD2I_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeD2I_true.yml
+++ b/java/jpf-regression/ExSymExeD2I_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeD2I_true/
+input_files:
+  - ../common/
+  - ExSymExeD2I_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeD2L_false.yml
+++ b/java/jpf-regression/ExSymExeD2L_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeD2L_false/
+input_files:
+  - ../common/
+  - ExSymExeD2L_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeD2L_true.yml
+++ b/java/jpf-regression/ExSymExeD2L_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeD2L_true/
+input_files:
+  - ../common/
+  - ExSymExeD2L_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeF2I_false.yml
+++ b/java/jpf-regression/ExSymExeF2I_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeF2I_false/
+input_files:
+  - ../common/
+  - ExSymExeF2I_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeF2I_true.yml
+++ b/java/jpf-regression/ExSymExeF2I_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeF2I_true/
+input_files:
+  - ../common/
+  - ExSymExeF2I_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeF2L_false.yml
+++ b/java/jpf-regression/ExSymExeF2L_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeF2L_false/
+input_files:
+  - ../common/
+  - ExSymExeF2L_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeF2L_true.yml
+++ b/java/jpf-regression/ExSymExeF2L_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeF2L_true/
+input_files:
+  - ../common/
+  - ExSymExeF2L_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeFNEG_false.yml
+++ b/java/jpf-regression/ExSymExeFNEG_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeFNEG_false/
+input_files:
+  - ../common/
+  - ExSymExeFNEG_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeFNEG_true.yml
+++ b/java/jpf-regression/ExSymExeFNEG_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeFNEG_true/
+input_files:
+  - ../common/
+  - ExSymExeFNEG_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeGetStatic_false.yml
+++ b/java/jpf-regression/ExSymExeGetStatic_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeGetStatic_false/
+input_files:
+  - ../common/
+  - ExSymExeGetStatic_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeGetStatic_true.yml
+++ b/java/jpf-regression/ExSymExeGetStatic_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeGetStatic_true/
+input_files:
+  - ../common/
+  - ExSymExeGetStatic_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeI2D_false.yml
+++ b/java/jpf-regression/ExSymExeI2D_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeI2D_false/
+input_files:
+  - ../common/
+  - ExSymExeI2D_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeI2D_true.yml
+++ b/java/jpf-regression/ExSymExeI2D_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeI2D_true/
+input_files:
+  - ../common/
+  - ExSymExeI2D_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeI2F_false.yml
+++ b/java/jpf-regression/ExSymExeI2F_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeI2F_false/
+input_files:
+  - ../common/
+  - ExSymExeI2F_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeI2F_true.yml
+++ b/java/jpf-regression/ExSymExeI2F_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeI2F_true/
+input_files:
+  - ../common/
+  - ExSymExeI2F_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeLCMP_false.yml
+++ b/java/jpf-regression/ExSymExeLCMP_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeLCMP_false/
+input_files:
+  - ../common/
+  - ExSymExeLCMP_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeLCMP_true.yml
+++ b/java/jpf-regression/ExSymExeLCMP_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeLCMP_true/
+input_files:
+  - ../common/
+  - ExSymExeLCMP_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeLongBytecodes_false.yml
+++ b/java/jpf-regression/ExSymExeLongBytecodes_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeLongBytecodes_false/
+input_files:
+  - ../common/
+  - ExSymExeLongBytecodes_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeLongBytecodes_true.yml
+++ b/java/jpf-regression/ExSymExeLongBytecodes_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeLongBytecodes_true/
+input_files:
+  - ../common/
+  - ExSymExeLongBytecodes_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeResearch_false.yml
+++ b/java/jpf-regression/ExSymExeResearch_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeResearch_false/
+input_files:
+  - ../common/
+  - ExSymExeResearch_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeResearch_true.yml
+++ b/java/jpf-regression/ExSymExeResearch_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeResearch_true/
+input_files:
+  - ../common/
+  - ExSymExeResearch_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeSimple_false.yml
+++ b/java/jpf-regression/ExSymExeSimple_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSimple_false/
+input_files:
+  - ../common/
+  - ExSymExeSimple_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeSimple_true.yml
+++ b/java/jpf-regression/ExSymExeSimple_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSimple_true/
+input_files:
+  - ../common/
+  - ExSymExeSimple_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeSuzette_false.yml
+++ b/java/jpf-regression/ExSymExeSuzette_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSuzette_false/
+input_files:
+  - ../common/
+  - ExSymExeSuzette_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeSuzette_true.yml
+++ b/java/jpf-regression/ExSymExeSuzette_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSuzette_true/
+input_files:
+  - ../common/
+  - ExSymExeSuzette_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeSwitch_false.yml
+++ b/java/jpf-regression/ExSymExeSwitch_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSwitch_false/
+input_files:
+  - ../common/
+  - ExSymExeSwitch_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeSwitch_true.yml
+++ b/java/jpf-regression/ExSymExeSwitch_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeSwitch_true/
+input_files:
+  - ../common/
+  - ExSymExeSwitch_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeTestAssignments_false.yml
+++ b/java/jpf-regression/ExSymExeTestAssignments_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeTestAssignments_false/
+input_files:
+  - ../common/
+  - ExSymExeTestAssignments_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeTestAssignments_true.yml
+++ b/java/jpf-regression/ExSymExeTestAssignments_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeTestAssignments_true/
+input_files:
+  - ../common/
+  - ExSymExeTestAssignments_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExeTestClassFields_false.yml
+++ b/java/jpf-regression/ExSymExeTestClassFields_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeTestClassFields_false/
+input_files:
+  - ../common/
+  - ExSymExeTestClassFields_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExeTestClassFields_true.yml
+++ b/java/jpf-regression/ExSymExeTestClassFields_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExeTestClassFields_true/
+input_files:
+  - ../common/
+  - ExSymExeTestClassFields_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/ExSymExe_false.yml
+++ b/java/jpf-regression/ExSymExe_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe_false/
+input_files:
+  - ../common/
+  - ExSymExe_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/ExSymExe_true.yml
+++ b/java/jpf-regression/ExSymExe_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: ExSymExe_true/
+input_files:
+  - ../common/
+  - ExSymExe_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true

--- a/java/jpf-regression/TestLazy_false.yml
+++ b/java/jpf-regression/TestLazy_false.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: TestLazy_false/
+input_files:
+  - ../common/
+  - TestLazy_false/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: false

--- a/java/jpf-regression/TestLazy_true.yml
+++ b/java/jpf-regression/TestLazy_true.yml
@@ -1,5 +1,7 @@
 format_version: "0.1"
-input_files: TestLazy_true/
+input_files:
+  - ../common/
+  - TestLazy_true/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true


### PR DESCRIPTION
- [n/a] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [n/a] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [n/a] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [n/a] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [n/a] intended property matches the corresponding `.prp` file
- [n/a] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [n/a] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [n/a] original sources present
- [n/a] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [n/a] preprocessed files generated with correct architecture
- [n/a] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
