### PR TITLE
Fix incompatible assignment in busybox-1.22.0/stty*

### DIFF
--- a/c/busybox-1.22.0/stty_false-no-overflow.c
+++ b/c/busybox-1.22.0/stty_false-no-overflow.c
@@ -1405,7 +1405,7 @@ static void set_control_char_or_die(struct control_info *info, const char *arg, 
         }
         if(!(tmp_if_expr$9 == (_Bool)0))
         {
-          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const unsigned char *)arg;
           signed int set_control_char_or_die$$1$$2$$2$$__result;
 
           set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];

--- a/c/busybox-1.22.0/stty_false-no-overflow.i
+++ b/c/busybox-1.22.0/stty_false-no-overflow.i
@@ -3427,7 +3427,7 @@ static void set_control_char_or_die(struct control_info *info, const char *arg, 
         }
         if(!(tmp_if_expr$9 == (_Bool)0))
         {
-          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const unsigned char *)arg;
           signed int set_control_char_or_die$$1$$2$$2$$__result;
           set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];
           if(__s2_len > 0ul)

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1405,7 +1405,7 @@ static void set_control_char_or_die(struct control_info *info, const char *arg, 
         }
         if(!(tmp_if_expr$9 == (_Bool)0))
         {
-          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const unsigned char *)arg;
           signed int set_control_char_or_die$$1$$2$$2$$__result;
 
           set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3427,7 +3427,7 @@ static void set_control_char_or_die(struct control_info *info, const char *arg, 
         }
         if(!(tmp_if_expr$9 == (_Bool)0))
         {
-          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const unsigned char *)arg;
           signed int set_control_char_or_die$$1$$2$$2$$__result;
           set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];
           if(__s2_len > 0ul)


### PR DESCRIPTION
The variable "arg" is of type "const char*" anyway, so the existing cast was unnecessary.
Adding a cast to "const unsigned char*" is valid because all pointers can be converted to pointers to character types (C11 §6.3.2.3 (7)).
Subsequent reads from this pointer are also allowed (§6.5 (7)).

This fixes #675, which contains more explanation on why I think this is necessary.