### PR TITLE
change transpose-u_true-unreach-call assertion

### DIFF
--- a/c/array-multidimensional/transpose-u_true-unreach-call.c
+++ b/c/array-multidimensional/transpose-u_true-unreach-call.c
@@ -33,7 +33,7 @@ int main()
 
 	for ( i = 0 ; i < n ; i++ ){
           for ( j = 0 ; j < n ; j++ ){
-                __VERIFIER_assert(C[i][j] == A[i][j]);
+                __VERIFIER_assert(C[j][i] == A[i][j]);
           }
     }
 return 0;

--- a/c/array-multidimensional/transpose-u_true-unreach-call.i
+++ b/c/array-multidimensional/transpose-u_true-unreach-call.i
@@ -33,7 +33,7 @@ int main()
 
 	for ( i = 0 ; i < n ; i++ ){
           for ( j = 0 ; j < n ; j++ ){
-                __VERIFIER_assert(C[i][j] == A[i][j]);
+                __VERIFIER_assert(C[j][i] == A[i][j]);
           }
     }
 return 0;


### PR DESCRIPTION
<!--
  There is change in assertion of   "transpose-u_true-unreach-call" .
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
