### PR TITLE
Fix those assert bugs in nondet-array* benchmarks

### DIFF
--- a/c/pthread-nondet/nondet-array_false-unreach-call.c
+++ b/c/pthread-nondet/nondet-array_false-unreach-call.c
@@ -27,6 +27,6 @@ int main(int argc, char* argv[]) {
   for (i = 0; i < n; i++) {
     sum += a[i];
   }
-  assert(sum == SIZE - 1);
+  assert(sum == n);
   return 0;
 }

--- a/c/pthread-nondet/nondet-array_false-unreach-call.i
+++ b/c/pthread-nondet/nondet-array_false-unreach-call.i
@@ -692,6 +692,6 @@ int main(int argc, char* argv[]) {
   for (i = 0; i < n; i++) {
     sum += a[i];
   }
-  __VERIFIER_assert(sum == 10 - 1);
+  __VERIFIER_assert(sum == n);
   return 0;
 }

--- a/c/pthread-nondet/nondet-array_true-unreach-call.c
+++ b/c/pthread-nondet/nondet-array_true-unreach-call.c
@@ -26,6 +26,6 @@ int main(int argc, char* argv[]) {
   for (i = 0; i < n; i++) {
     sum += a[i];
   }
-  assert(sum < SIZE);
+  assert(sum <= n);
   return 0;
 }

--- a/c/pthread-nondet/nondet-array_true-unreach-call.i
+++ b/c/pthread-nondet/nondet-array_true-unreach-call.i
@@ -692,6 +692,6 @@ int main(int argc, char* argv[]) {
   for (i = 0; i < n; i++) {
     sum += a[i];
   }
-  __VERIFIER_assert(sum < 10);
+  __VERIFIER_assert(sum <= n);
   return 0;
 }


### PR DESCRIPTION
<!--
In the benchmarks nondet-array_false-unreach-call.i, the "__VERIFIER_assert(sum == 10 - 1);" statement should be "__VERIFIER_assert(sum == n);".
In the benchmark nondet-array_true-unreach-call.i, the "__VERIFIER_assert(sum < 10);" statement should be "__VERIFIER_assert(sum <= n);". Otherwise, the property should be false.
-->
