### PR TITLE
fix broken Java code from a61b71c2

### DIFF
--- a/java/jbmc-regression/iarith2/Main.java
+++ b/java/jbmc-regression/iarith2/Main.java
@@ -15,7 +15,7 @@ class Main {
     value <<= 2;
     value >>= 1;
     value = -value;
-    value >> >= 1;
+    value >>>= 1;
     return value;
   }
 
@@ -27,7 +27,7 @@ class Main {
     value <<= 2L;
     value >>= 1L;
     value = -value;
-    value >> >= 1L;
+    value >>>= 1L;
     return value;
   }
 


### PR DESCRIPTION
Somehow the source-code formatter that was used in that commit introduced syntax errors.