### PR TITLE
Memsafety fixes

### DIFF
--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -1,3 +1,4 @@
+loops/*_false-valid-deref*.c
 loop-acceleration/*_false-valid-deref*.i
 ntdrivers/*_false-valid-deref*.i.cil.c
 ntdrivers-simplified/*_true-valid-memsafety*.cil.c

--- a/c/loops/invert_string_false-unreach-call_true-termination.i
+++ b/c/loops/invert_string_false-unreach-call_true-termination.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -11,6 +12,7 @@ unsigned int __VERIFIER_nondet_uint();
 
 int main() {
     int MAX = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(MAX > 0);
     char str1[MAX], str2[MAX];
     int cont, i, j;
     cont = 0;

--- a/c/loops/invert_string_false-valid-deref.c
+++ b/c/loops/invert_string_false-valid-deref.c
@@ -1,5 +1,4 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-extern void __VERIFIER_assume(int);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -12,7 +11,6 @@ unsigned int __VERIFIER_nondet_uint();
 
 int main() {
     int MAX = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(MAX > 0);
     char str1[MAX], str2[MAX];
     int cont, i, j;
     cont = 0;


### PR DESCRIPTION
Fix an invalid dereference in a file (described in the commit message). Move the wrong version of this file into a new directory. When another phase of SV-COMP is here, we can move it back and add it into MemSafety category.