### PR TITLE
Replace memcpy with memmove for overlapping memory

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
@@ -3647,6 +3647,7 @@ __inline static void list_splice_tail(struct list_head *list , struct list_head 
 extern void __bad_percpu_size(void) ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
@@ -8882,7 +8883,7 @@ static struct ipmi_smi_msg *smi_from_recv_msg(ipmi_smi_t intf , struct ipmi_recv
   } else {
 
   }
-  memcpy((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
+  memmove((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
   smi_msg->data_size = (int )recv_msg->msg.data_len;
   smi_msg->msgid = (long )((int )seq << 26) | (seqid & 67108863L);
   return (smi_msg);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.c
@@ -10691,6 +10691,7 @@ bool ldv_queue_delayed_work_on_65(int ldv_func_arg1 , struct workqueue_struct *l
 }
 __inline static long ldv__builtin_expect(long exp , long c ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern void *kmemdup(void const   * , size_t  , gfp_t  ) ;
 bool ldv_queue_work_on_75(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
@@ -41143,7 +41144,7 @@ static void hdmi_i2c_read(struct oaktrail_hdmi_dev *hdmi_dev )
   goto ldv_41596;
   ldv_41595: 
   temp = readl((void const volatile   *)hdmi_dev->regs + (unsigned long )((i + 1152) * 4));
-  memcpy((void *)buf + (unsigned long )(i * 4 + offset), (void const   *)(& temp),
+  memmove((void *)buf + (unsigned long )(i * 4 + offset), (void const   *)(& temp),
            4UL);
   i = i + 1;
   ldv_41596: ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--md-cluster.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--md-cluster.ko-entry_point_false-unreach-call.cil.out.c
@@ -4216,6 +4216,7 @@ __inline static int list_empty(struct list_head  const  *head )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern size_t strlen(char const   * ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
@@ -5080,7 +5081,7 @@ static int __sendmsg(struct md_cluster_info *cinfo , struct cluster_msg *cmsg )
   } else {
 
   }
-  memcpy((void *)(cinfo->message_lockres)->lksb.sb_lvbptr, (void const   *)cmsg,
+  memmove((void *)(cinfo->message_lockres)->lksb.sb_lvbptr, (void const   *)cmsg,
            48UL);
   error = dlm_lock_sync(cinfo->message_lockres, 1);
   if (error != 0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
@@ -12355,6 +12355,7 @@ bool ldv_queue_delayed_work_on_29(int ldv_func_arg1 , struct workqueue_struct *l
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 bool ldv_queue_work_on_39(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
                           struct work_struct *ldv_func_arg3 ) ;
 bool ldv_queue_work_on_41(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
@@ -14290,7 +14291,7 @@ static int cx25840_ir_rx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   mutex_lock_nested(& ir_state->rx_params_lock, 0U);
-  memcpy((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
   mutex_unlock(& ir_state->rx_params_lock);
   return (0);
 }
@@ -14445,7 +14446,7 @@ static int cx25840_ir_tx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   mutex_lock_nested(& ir_state->tx_params_lock, 0U);
-  memcpy((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
   mutex_unlock(& ir_state->tx_params_lock);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point_false-unreach-call.cil.out.c
@@ -5976,6 +5976,7 @@ extern unsigned long __per_cpu_offset[8192U] ;
 extern unsigned long this_cpu_off ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern size_t strlen(char const   * ) ;
 extern int strcmp(char const   * , char const   * ) ;
@@ -11822,7 +11823,7 @@ static void team_setup_by_port(struct net_device *dev , struct net_device *port_
   dev->hard_header_len = port_dev->hard_header_len;
   dev->addr_len = port_dev->addr_len;
   dev->mtu = port_dev->mtu;
-  memcpy((void *)(& dev->broadcast), (void const   *)(& port_dev->broadcast), (size_t )port_dev->addr_len);
+  memmove((void *)(& dev->broadcast), (void const   *)(& port_dev->broadcast), (size_t )port_dev->addr_len);
   eth_hw_addr_inherit(dev, port_dev);
   return;
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
@@ -8313,6 +8313,7 @@ __inline static struct task_struct *get_current(void)
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned long arch_local_save_flags(void) 
 { 
@@ -9114,7 +9115,7 @@ __inline static void SET_IEEE80211_PERM_ADDR(struct ieee80211_hw *hw , u8 *addr 
 
 
   {
-  memcpy((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
+  memmove((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
   return;
 }
 }
@@ -24242,7 +24243,6 @@ bool ldv_queue_delayed_work_on_83(int ldv_func_arg1 , struct workqueue_struct *l
 }
 }
 __inline static long ldv__builtin_expect(long exp , long c ) ;
-extern void *memmove(void * , void const   * , size_t  ) ;
 bool ldv_queue_work_on_93(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
                           struct work_struct *ldv_func_arg3 ) ;
 bool ldv_queue_work_on_95(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
@@ -13963,7 +13963,7 @@ struct cmd_ctrl_node *__lbs_cmd_async(struct lbs_private *priv , uint16_t comman
   }
   cmdnode->callback = callback;
   cmdnode->callback_arg = callback_arg;
-  memcpy((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
+  memmove((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
   (cmdnode->cmdbuf)->command = command;
   (cmdnode->cmdbuf)->size = (unsigned short )in_cmd_size;
   (cmdnode->cmdbuf)->result = 0U;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--gadget--libcomposite.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--gadget--libcomposite.ko-entry_point_false-unreach-call.cil.out.c
@@ -2853,6 +2853,7 @@ struct usb_os_desc_ext_prop_attribute {
    ssize_t (*store)(struct usb_os_desc_ext_prop * , char const   * , size_t  ) ;
 };
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
@@ -11547,7 +11548,7 @@ static ssize_t interf_grp_compatible_id_show(struct usb_os_desc *desc , char *pa
 
 
   {
-  memcpy((void *)page, (void const   *)desc->ext_compat_id, 8UL);
+  memmove((void *)page, (void const   *)desc->ext_compat_id, 8UL);
   return (8L);
 }
 }
@@ -11587,7 +11588,7 @@ static ssize_t interf_grp_sub_compatible_id_show(struct usb_os_desc *desc , char
 
 
   {
-  memcpy((void *)page, (void const   *)desc->ext_compat_id + 8U, 8UL);
+  memmove((void *)page, (void const   *)desc->ext_compat_id + 8U, 8UL);
   return (8L);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
@@ -3639,6 +3639,7 @@ __inline static void list_splice_tail(struct list_head *list , struct list_head 
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
@@ -8939,7 +8940,7 @@ static struct ipmi_smi_msg *smi_from_recv_msg(ipmi_smi_t intf , struct ipmi_recv
   } else {
 
   }
-  memcpy((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
+  memmove((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
   smi_msg->data_size = (int )recv_msg->msg.data_len;
   smi_msg->msgid = (long )((int )seq << 26) | (seqid & 67108863L);
   return (smi_msg);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.c
@@ -6806,7 +6806,7 @@ static void copy_config_rom(__be32 *dest , __be32 const   *src , size_t length )
 
   {
   size = length * 4UL;
-  memcpy((void *)dest, (void const   *)src, size);
+  memmove((void *)dest, (void const   *)src, size);
   if (size <= 1023UL) {
     memset((void *)(dest + length), 0, 1024UL - size);
   } else {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--amd--amdkfd--amdkfd.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--amd--amdkfd--amdkfd.ko-entry_point_true-unreach-call.cil.out.c
@@ -5260,6 +5260,7 @@ union TCP_WATCH_CNTL_BITS {
 enum hrtimer_restart;
 extern int printk(char const   *  , ...) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int mutex_trylock(struct mutex * ) ;
 int ldv_mutex_trylock_13(struct mutex *ldv_func_arg1 ) ;
 extern void mutex_unlock(struct mutex * ) ;
@@ -9781,7 +9782,7 @@ static int kfd_topology_get_crat_acpi(void *crat_image , size_t *size )
 
   }
   if (*size >= (size_t )crat_table->length && (unsigned long )crat_image != (unsigned long )((void *)0)) {
-    memcpy(crat_image, (void const   *)crat_table, (size_t )crat_table->length);
+    memmove(crat_image, (void const   *)crat_table, (size_t )crat_table->length);
   } else {
 
   }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
@@ -4315,6 +4315,7 @@ __inline static void INIT_LIST_HEAD(struct list_head *list )
 }
 }
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 __inline static u64 div_u64_rem(u64 dividend , u32 divisor , u32 *remainder ) 
 { 
 
@@ -14730,7 +14731,7 @@ static int cx25840_ir_rx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   ldv_mutex_lock_153(& ir_state->rx_params_lock);
-  memcpy((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
   ldv_mutex_unlock_154(& ir_state->rx_params_lock);
   return (0);
 }
@@ -14885,7 +14886,7 @@ static int cx25840_ir_tx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   ldv_mutex_lock_159(& ir_state->tx_params_lock);
-  memcpy((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
   ldv_mutex_unlock_160(& ir_state->tx_params_lock);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
@@ -7842,7 +7842,7 @@ static int opera1_xilinx_load_firmware(struct usb_device *dev , char const   *fi
       reset = 0U;
       fpga_command = 0U;
       memcpy_guard((void *)p, (void const   *)fw->data, fw->size);
-      memcpy((void *)p, (void const   *)fw->data, fw->size);
+      memmove((void *)p, (void const   *)fw->data, fw->size);
       opera1_xilinx_rw(dev, 188, 170, & fpga_command, 1, 1);
       i = 0;
       goto ldv_48410;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
@@ -8305,6 +8305,7 @@ __inline static int list_empty(struct list_head  const  *head )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 __inline static unsigned long arch_local_save_flags(void) 
@@ -9151,7 +9152,7 @@ __inline static void SET_IEEE80211_PERM_ADDR(struct ieee80211_hw *hw , u8 *addr 
 
 
   {
-  memcpy((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
+  memmove((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
   return;
 }
 }
@@ -25035,7 +25036,6 @@ void ldv_mutex_unlock_208(struct mutex *ldv_func_arg1 )
 }
 }
 __inline static long ldv__builtin_expect(long exp , long c ) ;
-extern void *memmove(void * , void const   * , size_t  ) ;
 int ldv_mutex_trylock_241(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_unlock_239(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_unlock_242(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
@@ -14054,7 +14054,7 @@ struct cmd_ctrl_node *__lbs_cmd_async(struct lbs_private *priv , uint16_t comman
   }
   cmdnode->callback = callback;
   cmdnode->callback_arg = callback_arg;
-  memcpy((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
+  memmove((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
   (cmdnode->cmdbuf)->command = command;
   (cmdnode->cmdbuf)->size = (unsigned short )in_cmd_size;
   (cmdnode->cmdbuf)->result = 0U;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point_true-unreach-call.cil.out.c
@@ -9063,7 +9063,7 @@ struct iw_statistics *prism54_get_wireless_stats(struct net_device *ndev )
   if (tmp___0 != 0) {
     memcpy_guard((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
                  32UL);
-    memcpy((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
+    memmove((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
              32UL);
     priv->local_iwstatistics.qual.updated = 0U;
     ldv_mutex_unlock_108(& priv->stats_lock);
@@ -13668,7 +13668,7 @@ struct net_device *islpci_setup(struct pci_dev *pdev )
   ndev->ethtool_ops = & islpci_ethtool_ops;
   ndev->addr_len = 6U;
   memcpy_guard((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
-  memcpy((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
+  memmove((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
   ndev->watchdog_timeo = 500;
   tmp___0 = netdev_priv((struct net_device  const  *)ndev);
   priv = (islpci_private *)tmp___0;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--hpsa.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--hpsa.ko-entry_point_true-unreach-call.cil.out.c
@@ -5278,6 +5278,7 @@ __inline static void list_add_tail(struct list_head *new , struct list_head *hea
 extern void list_del(struct list_head * ) ;
 extern unsigned long __phys_addr(unsigned long  ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
@@ -7454,7 +7455,7 @@ static ssize_t lunid_show(struct device *dev , struct device_attribute *attr , c
   } else {
 
   }
-  memcpy((void *)(& lunid), (void const   *)(& hdev->scsi3addr), 8UL);
+  memmove((void *)(& lunid), (void const   *)(& hdev->scsi3addr), 8UL);
   spin_unlock_irqrestore(& h->lock, flags);
   tmp___0 = snprintf(buf, 20UL, "0x%02x%02x%02x%02x%02x%02x%02x%02x\n", (int )lunid[0],
                      (int )lunid[1], (int )lunid[2], (int )lunid[3], (int )lunid[4],
@@ -7487,7 +7488,7 @@ static ssize_t unique_id_show(struct device *dev , struct device_attribute *attr
   } else {
 
   }
-  memcpy((void *)(& sn), (void const   *)(& hdev->device_id), 16UL);
+  memmove((void *)(& sn), (void const   *)(& hdev->device_id), 16UL);
   spin_unlock_irqrestore(& h->lock, flags);
   tmp___0 = snprintf(buf, 34UL, "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n",
                      (int )sn[0], (int )sn[1], (int )sn[2], (int )sn[3], (int )sn[4],

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--gadget--libcomposite.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--gadget--libcomposite.ko-entry_point_true-unreach-call.cil.out.c
@@ -2848,6 +2848,7 @@ struct usb_os_desc_ext_prop_attribute {
 };
 enum hrtimer_restart;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
 extern int mutex_trylock(struct mutex * ) ;
 int ldv_mutex_trylock_8(struct mutex *ldv_func_arg1 ) ;
@@ -11924,7 +11925,7 @@ static ssize_t interf_grp_compatible_id_show(struct usb_os_desc *desc , char *pa
 
 
   {
-  memcpy((void *)page, (void const   *)desc->ext_compat_id, 8UL);
+  memmove((void *)page, (void const   *)desc->ext_compat_id, 8UL);
   return (8L);
 }
 }
@@ -11964,7 +11965,7 @@ static ssize_t interf_grp_sub_compatible_id_show(struct usb_os_desc *desc , char
 
 
   {
-  memcpy((void *)page, (void const   *)desc->ext_compat_id + 8U, 8UL);
+  memmove((void *)page, (void const   *)desc->ext_compat_id + 8U, 8UL);
   return (8L);
 }
 }
@@ -11989,7 +11990,7 @@ static ssize_t interf_grp_sub_compatible_id_store(struct usb_os_desc *desc , cha
   } else {
 
   }
-  memcpy((void *)desc->ext_compat_id + 8U, (void const   *)page, (size_t )l);
+  memmove((void *)desc->ext_compat_id + 8U, (void const   *)page, (size_t )l);
   if ((unsigned long )desc->opts_mutex != (unsigned long )((struct mutex *)0)) {
     ldv_mutex_unlock_125(desc->opts_mutex);
   } else {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
@@ -14264,7 +14264,7 @@ static void h5_slip_one_byte(struct sk_buff *skb , u8 c )
   goto ldv_50458;
   case 219: 
   tmp___0 = skb_put(skb, 2U);
-  memcpy((void *)tmp___0, (void const   *)(& esc_esc), 2UL);
+  memmove((void *)tmp___0, (void const   *)(& esc_esc), 2UL);
   goto ldv_50458;
   default: 
   tmp___1 = skb_put(skb, 1U);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point_true-unreach-call.cil.out.c
@@ -3570,6 +3570,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  );
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -8821,7 +8822,7 @@ static struct ipmi_smi_msg *smi_from_recv_msg(ipmi_smi_t intf , struct ipmi_recv
   } else {
 
   }
-  memcpy((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
+  memmove((void *)(& smi_msg->data), (void const   *)recv_msg->msg.data, (size_t )recv_msg->msg.data_len);
   smi_msg->data_size = (int )recv_msg->msg.data_len;
   smi_msg->msgid = (long )((int )seq << 26) | (seqid & 67108863L);
   return (smi_msg);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--i2c--cx25840--cx25840.ko-entry_point_true-unreach-call.cil.out.c
@@ -4287,6 +4287,7 @@ extern int printk(char const   *  , ...) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  );
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -14333,7 +14334,7 @@ static int cx25840_ir_rx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   mutex_lock_nested(& ir_state->rx_params_lock, 0U);
-  memcpy((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->rx_params), 44UL);
   mutex_unlock(& ir_state->rx_params_lock);
   return (0);
 }
@@ -14486,7 +14487,7 @@ static int cx25840_ir_tx_g_parameters(struct v4l2_subdev *sd , struct v4l2_subde
 
   }
   mutex_lock_nested(& ir_state->tx_params_lock, 0U);
-  memcpy((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
+  memmove((void *)p, (void const   *)(& ir_state->tx_params), 44UL);
   mutex_unlock(& ir_state->tx_params_lock);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
@@ -24870,7 +24870,7 @@ static int xgbe_dcb_ieee_setpfc(struct net_device *netdev , struct ieee_pfc *pfc
   } else {
 
   }
-  memcpy((void *)pdata->pfc, (void const   *)pfc, 136UL);
+  memmove((void *)pdata->pfc, (void const   *)pfc, 136UL);
   (*(pdata->hw_if.config_dcb_pfc))(pdata);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--brocade--bna--bna.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--brocade--bna--bna.ko-entry_point_true-unreach-call.cil.out.c
@@ -8738,6 +8738,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -33611,7 +33612,7 @@ int bfa_nw_ioc_debug_fwsave(struct bfa_ioc *ioc , void *trcdata , int *trclen )
   } else {
 
   }
-  memcpy(trcdata, (void const   *)ioc->dbg_fwsave, (size_t )tlen);
+  memmove(trcdata, (void const   *)ioc->dbg_fwsave, (size_t )tlen);
   *trclen = tlen;
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point_true-unreach-call.cil.out.c
@@ -7203,6 +7203,7 @@ extern int printk(char const   *  , ...) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -15697,10 +15698,10 @@ static int fm10k_sw_init(struct fm10k_intfc *interface , struct pci_device_id  c
   hw->revision_id = pdev->revision;
   hw->subsystem_vendor_id = pdev->subsystem_vendor;
   hw->subsystem_device_id = pdev->subsystem_device;
-  memcpy((void *)(& hw->mac.ops), (void const   *)fi->mac_ops, 176UL);
+  memmove((void *)(& hw->mac.ops), (void const   *)fi->mac_ops, 176UL);
   hw->mac.type = fi->mac;
   if ((unsigned long )fi->iov_ops != (unsigned long )((struct fm10k_iov_ops */* const  */)0)) {
-    memcpy((void *)(& hw->iov.ops), (void const   *)fi->iov_ops, 72UL);
+    memmove((void *)(& hw->iov.ops), (void const   *)fi->iov_ops, 72UL);
   } else {
 
   }
@@ -17809,7 +17810,6 @@ __inline static void list_add_tail(struct list_head *new , struct list_head *hea
 }
 }
 extern void list_del(struct list_head * ) ;
-extern void *memmove(void * , void const   * , size_t  ) ;
 __inline static void *ERR_PTR(long error ) ;
 bool ldv_queue_work_on_192(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
                            struct work_struct *ldv_func_arg3 ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point_true-unreach-call.cil.out.c
@@ -6611,6 +6611,7 @@ void *ldv_err_ptr(long error ) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -10328,7 +10329,7 @@ static void rtl8169_update_counters(struct net_device *dev )
   writel(cmd | 8U, (void volatile   *)ioaddr + 16U);
   tmp___2 = rtl_udelay_loop_wait_low(tp, & rtl_counters_cond, 10U, 1000);
   if ((int )tmp___2) {
-    memcpy((void *)(& tp->counters), (void const   *)counters, 64UL);
+    memmove((void *)(& tp->counters), (void const   *)counters, 64UL);
   } else {
 
   }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.c
@@ -6633,6 +6633,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -8306,7 +8307,7 @@ static int get_registers(struct r8152 *tp , u16 value , u16 index , u16 size , v
   tmp___0 = __create_pipe(tp->udev, 0U);
   ret = usb_control_msg(tp->udev, tmp___0 | 2147483776U, 5, 192, (int )value, (int )index,
                         tmp, (int )size, 500);
-  memcpy(data, (void const   *)tmp, (size_t )size);
+  memmove(data, (void const   *)tmp, (size_t )size);
   kfree((void const   *)tmp);
   return (ret);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.c
@@ -8260,6 +8260,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -9117,7 +9118,7 @@ __inline static void SET_IEEE80211_PERM_ADDR(struct ieee80211_hw *hw , u8 *addr 
 
 
   {
-  memcpy((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
+  memmove((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, 6UL);
   return;
 }
 }
@@ -24840,7 +24841,6 @@ struct sk_buff *ldv_skb_clone_243(struct sk_buff *ldv_func_arg1 , gfp_t flags )
 }
 }
 __inline static long ldv__builtin_expect(long exp , long c ) ;
-extern void *memmove(void * , void const   * , size_t  ) ;
 bool ldv_queue_work_on_263(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,
                            struct work_struct *ldv_func_arg3 ) ;
 bool ldv_queue_work_on_265(int ldv_func_arg1 , struct workqueue_struct *ldv_func_arg2 ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.c
@@ -14068,7 +14068,7 @@ struct cmd_ctrl_node *__lbs_cmd_async(struct lbs_private *priv , uint16_t comman
   }
   cmdnode->callback = callback;
   cmdnode->callback_arg = callback_arg;
-  memcpy((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
+  memmove((void *)cmdnode->cmdbuf, (void const   *)in_cmd, (size_t )in_cmd_size);
   (cmdnode->cmdbuf)->command = command;
   (cmdnode->cmdbuf)->size = (unsigned short )in_cmd_size;
   (cmdnode->cmdbuf)->result = 0U;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point_true-unreach-call.cil.out.c
@@ -9139,7 +9139,7 @@ struct iw_statistics *prism54_get_wireless_stats(struct net_device *ndev )
   if (tmp___0 != 0) {
     memcpy_guard((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
              32UL);
-    memcpy((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
+    memmove((void *)(& priv->iwstatistics), (void const   *)(& priv->local_iwstatistics),
              32UL);
     priv->local_iwstatistics.qual.updated = 0U;
     mutex_unlock(& priv->stats_lock);
@@ -13583,7 +13583,7 @@ struct net_device *islpci_setup(struct pci_dev *pdev )
   ndev->ethtool_ops = & islpci_ethtool_ops;
   ndev->addr_len = 6U;
   memcpy_guard((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
-  memcpy((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
+  memmove((void *)ndev->dev_addr, (void const   *)(& dummy_mac), 6UL);
   ndev->watchdog_timeo = 500;
   tmp___0 = netdev_priv((struct net_device  const  *)ndev);
   priv = (islpci_private *)tmp___0;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point_true-unreach-call.cil.out.c
@@ -5951,6 +5951,7 @@ extern int sscanf(char const   * , char const   *  , ...) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -6471,7 +6472,7 @@ static ssize_t pcmcia_store_new_id(struct device_driver *driver , char const   *
   dynid->id.func_id = func_id;
   dynid->id.function = function;
   dynid->id.device_no = device_no;
-  memcpy((void *)(& dynid->id.prod_id_hash), (void const   *)(& prod_id_hash), 16UL);
+  memmove((void *)(& dynid->id.prod_id_hash), (void const   *)(& prod_id_hash), 16UL);
   mutex_lock_nested(& pdrv->dynids.lock, 0U);
   list_add_tail(& dynid->node, & pdrv->dynids.list);
   mutex_unlock(& pdrv->dynids.lock);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point_true-unreach-call.cil.out.c
@@ -5327,6 +5327,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7483,7 +7484,7 @@ static ssize_t lunid_show(struct device *dev , struct device_attribute *attr , c
   } else {
 
   }
-  memcpy((void *)(& lunid), (void const   *)(& hdev->scsi3addr), 8UL);
+  memmove((void *)(& lunid), (void const   *)(& hdev->scsi3addr), 8UL);
   spin_unlock_irqrestore(& h->lock, flags);
   tmp = snprintf(buf, 20UL, "0x%02x%02x%02x%02x%02x%02x%02x%02x\n", (int )lunid[0],
                  (int )lunid[1], (int )lunid[2], (int )lunid[3], (int )lunid[4], (int )lunid[5],
@@ -7514,7 +7515,7 @@ static ssize_t unique_id_show(struct device *dev , struct device_attribute *attr
   } else {
 
   }
-  memcpy((void *)(& sn), (void const   *)(& hdev->device_id), 16UL);
+  memmove((void *)(& sn), (void const   *)(& hdev->device_id), 16UL);
   spin_unlock_irqrestore(& h->lock, flags);
   tmp = snprintf(buf, 34UL, "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n",
                  (int )sn[0], (int )sn[1], (int )sn[2], (int )sn[3], (int )sn[4],

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.c
@@ -6169,6 +6169,7 @@ __inline static struct task_struct *get_current(void)
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern char *strcat(char * , char const   * ) ;
 __inline static bool IS_ERR(void const   *ptr ) ;
@@ -11062,7 +11063,7 @@ static SLMP_INFO *alloc_dev(int adapter_num , int port_num , struct pci_dev *pde
     spinlock_check(& info->netlock);
     __raw_spin_lock_init(& info->netlock.__annonCompField18.rlock, "&(&info->netlock)->rlock",
                          & __key___2);
-    memcpy((void *)(& info->params), (void const   *)(& default_params), 48UL);
+    memmove((void *)(& info->params), (void const   *)(& default_params), 48UL);
     info->idle_mode = 0U;
     info->adapter_num = adapter_num;
     info->port_num = port_num;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.c
@@ -3952,6 +3952,7 @@ void ldv_spin_unlock(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -5070,7 +5071,7 @@ static ssize_t show_country_codes(struct device *dev , struct device_attribute *
   intf = (struct usb_interface *)__mptr + 0xffffffffffffffd0UL;
   tmp = usb_get_intfdata(intf);
   acm = (struct acm *)tmp;
-  memcpy((void *)buf, (void const   *)acm->country_codes, (size_t )acm->country_code_size);
+  memmove((void *)buf, (void const   *)acm->country_codes, (size_t )acm->country_code_size);
   return ((ssize_t )acm->country_code_size);
 }
 }


### PR DESCRIPTION
This commit replaces calls to `memcpy` with calls to `memmove` where the
source and destination addresses could potentially overlap, and adds an
extern declaration of `memmove` to those files if they did not already
have one. The overlaps were detected using the CBMC Path tool. Calling
`memcpy` on such overlapping memory areas is undefined behaviour, so
CBMC returns a counterexample on benchmarks that are expected to return
true.

This commit fixes the same issues that 55d4083f does for more source
files, but also correctly includes extern declarations of memmove as
introduced in the bugfix 1280ba1f.