### PR TITLE
Use property from direct location, not via symlink

### DIFF
--- a/c/ConcurrencySafety.prp
+++ b/c/ConcurrencySafety.prp
@@ -1,1 +1,0 @@
-properties/unreach-call.prp

--- a/c/DefinedBehavior.prp
+++ b/c/DefinedBehavior.prp
@@ -1,1 +1,0 @@
-properties/def-behavior.prp

--- a/c/MemSafety-MemCleanup.prp
+++ b/c/MemSafety-MemCleanup.prp
@@ -1,1 +1,0 @@
-properties/valid-memcleanup.prp

--- a/c/MemSafety.prp
+++ b/c/MemSafety.prp
@@ -1,1 +1,0 @@
-properties/valid-memsafety.prp

--- a/c/NoOverflows.prp
+++ b/c/NoOverflows.prp
@@ -1,1 +1,0 @@
-properties/no-overflow.prp

--- a/c/ReachSafety.prp
+++ b/c/ReachSafety.prp
@@ -1,1 +1,0 @@
-properties/unreach-call.prp

--- a/c/Systems_BusyBox_MemSafety.prp
+++ b/c/Systems_BusyBox_MemSafety.prp
@@ -1,1 +1,0 @@
-properties/valid-memsafety.prp

--- a/c/Systems_BusyBox_NoOverflows.prp
+++ b/c/Systems_BusyBox_NoOverflows.prp
@@ -1,1 +1,0 @@
-properties/no-overflow.prp

--- a/c/Systems_DeviceDriversLinux64_ConcurrencySafety.prp
+++ b/c/Systems_DeviceDriversLinux64_ConcurrencySafety.prp
@@ -1,1 +1,0 @@
-properties/unreach-call.prp

--- a/c/Systems_DeviceDriversLinux64_ReachSafety.prp
+++ b/c/Systems_DeviceDriversLinux64_ReachSafety.prp
@@ -1,1 +1,0 @@
-properties/unreach-call.prp

--- a/c/Termination.prp
+++ b/c/Termination.prp
@@ -1,1 +1,0 @@
-properties/termination.prp


### PR DESCRIPTION
Clean-up the structure of the repository a bit.

The benchmark definitions were adjusted already by a sequence of commits
(https://github.com/sosy-lab/sv-comp/commit/c8defb51cb089e3640cf6eec9d974eb96978143b).