### PR TITLE
Turn property file into a link to the definitive version of the content

### DIFF
--- a/java/ReachSafety.prp
+++ b/java/ReachSafety.prp
@@ -1,1 +1,1 @@
-CHECK( init(Main.main()), LTL(G assert) )
+properties/assert.prp


### PR DESCRIPTION
To have this similar to the C track, let's keep a link to the definitive content.
Perhaps we will later delete this, but currently we still need this file (it's references from the benchmark definitions).