### PR TITLE
Fix overflow bugs introduced by using Verifier

### DIFF
--- a/java/jpf-regression/ExSymExe12_true/Main.java
+++ b/java/jpf-regression/ExSymExe12_true/Main.java
@@ -36,7 +36,7 @@ public class Main {
 
     Main inst = new Main();
     field = 9;
-    int arg = Verifier.nondetInt();
+    int arg = Verifier.nondetShort();
     if (arg < 0)
       return;
     inst.test(x, arg, field2);

--- a/java/jpf-regression/ExSymExe14_true/Main.java
+++ b/java/jpf-regression/ExSymExe14_true/Main.java
@@ -31,7 +31,7 @@ public class Main {
   static int field2;
 
   public static void main(String[] args) {
-    int arg = Verifier.nondetInt();
+    int arg = Verifier.nondetShort();
     if (arg < 0)
       return;
     int x = arg;

--- a/java/jpf-regression/ExSymExe15_true/Main.java
+++ b/java/jpf-regression/ExSymExe15_true/Main.java
@@ -36,7 +36,7 @@ public class Main {
                   symbolic */
 
     Main inst = new Main();
-    field = Verifier.nondetInt();
+    field = Verifier.nondetShort();
     if (field < 0)
       return;
     inst.test(x, field, field2);

--- a/java/jpf-regression/ExSymExeF2L_false/Main.java
+++ b/java/jpf-regression/ExSymExeF2L_false/Main.java
@@ -30,7 +30,7 @@ public class Main {
 
   public static void main(String[] args) {
     float x = Verifier.nondetFloat();
-    if (x < 0.0f) {
+    if (x >= 0.0f) {
       Main inst = new Main();
       inst.test(x);
     }

--- a/java/jpf-regression/ExSymExeI2D_true/Main.java
+++ b/java/jpf-regression/ExSymExeI2D_true/Main.java
@@ -30,7 +30,7 @@ public class Main {
 
   public static void main(String[] args) {
     int x = Verifier.nondetInt();
-    x = x > 0 ? x % 10 : -x % 10;
+    x = x > 0 ? x % 10 : -(x % 10);
 
     Main inst = new Main();
     inst.test(x);

--- a/java/jpf-regression/ExSymExeLongBytecodes_true/Main.java
+++ b/java/jpf-regression/ExSymExeLongBytecodes_true/Main.java
@@ -29,7 +29,7 @@ import org.sosy_lab.sv_benchmarks.Verifier;
 public class Main {
 
   public static void main(String[] args) {
-    long x = Verifier.nondetLong();
+    long x = Verifier.nondetInt();
     x = x > 0 ? -x : x;
     long y = 5;
     Main inst = new Main();

--- a/java/jpf-regression/ExSymExeSimple_true/Main.java
+++ b/java/jpf-regression/ExSymExeSimple_true/Main.java
@@ -42,6 +42,8 @@ public class Main {
   }
   public static void main(String[] args) {
     int arg = Verifier.nondetInt();
+    if (arg >= Integer.MAX_VALUE)
+      return;
     Main inst = new Main();
     Node n = new Node();
     n.test(arg, arg + 1);


### PR DESCRIPTION
When adapting these benchmarks to use Verifier (a3848b97) I inadvertently introduced some overflow bugs, which would change the expected outcome. These are fixed here.
