### PR TITLE
arrays: fix standard_partition benchmark

### DIFF
--- a/c/array-examples/standard_partition_false-unreach-call_ground.c
+++ b/c/array-examples/standard_partition_false-unreach-call_ground.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 100000
@@ -12,6 +13,7 @@ int main( ) {
   int cc[N];
   
   while( a < N ) {
+    aa[ a ] = __VERIFIER_nondet_int();
     if( aa[ a ] >= 0 ) {
       bb[ b ] = aa[ a ];
       b = b + 1;

--- a/c/array-examples/standard_partition_false-unreach-call_ground.i
+++ b/c/array-examples/standard_partition_false-unreach-call_ground.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int main( ) {
   int aa[100000];
@@ -8,6 +9,7 @@ int main( ) {
   int bb[100000];
   int cc[100000];
   while( a < 100000 ) {
+    aa[ a ] = __VERIFIER_nondet_int();
     if( aa[ a ] >= 0 ) {
       bb[ b ] = aa[ a ];
       b = b + 1;


### PR DESCRIPTION
This benchmark read values from uninitialized array on stack.

