### PR TITLE
Use Java Verifier class in jpf-regression benchmarks

### DIFF
--- a/java/jpf-regression/ExDarko_false/Main.java
+++ b/java/jpf-regression/ExDarko_false/Main.java
@@ -24,13 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    new Main().unboxed(args.length, 2);
-    new Main().boxed(args.length, 2);
-    new Main().customBoxed(args.length, 2);
+    new Main().unboxed(Verifier.nondetInt(), 2);
+    new Main().boxed(Verifier.nondetInt(), 2);
+    new Main().customBoxed(Verifier.nondetInt(), 2);
   }
 
   private void unboxed(int i, int j) {

--- a/java/jpf-regression/ExDarko_true/Main.java
+++ b/java/jpf-regression/ExDarko_true/Main.java
@@ -24,11 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    new Main().unboxed((args.length % 10) + 1, (args.length % 10));
+    int x = Verifier.nondetInt();
+    int y = Verifier.nondetInt();
+    if (x == y)
+      return;
+    new Main().unboxed(x, y);
     new Main().boxed(1, 2);
     new Main().customBoxed(1, 2);
   }

--- a/java/jpf-regression/ExException_false/Main.java
+++ b/java/jpf-regression/ExException_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   int zero() { return 0; }
@@ -38,7 +39,7 @@ public class Main {
   }
   public static void main(String[] args) {
     System.out.println(0);
-    test(args.length);
+    test(Verifier.nondetInt());
     System.out.println(1);
   }
 }

--- a/java/jpf-regression/ExException_true/Main.java
+++ b/java/jpf-regression/ExException_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   int zero() { return 0; }
@@ -38,7 +39,7 @@ public class Main {
   }
   public static void main(String[] args) {
     System.out.println(0);
-    test(args.length > 0 ? 1 : 2);
+    test(Verifier.nondetBoolean() ? 1 : 2);
     System.out.println(1);
   }
 }

--- a/java/jpf-regression/ExGenSymExe_false/Main.java
+++ b/java/jpf-regression/ExGenSymExe_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
@@ -33,7 +34,7 @@ public class Main {
     n.next = m;
     n.next.next = n;
     Node na = n.swapNode();
-    n.elem = args.length;
+    n.elem = Verifier.nondetInt();
     // Debug.printSymbolicRef(n);
     // Debug.printPC("\nPC");
     // Debug.printHeapPC("Heap PC");

--- a/java/jpf-regression/ExGenSymExe_true/Main.java
+++ b/java/jpf-regression/ExGenSymExe_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
@@ -33,7 +34,7 @@ public class Main {
     n.next = m;
     n.next.next = n;
     Node na = n.swapNode();
-    n.elem = args.length;
+    n.elem = Verifier.nondetInt();
     // Debug.printSymbolicRef(n);
     // Debug.printPC("\nPC");
     // Debug.printHeapPC("Heap PC");

--- a/java/jpf-regression/ExLazy_false/Main.java
+++ b/java/jpf-regression/ExLazy_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
@@ -35,5 +36,5 @@ public class Main {
       assert false;
     }
   }
-  public static void main(String[] args) { test(null, args.length); }
+  public static void main(String[] args) { test(null, Verifier.nondetInt()); }
 }

--- a/java/jpf-regression/ExLazy_true/Main.java
+++ b/java/jpf-regression/ExLazy_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
@@ -36,9 +37,9 @@ public class Main {
     }
   }
   public static void main(String[] args) {
-    if (args.length == 0)
+    if (Verifier.nondetInt() == 0)
       test(null, 0);
     else
-      test(null, args.length);
+      test(null, Verifier.nondetInt());
   }
 }

--- a/java/jpf-regression/ExMIT_false/Main.java
+++ b/java/jpf-regression/ExMIT_false/Main.java
@@ -24,9 +24,10 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
-  public static void main(String[] args) { foo(args.length); }
+  public static void main(String[] args) { foo(Verifier.nondetInt()); }
   public static int foo(int i) {
     if (2 * (i + 1) == 10) {
       assert false;

--- a/java/jpf-regression/ExMIT_true/Main.java
+++ b/java/jpf-regression/ExMIT_true/Main.java
@@ -24,10 +24,11 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   public static void main(String[] args) {
-    if (args.length == 1)
+    if (Verifier.nondetInt() == 1)
       foo(0);
   }
   public static int foo(int i) {

--- a/java/jpf-regression/ExSymExe10_false/Main.java
+++ b/java/jpf-regression/ExSymExe10_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
@@ -33,7 +34,9 @@ public class Main {
                     be symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
     inst.test(x, field);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe10_true/Main.java
+++ b/java/jpf-regression/ExSymExe10_true/Main.java
@@ -24,18 +24,18 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;
-    if (args.length == 2)
+    if (Verifier.nondetInt() == 2)
       inst.test(x, field);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe11_false/Main.java
+++ b/java/jpf-regression/ExSymExe11_false/Main.java
@@ -24,17 +24,17 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
     inst.test(x, field);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe11_true/Main.java
+++ b/java/jpf-regression/ExSymExe11_true/Main.java
@@ -24,17 +24,20 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
-    field = args.length % 100;
+    field = arg % 100;
     inst.test(x, field);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe12_false/Main.java
+++ b/java/jpf-regression/ExSymExe12_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
@@ -34,7 +35,7 @@ public class Main {
                     be symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe12_true/Main.java
+++ b/java/jpf-regression/ExSymExe12_true/Main.java
@@ -24,19 +24,22 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;
-    inst.test(x, args.length, field2);
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    inst.test(x, arg, field2);
     // test(x,x);
   }
   /* we want to let the user specify that this method should be symbolic */

--- a/java/jpf-regression/ExSymExe13_false/Main.java
+++ b/java/jpf-regression/ExSymExe13_false/Main.java
@@ -24,18 +24,21 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        -args.length; /* we want to specify in an annotation that this param
-                         should be symbolic */
+    int x = Verifier.nondetInt();
+    if (x > 0)
+      return;
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe13_true/Main.java
+++ b/java/jpf-regression/ExSymExe13_true/Main.java
@@ -24,19 +24,21 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        args.length; /* we want to specify in an annotation that this param
-                        should be symbolic */
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    int x = arg;
 
     Main inst = new Main();
     field = 9;
-    inst.test(x, args.length, field2);
+    inst.test(x, arg, field2);
     // test(x,x);
   }
   /* we want to let the user specify that this method should be symbolic */

--- a/java/jpf-regression/ExSymExe14_false/Main.java
+++ b/java/jpf-regression/ExSymExe14_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
@@ -34,7 +35,9 @@ public class Main {
                     be symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe14_true/Main.java
+++ b/java/jpf-regression/ExSymExe14_true/Main.java
@@ -24,19 +24,21 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        args.length; /* we want to specify in an annotation that this param
-                        should be symbolic */
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    int x = arg;
 
     Main inst = new Main();
-    field = args.length;
-    inst.test(x, args.length, field2);
+    field = arg;
+    inst.test(x, arg, field2);
     // test(x,x);
   }
   /* we want to let the user specify that this method should be symbolic */

--- a/java/jpf-regression/ExSymExe15_false/Main.java
+++ b/java/jpf-regression/ExSymExe15_false/Main.java
@@ -24,18 +24,18 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe15_true/Main.java
+++ b/java/jpf-regression/ExSymExe15_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
@@ -35,7 +36,9 @@ public class Main {
                   symbolic */
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe16_true/Main.java
+++ b/java/jpf-regression/ExSymExe16_true/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe17_false/Main.java
+++ b/java/jpf-regression/ExSymExe17_false/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        4; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 4; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 0;

--- a/java/jpf-regression/ExSymExe17_true/Main.java
+++ b/java/jpf-regression/ExSymExe17_true/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe18_false/Main.java
+++ b/java/jpf-regression/ExSymExe18_false/Main.java
@@ -24,14 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x = args.length % 30; /* we want to specify in an annotation that this
-                                 param should be symbolic */
+    int x = Verifier.nondetInt();
 
     Main inst = new Main();
     field = 9000;

--- a/java/jpf-regression/ExSymExe18_true/Main.java
+++ b/java/jpf-regression/ExSymExe18_true/Main.java
@@ -30,9 +30,8 @@ public class Main {
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe19_false/Main.java
+++ b/java/jpf-regression/ExSymExe19_false/Main.java
@@ -24,18 +24,17 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        args.length; /* we want to specify in an annotation that this param
-                        should be symbolic */
+    int x = Verifier.nondetInt();
 
     Main inst = new Main();
-    field = args.length;
+    field = Verifier.nondetInt();
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe19_true/Main.java
+++ b/java/jpf-regression/ExSymExe19_true/Main.java
@@ -24,18 +24,21 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
-    field = args.length % 10;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
+    field = field % 10;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe1_false/Main.java
+++ b/java/jpf-regression/ExSymExe1_false/Main.java
@@ -23,13 +23,14 @@
  * limitations under the License.
  */
 
-// ckage gov.nasa.jpf.symbc;
+// package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 1000;
-    int y = args.length % 50;
+    int x = Verifier.nondetInt() % 1000;
+    int y = Verifier.nondetInt() % 50;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe1_true/Main.java
+++ b/java/jpf-regression/ExSymExe1_true/Main.java
@@ -23,13 +23,14 @@
  * limitations under the License.
  */
 
-// ckage gov.nasa.jpf.symbc;
+// package gov.nasa.jpf.symbc;
 
 public class Main {
 
   public static void main(String[] args) {
     int x = 3;
     int y = 5;
+
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe20_false/Main.java
+++ b/java/jpf-regression/ExSymExe20_false/Main.java
@@ -24,17 +24,24 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x = args.length % 3; /* we want to specify in an annotation that this
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
+    x = x % 3; /* we want to specify in an annotation that this
                                 param should be symbolic */
 
     Main inst = new Main();
-    field = args.length % 9;
+    field = Verifier.nondetInt();
+    if (field < 0)
+      return;
+    field = field % 9;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe20_true/Main.java
+++ b/java/jpf-regression/ExSymExe20_true/Main.java
@@ -30,9 +30,8 @@ public class Main {
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe21_false/Main.java
+++ b/java/jpf-regression/ExSymExe21_false/Main.java
@@ -24,17 +24,17 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static int field;
   static int field2;
 
   public static void main(String[] args) {
-    int x = args.length % 3; /* we want to specify in an annotation that this
-                                param should be symbolic */
+    int x = Verifier.nondetInt();
 
     Main inst = new Main();
-    field = args.length % 9;
+    field = Verifier.nondetInt() % 9;
     inst.test(x, field, field2);
     // test(x,x);
   }

--- a/java/jpf-regression/ExSymExe21_true/Main.java
+++ b/java/jpf-regression/ExSymExe21_true/Main.java
@@ -30,9 +30,8 @@ public class Main {
   static int field2;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe25_false/Main.java
+++ b/java/jpf-regression/ExSymExe25_false/Main.java
@@ -24,13 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int a = args.length % 3;
+    int a = Verifier.nondetInt();
     Main inst = new Main();
-    int b = args.length % 8;
+    int b = Verifier.nondetInt();
     inst.test(a, b, a);
   }
 

--- a/java/jpf-regression/ExSymExe26_false/Main.java
+++ b/java/jpf-regression/ExSymExe26_false/Main.java
@@ -24,13 +24,18 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int a = args.length % 3;
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+
+    int a = arg % 3;
     Main inst = new Main();
-    int b = args.length % 8;
+    int b = arg % 8;
     inst.test(a, b, a);
   }
 

--- a/java/jpf-regression/ExSymExe27_false/Main.java
+++ b/java/jpf-regression/ExSymExe27_false/Main.java
@@ -24,13 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int a = args.length % 3;
+    int a = Verifier.nondetInt();
     Main inst = new Main();
-    int b = args.length % 8;
+    int b = Verifier.nondetInt();
     inst.test(a, b, a);
   }
 

--- a/java/jpf-regression/ExSymExe28_false/Main.java
+++ b/java/jpf-regression/ExSymExe28_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3;
-    int y = args.length % 5;
+    int x = Verifier.nondetInt();
+    int y = Verifier.nondetInt();
     Main inst = new Main();
     inst.test(x, y, 9);
   }

--- a/java/jpf-regression/ExSymExe29_false/Main.java
+++ b/java/jpf-regression/ExSymExe29_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3;
-    int y = args.length % 5;
+    int x = Verifier.nondetInt() % 3;
+    int y = Verifier.nondetInt() % 5;
     Main inst = new Main();
     inst.test(x, y, 9);
   }

--- a/java/jpf-regression/ExSymExe2_false/Main.java
+++ b/java/jpf-regression/ExSymExe2_false/Main.java
@@ -24,12 +24,19 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 5 - 5;
-    int y = args.length % 5 - 5;
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
+    x = x % 5 - 5;
+    int y = Verifier.nondetInt();
+    if (y < 0)
+      return;
+    y = y % 5 - 5;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe3_false/Main.java
+++ b/java/jpf-regression/ExSymExe3_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3 - 3;
-    int y = args.length % 5 - 5;
+    int x = Verifier.nondetInt();
+    int y = Verifier.nondetInt();
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe4_false/Main.java
+++ b/java/jpf-regression/ExSymExe4_false/Main.java
@@ -24,12 +24,19 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 13 - 13;
-    int y = args.length % 15 - 15;
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
+    x = x % 13 - 13;
+    int y = Verifier.nondetInt();
+    if (y < 0)
+      return;
+    y = y % 15 - 15;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe5_false/Main.java
+++ b/java/jpf-regression/ExSymExe5_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3 - 3;
-    int y = args.length % 115 - 115;
+    int x = Verifier.nondetInt();
+    int y = Verifier.nondetInt();
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe6_false/Main.java
+++ b/java/jpf-regression/ExSymExe6_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3;
-    int y = args.length % 0;
+    int x = Verifier.nondetInt() % 3;
+    int y = Verifier.nondetInt() % 0;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe7_false/Main.java
+++ b/java/jpf-regression/ExSymExe7_false/Main.java
@@ -24,12 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = 10 - args.length % 9;
-    int y = 10 - args.length % 5;
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    int x = 10 - arg % 9;
+    int y = 10 - arg % 5;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe7_true/Main.java
+++ b/java/jpf-regression/ExSymExe7_true/Main.java
@@ -24,12 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 5;
-    int y = args.length % 5;
+    int arg = Verifier.nondetInt();
+    if (arg < 0)
+      return;
+    int x = arg % 5;
+    int y = arg % 5;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe8_false/Main.java
+++ b/java/jpf-regression/ExSymExe8_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 3;
-    int y = args.length % 5;
+    int x = Verifier.nondetInt() % 3;
+    int y = Verifier.nondetInt() % 5;
     Main inst = new Main();
     inst.test(x, y);
   }

--- a/java/jpf-regression/ExSymExe9_false/Main.java
+++ b/java/jpf-regression/ExSymExe9_false/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        10; /* we want to specify in an annotation that this param should be
-               symbolic */
+    int x = 10; /* we want to specify in an annotation that this param should be
+                   symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExe9_true/Main.java
+++ b/java/jpf-regression/ExSymExe9_true/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExeComplexMath_false/Main.java
+++ b/java/jpf-regression/ExSymExeComplexMath_false/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExeComplexMath_true/Main.java
+++ b/java/jpf-regression/ExSymExeComplexMath_true/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
 
     Main inst = new Main();
     field = 9;

--- a/java/jpf-regression/ExSymExeD2I_true/Main.java
+++ b/java/jpf-regression/ExSymExeD2I_true/Main.java
@@ -24,11 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    double x = 3.0;
+    double x = Verifier.nondetDouble();
+    if (x < 3.0)
+      return;
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeD2L_false/Main.java
+++ b/java/jpf-regression/ExSymExeD2L_false/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    double x = args.length % 100;
+    double x = Verifier.nondetDouble();
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeD2L_true/Main.java
+++ b/java/jpf-regression/ExSymExeD2L_true/Main.java
@@ -24,11 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    double x = args.length > 0 ? 3.0 : -args.length;
+    double x = Verifier.nondetDouble();
+    if (x < 0.0)
+      return;
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeF2L_false/Main.java
+++ b/java/jpf-regression/ExSymExeF2L_false/Main.java
@@ -24,14 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    float x = args.length % 100;
-
-    Main inst = new Main();
-    inst.test(x);
+    float x = Verifier.nondetFloat();
+    if (x < 0.0f) {
+      Main inst = new Main();
+      inst.test(x);
+    }
   }
 
   public void test(float x) {

--- a/java/jpf-regression/ExSymExeF2L_true/Main.java
+++ b/java/jpf-regression/ExSymExeF2L_true/Main.java
@@ -24,14 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    float x = args.length > 0 ? args.length - 1 : -args.length;
-
-    Main inst = new Main();
-    inst.test(x);
+    float x = Verifier.nondetFloat();
+    if (x <= 0.0f) {
+      Main inst = new Main();
+      inst.test(x);
+    }
   }
 
   public void test(float x) {

--- a/java/jpf-regression/ExSymExeFNEG_false/Main.java
+++ b/java/jpf-regression/ExSymExeFNEG_false/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    float x = args.length % 100;
+    float x = Verifier.nondetFloat();
     Main inst = new Main();
     inst.test(x);
   }

--- a/java/jpf-regression/ExSymExeFNEG_true/Main.java
+++ b/java/jpf-regression/ExSymExeFNEG_true/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    float x = args.length > 0 ? args.length % 100 : -args.length % 100;
+    float x = Verifier.nondetFloat();
     Main inst = new Main();
     inst.test(x);
   }

--- a/java/jpf-regression/ExSymExeI2D_false/Main.java
+++ b/java/jpf-regression/ExSymExeI2D_false/Main.java
@@ -24,11 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length % 100;
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeI2D_true/Main.java
+++ b/java/jpf-regression/ExSymExeI2D_true/Main.java
@@ -24,11 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length > 0 ? args.length % 10 : -args.length % 10;
+    int x = Verifier.nondetInt();
+    x = x > 0 ? x % 10 : -x % 10;
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeI2F_true/Main.java
+++ b/java/jpf-regression/ExSymExeI2F_true/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length > 0 ? 3 : -args.length % 100;
+    int x = Verifier.nondetBoolean() ? 3 : 0;
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeLCMP_false/Main.java
+++ b/java/jpf-regression/ExSymExeLCMP_false/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    long x = args.length;
+    long x = Verifier.nondetLong();
 
     Main inst = new Main();
     inst.test(x, 5);

--- a/java/jpf-regression/ExSymExeLCMP_true/Main.java
+++ b/java/jpf-regression/ExSymExeLCMP_true/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    long x = args.length;
+    long x = (long)Verifier.nondetInt();
 
     Main inst = new Main();
     inst.test(x, 5);

--- a/java/jpf-regression/ExSymExeLongBytecodes_false/Main.java
+++ b/java/jpf-regression/ExSymExeLongBytecodes_false/Main.java
@@ -24,11 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    long x = args.length;
+    long x = Verifier.nondetLong();
     long y = 5;
     Main inst = new Main();
     inst.test(x, y);

--- a/java/jpf-regression/ExSymExeLongBytecodes_true/Main.java
+++ b/java/jpf-regression/ExSymExeLongBytecodes_true/Main.java
@@ -24,11 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    long x = args.length > 0 ? -args.length : args.length;
+    long x = Verifier.nondetLong();
+    x = x > 0 ? -x : x;
     long y = 5;
     Main inst = new Main();
     inst.test(x, y);

--- a/java/jpf-regression/ExSymExeResearch_false/Main.java
+++ b/java/jpf-regression/ExSymExeResearch_false/Main.java
@@ -24,11 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length;
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
     int y = 5;
     Main inst = new Main();
     assert inst.test(x, y) == 2;

--- a/java/jpf-regression/ExSymExeResearch_true/Main.java
+++ b/java/jpf-regression/ExSymExeResearch_true/Main.java
@@ -24,11 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x = args.length > 0 ? args.length : -args.length;
+    int arg = Verifier.nondetInt();
+    int x = arg > 0 ? arg : -arg;
     int y = 5;
     Main inst = new Main();
     assert inst.test(x, y) != x + y;

--- a/java/jpf-regression/ExSymExeSimple_false/Main.java
+++ b/java/jpf-regression/ExSymExeSimple_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static class Node {
@@ -40,10 +41,10 @@ public class Main {
     }
   }
   public static void main(String[] args) {
-
+    int arg = Verifier.nondetInt();
     Main inst = new Main();
     Node n = new Node();
-    n.test(args.length, args.length);
+    n.test(arg, arg);
     // Debug.printPC("PC: ");
     System.out.println("*****************");
   }

--- a/java/jpf-regression/ExSymExeSimple_true/Main.java
+++ b/java/jpf-regression/ExSymExeSimple_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   static class Node {
@@ -40,10 +41,10 @@ public class Main {
     }
   }
   public static void main(String[] args) {
-
+    int arg = Verifier.nondetInt();
     Main inst = new Main();
     Node n = new Node();
-    n.test(args.length, args.length + 1);
+    n.test(arg, arg + 1);
     // Debug.printPC("PC: ");
     System.out.println("*****************");
   }

--- a/java/jpf-regression/ExSymExeSuzette_false/Main.java
+++ b/java/jpf-regression/ExSymExeSuzette_false/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   public void test(int x, int y) {
@@ -68,7 +69,7 @@ public class Main {
 
     Main ex = new Main();
 
-    ex.test(args.length, args.length);
+    ex.test(Verifier.nondetInt(), Verifier.nondetInt());
     // test(0,0);
   }
 }

--- a/java/jpf-regression/ExSymExeSuzette_true/Main.java
+++ b/java/jpf-regression/ExSymExeSuzette_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   public void test(int x, int y) {
@@ -66,7 +67,10 @@ public class Main {
 
     Main ex = new Main();
 
-    ex.test(args.length > 10 ? 0 : args.length, 0);
+    int arg = Verifier.nondetInt();
+    if (arg < 0 || arg > 10)
+      return;
+    ex.test(arg, 0);
     // test(0,0);
   }
 }

--- a/java/jpf-regression/ExSymExeSwitch_false/Main.java
+++ b/java/jpf-regression/ExSymExeSwitch_false/Main.java
@@ -24,13 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x =
-        args.length; /* we want to specify in an annotation that this param
-                        should be symbolic */
+    int x = Verifier.nondetInt();
 
     test(x);
   }

--- a/java/jpf-regression/ExSymExeSwitch_true/Main.java
+++ b/java/jpf-regression/ExSymExeSwitch_true/Main.java
@@ -24,15 +24,14 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
 
   public static void main(String[] args) {
-    int x =
-        args.length > 0 ? -args.length
-                        : args.length; /* we want to specify in an annotation
-                                          that this param should be symbolic */
-
+    int x = Verifier.nondetInt();
+    if (x > 0)
+      return;
     test(x);
   }
   /* we want to let the user specify that this method should be symbolic */

--- a/java/jpf-regression/ExSymExeTestAssignments_false/Main.java
+++ b/java/jpf-regression/ExSymExeTestAssignments_false/Main.java
@@ -24,12 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   int field;
 
   public static void main(String[] args) {
-    int x = args.length;
+    int x = Verifier.nondetInt();
     test(x);
   }
 

--- a/java/jpf-regression/ExSymExeTestAssignments_true/Main.java
+++ b/java/jpf-regression/ExSymExeTestAssignments_true/Main.java
@@ -24,12 +24,15 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   int field;
 
   public static void main(String[] args) {
-    int x = args.length;
+    int x = Verifier.nondetInt();
+    if (x < 0)
+      return;
     test(x);
   }
 

--- a/java/jpf-regression/ExSymExeTestClassFields_false/Main.java
+++ b/java/jpf-regression/ExSymExeTestClassFields_false/Main.java
@@ -24,13 +24,16 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   //@Symbolic("true")
   static int field;
   int field2;
 
-  public static void main(String[] args) { (new Main()).test(args.length); }
+  public static void main(String[] args) {
+    (new Main()).test(Verifier.nondetInt());
+  }
   public void test(int arg) {
     if (field == 0 && field2 == 0 && arg == 3) {
       assert false;

--- a/java/jpf-regression/ExSymExeTestClassFields_true/Main.java
+++ b/java/jpf-regression/ExSymExeTestClassFields_true/Main.java
@@ -24,6 +24,7 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   //@Symbolic("true")
@@ -31,7 +32,7 @@ public class Main {
   int field2;
 
   public static void main(String[] args) {
-    if (args.length == 2)
+    if (Verifier.nondetInt() == 2)
       (new Main()).test();
   }
   public void test() {

--- a/java/jpf-regression/ExSymExe_false/Main.java
+++ b/java/jpf-regression/ExSymExe_false/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
     Main inst = new Main();
     field = 9;
     inst.test(2, 1);

--- a/java/jpf-regression/ExSymExe_true/Main.java
+++ b/java/jpf-regression/ExSymExe_true/Main.java
@@ -29,9 +29,8 @@ public class Main {
   static int field;
 
   public static void main(String[] args) {
-    int x =
-        3; /* we want to specify in an annotation that this param should be
-              symbolic */
+    int x = 3; /* we want to specify in an annotation that this param should be
+                  symbolic */
     Main inst = new Main();
     field = 9;
     inst.test(0, 1);

--- a/java/jpf-regression/TestLazy_false/Main.java
+++ b/java/jpf-regression/TestLazy_false/Main.java
@@ -24,9 +24,12 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
-  public static void main(String[] args) { (new Main()).f(args.length, 0); }
+  public static void main(String[] args) {
+    (new Main()).f(Verifier.nondetInt(), 0);
+  }
 
   public void f(int a, int b) {
     Integer i = null;

--- a/java/jpf-regression/TestLazy_true/Main.java
+++ b/java/jpf-regression/TestLazy_true/Main.java
@@ -24,11 +24,13 @@
  */
 
 // package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
 
 public class Main {
   public static void main(String[] args) {
-    if (args.length == 0)
-      (new Main()).f(0, args.length);
+    int arg = Verifier.nondetInt();
+    if (arg == 0)
+      (new Main()).f(0, arg);
   }
 
   public void f(int a, int b) {


### PR DESCRIPTION

- [n/a] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [n/a] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [n/a] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [n/a] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [n/a] intended property matches the corresponding `.prp` file
- [n/a] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [n/a] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [n/a] original sources present
- [n/a] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [n/a] preprocessed files generated with correct architecture
- [n/a] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
