### PR TITLE
lists: rename custom exit function to avoid collision with reserved identifier

### DIFF
--- a/c/list-ext-properties/list-ext_1_true-valid-memsafety.c
+++ b/c/list-ext-properties/list-ext_1_true-valid-memsafety.c
@@ -9,7 +9,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
   _EXIT: goto _EXIT;
 }
 
@@ -26,7 +26,7 @@ int main() {
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
 
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
 
   List t;
   List p = a;
@@ -35,7 +35,7 @@ int main() {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;
@@ -45,7 +45,7 @@ int main() {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/list-ext_1_true-valid-memsafety.i
+++ b/c/list-ext-properties/list-ext_1_true-valid-memsafety.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
   _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,14 +627,14 @@ int main() {
   int i = 0;
   int y = 0;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (i < 10 && __VERIFIER_nondet_int()) {
     i++;
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
@@ -642,7 +642,7 @@ int main() {
     y++;
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.c
+++ b/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.c
@@ -9,7 +9,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
   _EXIT: goto _EXIT;
 }
 
@@ -26,7 +26,7 @@ int main() {
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
 
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
 
   List t;
   List p = a;
@@ -35,7 +35,7 @@ int main() {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;
@@ -45,7 +45,7 @@ int main() {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.i
+++ b/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
   _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,14 +627,14 @@ int main() {
   int i = 0;
   int y = 0;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (i < 10 && __VERIFIER_nondet_int()) {
     i++;
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
@@ -642,7 +642,7 @@ int main() {
     y++;
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext-properties/list-ext_flag_1_true-valid-memsafety.c
+++ b/c/list-ext-properties/list-ext_flag_1_true-valid-memsafety.c
@@ -10,7 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <stdlib.h>
 /*  #include "assert.h" */
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -27,7 +27,7 @@ int main() {
    * with 1,2 depending on some flag
    */
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   
   int i = 0;
@@ -44,7 +44,7 @@ int main() {
 
     t = (List) malloc(sizeof(struct node));
     
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/list-ext_flag_1_true-valid-memsafety.i
+++ b/c/list-ext-properties/list-ext_flag_1_true-valid-memsafety.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,7 +627,7 @@ typedef struct node {
 int main() {
   List p, a, t;
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   int i = 0;
   while (i < 20 && __VERIFIER_nondet_int()) {
@@ -639,7 +639,7 @@ int main() {
       p->h = 2;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.c
+++ b/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.c
@@ -10,7 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <stdlib.h>
 /*  #include "assert.h" */
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -27,7 +27,7 @@ int main() {
    * with 1,2 depending on some flag
    */
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   
   int i = 0;
@@ -44,7 +44,7 @@ int main() {
 
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.i
+++ b/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,7 +627,7 @@ typedef struct node {
 int main() {
   List p, a, t;
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   int i = 0;
   while (i < 20 && __VERIFIER_nondet_int()) {
@@ -639,7 +639,7 @@ int main() {
       p->h = 2;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext-properties/simple-ext_1_true-valid-memsafety.c
+++ b/c/list-ext-properties/simple-ext_1_true-valid-memsafety.c
@@ -8,7 +8,7 @@ extern int __VERIFIER_nondet_int(void);
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -21,7 +21,7 @@ int main() {
   /* Build a list of the form 0->1->...->29->30 */
   List a = (List) malloc(sizeof(struct node));
 
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
 
   List t;
   List p = a;
@@ -32,7 +32,7 @@ int main() {
     p->h = i;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/simple-ext_1_true-valid-memsafety.i
+++ b/c/list-ext-properties/simple-ext_1_true-valid-memsafety.i
@@ -617,7 +617,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -626,14 +626,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   int i = 0;
   while (i < 30 && __VERIFIER_nondet_int()) {
     p->h = i;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     i++;

--- a/c/list-ext-properties/simple-ext_false-unreach-call_false-valid-memcleanup_true-termination.c
+++ b/c/list-ext-properties/simple-ext_false-unreach-call_false-valid-memcleanup_true-termination.c
@@ -8,7 +8,7 @@ extern int __VERIFIER_nondet_int(void);
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -21,7 +21,7 @@ int main() {
   /* Build a list of the form 0->1->...->29->30 */
   List a = (List) malloc(sizeof(struct node));
 
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
 
   List t;
   List p = a;
@@ -32,7 +32,7 @@ int main() {
     p->h = i;
     t = (List) malloc(sizeof(struct node));
 
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
 
     p->n = t;
     p = p->n;

--- a/c/list-ext-properties/simple-ext_false-unreach-call_false-valid-memcleanup_true-termination.i
+++ b/c/list-ext-properties/simple-ext_false-unreach-call_false-valid-memcleanup_true-termination.i
@@ -617,7 +617,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -626,14 +626,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   int i = 0;
   while (i < 30 && __VERIFIER_nondet_int()) {
     p->h = i;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     i++;

--- a/c/list-ext2-properties/list_and_tree_cnstr_false-unreach-call_false-termination.c
+++ b/c/list-ext2-properties/list_and_tree_cnstr_false-unreach-call_false-termination.c
@@ -16,7 +16,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -82,20 +82,20 @@ int main() {
 
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/list_and_tree_cnstr_false-unreach-call_false-termination.i
+++ b/c/list-ext2-properties/list_and_tree_cnstr_false-unreach-call_false-termination.i
@@ -526,7 +526,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -582,20 +582,20 @@ int main() {
     free(n);
     }
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/list_and_tree_cnstr_true-unreach-call_false-termination.c
+++ b/c/list-ext2-properties/list_and_tree_cnstr_true-unreach-call_false-termination.c
@@ -17,7 +17,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -83,20 +83,20 @@ int main() {
 
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/list_and_tree_cnstr_true-unreach-call_false-termination.i
+++ b/c/list-ext2-properties/list_and_tree_cnstr_true-unreach-call_false-termination.i
@@ -526,7 +526,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -582,20 +582,20 @@ int main() {
     free(n);
     }
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl_false-unreach-call.c
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl_false-unreach-call.c
@@ -88,7 +88,7 @@ void destroy_sl(struct sl *sl)
 	free(sl);
 }
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -100,14 +100,14 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->...->1->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   a->h = 2;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl_false-unreach-call.i
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl_false-unreach-call.i
@@ -574,7 +574,7 @@ void destroy_sl(struct sl *sl)
  }
  free(sl);
 }
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -583,14 +583,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   a->h = 2;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl_true-unreach-call.c
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl_true-unreach-call.c
@@ -15,7 +15,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -99,13 +99,13 @@ void destroy_sl(struct sl *sl)
 int main() {
   /* Build a list of the form 1->...->1->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl_true-unreach-call.i
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl_true-unreach-call.i
@@ -526,7 +526,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -583,13 +583,13 @@ void destroy_sl(struct sl *sl)
 }
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-ext2-properties/simple_search_value_false-unreach-call.c
+++ b/c/list-ext2-properties/simple_search_value_false-unreach-call.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->2->3->4... */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
 
@@ -31,7 +31,7 @@ int main() {
   while (counter < 10 || __VERIFIER_nondet_int()) {
     p->h = counter;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     counter++;

--- a/c/list-ext2-properties/simple_search_value_false-unreach-call.i
+++ b/c/list-ext2-properties/simple_search_value_false-unreach-call.i
@@ -526,7 +526,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -535,14 +535,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   int counter = 0;
   while (counter < 10 || __VERIFIER_nondet_int()) {
     p->h = counter;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     counter++;

--- a/c/list-ext2-properties/simple_search_value_true-unreach-call.c
+++ b/c/list-ext2-properties/simple_search_value_true-unreach-call.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->2->3->4... */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
 
@@ -31,7 +31,7 @@ int main() {
   while (counter < 10 || __VERIFIER_nondet_int()) {
     p->h = counter;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     counter++;

--- a/c/list-ext2-properties/simple_search_value_true-unreach-call.i
+++ b/c/list-ext2-properties/simple_search_value_true-unreach-call.i
@@ -526,7 +526,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -535,14 +535,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   int counter = 0;
   while (counter < 10 || __VERIFIER_nondet_int()) {
     p->h = counter;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
     counter++;

--- a/c/list-ext3-properties/dll_circular_traversal_false-valid-deref.c
+++ b/c/list-ext3-properties/dll_circular_traversal_false-valid-deref.c
@@ -14,14 +14,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL dll_circular_create(int len, int data) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(NULL == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -30,7 +30,7 @@ DLL dll_circular_create(int len, int data) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/dll_circular_traversal_false-valid-deref.i
+++ b/c/list-ext3-properties/dll_circular_traversal_false-valid-deref.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_circular_create(int len, int data) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -573,7 +573,7 @@ DLL dll_circular_create(int len, int data) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/dll_circular_traversal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/dll_circular_traversal_true-unreach-call_true-valid-memsafety.c
@@ -13,14 +13,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL dll_circular_create(int len, int data) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(NULL == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -29,7 +29,7 @@ DLL dll_circular_create(int len, int data) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/dll_circular_traversal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/dll_circular_traversal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_circular_create(int len, int data) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -573,7 +573,7 @@ DLL dll_circular_create(int len, int data) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/dll_nondet_free_order_false-valid-memtrack.c
+++ b/c/list-ext3-properties/dll_nondet_free_order_false-valid-memtrack.c
@@ -12,14 +12,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL dll_circular_create(int len) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(NULL == last) {
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -27,7 +27,7 @@ DLL dll_circular_create(int len) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head->prev = new_head;

--- a/c/list-ext3-properties/dll_nondet_free_order_false-valid-memtrack.i
+++ b/c/list-ext3-properties/dll_nondet_free_order_false-valid-memtrack.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_circular_create(int len) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == last) {
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -571,7 +571,7 @@ DLL dll_circular_create(int len) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head->prev = new_head;

--- a/c/list-ext3-properties/dll_nondet_free_order_true-valid-memsafety.c
+++ b/c/list-ext3-properties/dll_nondet_free_order_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL dll_circular_create(int len) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(NULL == last) {
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -26,7 +26,7 @@ DLL dll_circular_create(int len) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head->prev = new_head;

--- a/c/list-ext3-properties/dll_nondet_free_order_true-valid-memsafety.i
+++ b/c/list-ext3-properties/dll_nondet_free_order_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_circular_create(int len) {
   DLL last = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == last) {
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->prev = last;
@@ -571,7 +571,7 @@ DLL dll_circular_create(int len) {
   while(len > 1) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head->prev = new_head;

--- a/c/list-ext3-properties/dll_nullified_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-ext3-properties/dll_nullified_false-unreach-call_false-valid-memcleanup.c
@@ -16,7 +16,7 @@ typedef struct node {
   int data_2;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -25,7 +25,7 @@ DLL dll_create(int len) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data_0 = 0;
     new_head->data_1 = 0;

--- a/c/list-ext3-properties/dll_nullified_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-ext3-properties/dll_nullified_false-unreach-call_false-valid-memcleanup.i
@@ -561,7 +561,7 @@ typedef struct node {
   struct node* prev;
   int data_2;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_create(int len) {
@@ -569,7 +569,7 @@ DLL dll_create(int len) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data_0 = 0;
     new_head->data_1 = 0;

--- a/c/list-ext3-properties/dll_nullified_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/dll_nullified_true-unreach-call_true-valid-memsafety.c
@@ -14,7 +14,7 @@ typedef struct node {
   int data_2;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ DLL dll_create(int len) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data_0 = 0;
     new_head->data_1 = 0;

--- a/c/list-ext3-properties/dll_nullified_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/dll_nullified_true-unreach-call_true-valid-memsafety.i
@@ -560,7 +560,7 @@ typedef struct node {
   struct node* prev;
   int data_2;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL dll_create(int len) {
@@ -568,7 +568,7 @@ DLL dll_create(int len) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data_0 = 0;
     new_head->data_1 = 0;

--- a/c/list-ext3-properties/sll_circular_traversal_false-valid-deref.c
+++ b/c/list-ext3-properties/sll_circular_traversal_false-valid-deref.c
@@ -12,14 +12,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL sll_circular_create(int len, int data) {
   SLL const last = (SLL) malloc(sizeof(struct node));
   if(NULL == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->data = data;
@@ -27,7 +27,7 @@ SLL sll_circular_create(int len, int data) {
   while(len > 1) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head){
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/sll_circular_traversal_false-valid-deref.i
+++ b/c/list-ext3-properties/sll_circular_traversal_false-valid-deref.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node* next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_circular_create(int len, int data) {
   SLL const last = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->data = data;
@@ -571,7 +571,7 @@ SLL sll_circular_create(int len, int data) {
   while(len > 1) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head){
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/sll_circular_traversal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/sll_circular_traversal_true-unreach-call_true-valid-memsafety.c
@@ -12,14 +12,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL sll_circular_create(int len, int data) {
   SLL const last = (SLL) malloc(sizeof(struct node));
   if(NULL == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->data = data;
@@ -27,7 +27,7 @@ SLL sll_circular_create(int len, int data) {
   while(len > 1) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head){
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/sll_circular_traversal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/sll_circular_traversal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node* next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_circular_create(int len, int data) {
   SLL const last = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == last){
-    exit(1);
+    myexit(1);
   }
   last->next = last;
   last->data = data;
@@ -571,7 +571,7 @@ SLL sll_circular_create(int len, int data) {
   while(len > 1) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head){
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     new_head->data = data;

--- a/c/list-ext3-properties/sll_length_check_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-ext3-properties/sll_length_check_false-unreach-call_false-valid-memcleanup.c
@@ -11,7 +11,7 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -20,7 +20,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;

--- a/c/list-ext3-properties/sll_length_check_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-ext3-properties/sll_length_check_false-unreach-call_false-valid-memcleanup.i
@@ -557,7 +557,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
 typedef struct node {
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -565,7 +565,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;

--- a/c/list-ext3-properties/sll_length_check_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/sll_length_check_true-unreach-call_true-valid-memsafety.c
@@ -11,7 +11,7 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -20,7 +20,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;

--- a/c/list-ext3-properties/sll_length_check_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/sll_length_check_true-unreach-call_true-valid-memsafety.i
@@ -557,7 +557,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
 typedef struct node {
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -565,7 +565,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;

--- a/c/list-ext3-properties/sll_nondet_insert_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-ext3-properties/sll_nondet_insert_false-unreach-call_false-valid-memcleanup.c
@@ -12,7 +12,7 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -21,7 +21,7 @@ SLL sll_create(int len) {
   while(len-- > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -49,7 +49,7 @@ void sll_destroy(SLL head) {
 void sll_insert(SLL* head, int position) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(NULL == new_node) {
-    exit(1);
+    myexit(1);
   }
   SLL second_to_last = NULL;
   SLL last = *head;

--- a/c/list-ext3-properties/sll_nondet_insert_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-ext3-properties/sll_nondet_insert_false-unreach-call_false-valid-memcleanup.i
@@ -557,7 +557,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
 typedef struct node {
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -565,7 +565,7 @@ SLL sll_create(int len) {
   while(len-- > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -590,7 +590,7 @@ void sll_destroy(SLL head) {
 void sll_insert(SLL* head, int position) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == new_node) {
-    exit(1);
+    myexit(1);
   }
   SLL second_to_last = ((void *)0);
   SLL last = *head;

--- a/c/list-ext3-properties/sll_nondet_insert_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/sll_nondet_insert_true-unreach-call_true-valid-memsafety.c
@@ -12,7 +12,7 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -21,7 +21,7 @@ SLL sll_create(int len) {
   while(len-- > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -49,7 +49,7 @@ void sll_destroy(SLL head) {
 void sll_insert(SLL* head, int position) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(NULL == new_node) {
-    exit(1);
+    myexit(1);
   }
   SLL second_to_last = NULL;
   SLL last = *head;

--- a/c/list-ext3-properties/sll_nondet_insert_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/sll_nondet_insert_true-unreach-call_true-valid-memsafety.i
@@ -557,7 +557,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
 typedef struct node {
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -565,7 +565,7 @@ SLL sll_create(int len) {
   while(len-- > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -590,7 +590,7 @@ void sll_destroy(SLL head) {
 void sll_insert(SLL* head, int position) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == new_node) {
-    exit(1);
+    myexit(1);
   }
   SLL second_to_last = ((void *)0);
   SLL last = *head;

--- a/c/list-ext3-properties/sll_of_sll_nondet_append_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append_false-unreach-call_false-valid-memcleanup.c
@@ -14,7 +14,7 @@ typedef struct node {
   struct node* inner;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -35,7 +35,7 @@ SLL sll_create(int len) {
 SLL node_create_with_sublist(int sublist_length) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(NULL == new_node) {
-    exit(1);
+    myexit(1);
   }
   new_node->inner = sll_create(sublist_length);
   new_node->next = NULL;

--- a/c/list-ext3-properties/sll_of_sll_nondet_append_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append_false-unreach-call_false-valid-memcleanup.i
@@ -558,7 +558,7 @@ typedef struct node {
   struct node* next;
   struct node* inner;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -566,7 +566,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -577,7 +577,7 @@ SLL sll_create(int len) {
 SLL node_create_with_sublist(int sublist_length) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == new_node) {
-    exit(1);
+    myexit(1);
   }
   new_node->inner = sll_create(sublist_length);
   new_node->next = ((void *)0);

--- a/c/list-ext3-properties/sll_of_sll_nondet_append_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append_true-unreach-call_true-valid-memsafety.c
@@ -13,7 +13,7 @@ typedef struct node {
   struct node* inner;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -22,7 +22,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -34,7 +34,7 @@ SLL sll_create(int len) {
 SLL node_create_with_sublist(int sublist_length) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(NULL == new_node) {
-    exit(1);
+    myexit(1);
   }
   new_node->inner = sll_create(sublist_length);
   new_node->next = NULL;

--- a/c/list-ext3-properties/sll_of_sll_nondet_append_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append_true-unreach-call_true-valid-memsafety.i
@@ -558,7 +558,7 @@ typedef struct node {
   struct node* next;
   struct node* inner;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL sll_create(int len) {
@@ -566,7 +566,7 @@ SLL sll_create(int len) {
   while(len > 0) {
     SLL new_head = (SLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->next = head;
     head = new_head;
@@ -577,7 +577,7 @@ SLL sll_create(int len) {
 SLL node_create_with_sublist(int sublist_length) {
   SLL new_node = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == new_node) {
-    exit(1);
+    myexit(1);
   }
   new_node->inner = sll_create(sublist_length);
   new_node->next = ((void *)0);

--- a/c/list-ext3-properties/sll_shallow_copy_false-valid-memtrack.c
+++ b/c/list-ext3-properties/sll_shallow_copy_false-valid-memtrack.c
@@ -9,14 +9,14 @@ struct node {
   struct node* next;
 };
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 struct node* alloc_node() {
   struct node* temp = (struct node*) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   return temp;
 }

--- a/c/list-ext3-properties/sll_shallow_copy_false-valid-memtrack.i
+++ b/c/list-ext3-properties/sll_shallow_copy_false-valid-memtrack.i
@@ -555,13 +555,13 @@ extern int getloadavg (double __loadavg[], int __nelem)
 struct node {
   struct node* next;
 };
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 struct node* alloc_node() {
   struct node* temp = (struct node*) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   return temp;
 }

--- a/c/list-ext3-properties/sll_shallow_copy_true-valid-memsafety.c
+++ b/c/list-ext3-properties/sll_shallow_copy_true-valid-memsafety.c
@@ -9,14 +9,14 @@ struct node {
   struct node* next;
 };
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 struct node* alloc_node() {
   struct node* temp = (struct node*) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   return temp;
 }

--- a/c/list-ext3-properties/sll_shallow_copy_true-valid-memsafety.i
+++ b/c/list-ext3-properties/sll_shallow_copy_true-valid-memsafety.i
@@ -555,13 +555,13 @@ extern int getloadavg (double __loadavg[], int __nelem)
 struct node {
   struct node* next;
 };
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 struct node* alloc_node() {
   struct node* temp = (struct node*) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   return temp;
 }

--- a/c/list-properties/alternating_list_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/alternating_list_false-unreach-call_false-valid-memcleanup.c
@@ -14,7 +14,7 @@ typedef struct node {
   struct node *n;
 } *List;
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ int main() {
   
   /* Build a list of the form (1->2)*->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
@@ -35,7 +35,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/alternating_list_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-properties/alternating_list_false-unreach-call_false-valid-memcleanup.i
@@ -620,13 +620,13 @@ typedef struct node {
   int h;
   struct node *n;
 } *List;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 int main() {
   int flag = 1;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
@@ -638,7 +638,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/alternating_list_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-properties/alternating_list_true-unreach-call_true-valid-memsafety.c
@@ -13,7 +13,7 @@ typedef struct node {
   struct node *n;
 } *List;
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -22,7 +22,7 @@ int main() {
   
   /* Build a list of the form (1->2)*->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
@@ -34,7 +34,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/alternating_list_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-properties/alternating_list_true-unreach-call_true-valid-memsafety.i
@@ -620,13 +620,13 @@ typedef struct node {
   int h;
   struct node *n;
 } *List;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 int main() {
   int flag = 1;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
@@ -638,7 +638,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/list_false-unreach-call_false-valid-memcleanup.c
@@ -9,7 +9,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -21,20 +21,20 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-properties/list_false-unreach-call_false-valid-memcleanup.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -625,20 +625,20 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_flag_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/list_flag_false-unreach-call_false-valid-memcleanup.c
@@ -10,7 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <stdlib.h>
 /*  #include "assert.h" */
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -27,7 +27,7 @@ int main() {
    * with x depending on some flag
    */
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   while (__VERIFIER_nondet_int()) {
     if (flag) {
@@ -38,7 +38,7 @@ int main() {
     /*** TVLA forgets at this point the dependence
 	 between p->h and the value of flag        ***/
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_flag_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-properties/list_flag_false-unreach-call_false-valid-memcleanup.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,7 +627,7 @@ int main() {
   int flag = __VERIFIER_nondet_int();
   List p, a, t;
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   while (__VERIFIER_nondet_int()) {
     if (flag) {
@@ -636,7 +636,7 @@ int main() {
       p->h = 2;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_flag_true-unreach-call_false-valid-memtrack.c
+++ b/c/list-properties/list_flag_true-unreach-call_false-valid-memtrack.c
@@ -10,7 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <stdlib.h>
 /*  #include "assert.h" */
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -27,7 +27,7 @@ int main() {
    * with x depending on some flag
    */
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   while (__VERIFIER_nondet_int()) {
     if (flag) {
@@ -38,7 +38,7 @@ int main() {
     /*** TVLA forgets at this point the dependence
 	 between p->h and the value of flag        ***/
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_flag_true-unreach-call_false-valid-memtrack.i
+++ b/c/list-properties/list_flag_true-unreach-call_false-valid-memtrack.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -627,7 +627,7 @@ int main() {
   int flag = __VERIFIER_nondet_int();
   List p, a, t;
   a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   p = a;
   while (__VERIFIER_nondet_int()) {
     if (flag) {
@@ -636,7 +636,7 @@ int main() {
       p->h = 2;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_true-unreach-call_false-valid-memtrack.c
+++ b/c/list-properties/list_true-unreach-call_false-valid-memtrack.c
@@ -9,7 +9,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -21,20 +21,20 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->...->1->2->....->2->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/list_true-unreach-call_false-valid-memtrack.i
+++ b/c/list-properties/list_true-unreach-call_false-valid-memtrack.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -625,20 +625,20 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }
   while (__VERIFIER_nondet_int()) {
     p->h = 2;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/simple_built_from_end_true-unreach-call_false-valid-memtrack.c
+++ b/c/list-properties/simple_built_from_end_true-unreach-call_false-valid-memtrack.c
@@ -8,7 +8,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -23,7 +23,7 @@ int main() {
   List p = 0;
   while (__VERIFIER_nondet_int()) {
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     t->h = 1;
     t->n = p;
     p = t;

--- a/c/list-properties/simple_built_from_end_true-unreach-call_false-valid-memtrack.i
+++ b/c/list-properties/simple_built_from_end_true-unreach-call_false-valid-memtrack.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -628,7 +628,7 @@ int main() {
   List p = 0;
   while (__VERIFIER_nondet_int()) {
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     t->h = 1;
     t->n = p;
     p = t;

--- a/c/list-properties/simple_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/simple_false-unreach-call_false-valid-memcleanup.c
@@ -8,7 +8,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -20,14 +20,14 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->...->1->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   a->h = 2;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/simple_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-properties/simple_false-unreach-call_false-valid-memcleanup.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -625,14 +625,14 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   a->h = 2;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/simple_true-unreach-call_false-valid-memtrack.c
+++ b/c/list-properties/simple_true-unreach-call_false-valid-memtrack.c
@@ -8,7 +8,7 @@ extern int __VERIFIER_nondet_int();
  */
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
 	_EXIT: goto _EXIT;
 }
 
@@ -20,13 +20,13 @@ typedef struct node {
 int main() {
   /* Build a list of the form 1->...->1->0 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/simple_true-unreach-call_false-valid-memtrack.i
+++ b/c/list-properties/simple_true-unreach-call_false-valid-memtrack.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -625,13 +625,13 @@ typedef struct node {
 } *List;
 int main() {
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List p = a;
   while (__VERIFIER_nondet_int()) {
     p->h = 1;
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/splice_false-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/splice_false-unreach-call_false-valid-memcleanup.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
 
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -25,7 +25,7 @@ int main() {
   
   /* Build a list of the form (1->2)*->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List l1;
   List l2;
@@ -41,7 +41,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/splice_false-unreach-call_false-valid-memcleanup.i
+++ b/c/list-properties/splice_false-unreach-call_false-valid-memcleanup.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -626,7 +626,7 @@ typedef struct node {
 int main() {
   int flag = 1;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List l1;
   List l2;
@@ -642,7 +642,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/splice_true-unreach-call_false-valid-memtrack.c
+++ b/c/list-properties/splice_true-unreach-call_false-valid-memtrack.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
 
 #include <stdlib.h>
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
@@ -25,7 +25,7 @@ int main() {
   
   /* Build a list of the form (1->2)*->3 */
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List l1;
   List l2;
@@ -41,7 +41,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-properties/splice_true-unreach-call_false-valid-memtrack.i
+++ b/c/list-properties/splice_true-unreach-call_false-valid-memtrack.i
@@ -616,7 +616,7 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 typedef struct node {
@@ -626,7 +626,7 @@ typedef struct node {
 int main() {
   int flag = 1;
   List a = (List) malloc(sizeof(struct node));
-  if (a == 0) exit(1);
+  if (a == 0) myexit(1);
   List t;
   List l1;
   List l2;
@@ -642,7 +642,7 @@ int main() {
       flag = 1;
     }
     t = (List) malloc(sizeof(struct node));
-    if (t == 0) exit(1);
+    if (t == 0) myexit(1);
     p->n = t;
     p = p->n;
   }

--- a/c/list-simple/dll2c_append_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_append_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_append_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_append_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_append_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_append_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_append_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_append_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_insert_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_insert_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_insert_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_insert_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_insert_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_insert_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_insert_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_insert_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_prepend_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_prepend_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_prepend_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_prepend_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_remove_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_remove_all_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_remove_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_remove_all_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2c_update_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2c_update_all_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   int data;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2c_update_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2c_update_all_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node *prev;
   int data;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2n_append_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_append_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2n_append_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_append_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2n_append_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_append_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;

--- a/c/list-simple/dll2n_append_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_append_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);

--- a/c/list-simple/dll2n_insert_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_insert_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_insert_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_insert_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_insert_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_insert_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_insert_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_insert_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_prepend_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_prepend_equal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_prepend_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_prepend_equal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_remove_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_remove_all_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_remove_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_remove_all_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_update_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/dll2n_update_all_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* prev;
 } *DLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->prev = NULL;
@@ -31,7 +31,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(NULL == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/dll2n_update_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/dll2n_update_all_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   struct node* next;
   struct node* prev;
 } *DLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 DLL node_create(int data) {
   DLL temp = (DLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->prev = ((void *)0);
@@ -576,7 +576,7 @@ DLL dll_create(int len, int data) {
   while(len > 0) {
     DLL new_head = (DLL) malloc(sizeof(struct node));
     if(((void *)0) == new_head) {
-      exit(1);
+      myexit(1);
     }
     new_head->data = data;
     new_head->next = head;

--- a/c/list-simple/sll2c_append_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_append_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_append_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_append_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_append_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_append_unequal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_append_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_append_unequal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_insert_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_insert_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_insert_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_insert_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_insert_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_insert_unequal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_insert_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_insert_unequal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_prepend_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_prepend_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_prepend_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_prepend_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_prepend_unequal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_remove_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_remove_all_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_remove_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_remove_all_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_update_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2c_update_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2c_update_all_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   int data;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2c_update_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2c_update_all_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   struct node *next;
   int data;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_append_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_append_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_append_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_append_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_append_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_append_unequal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_append_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_append_unequal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_insert_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_insert_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_insert_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_insert_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_insert_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_insert_unequal_true-unreach-call_true-valid-memsafety.c
@@ -11,14 +11,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_insert_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_insert_unequal_true-unreach-call_true-valid-memsafety.i
@@ -558,13 +558,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_prepend_equal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_prepend_equal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_prepend_equal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_prepend_equal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_prepend_unequal_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_remove_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_remove_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_remove_all_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_remove_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_remove_all_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_update_all_reverse_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;

--- a/c/list-simple/sll2n_update_all_true-unreach-call_true-valid-memsafety.c
+++ b/c/list-simple/sll2n_update_all_true-unreach-call_true-valid-memsafety.c
@@ -10,14 +10,14 @@ typedef struct node {
   struct node* next;
 } *SLL;
 
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(NULL == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = NULL;
   temp->data = data;

--- a/c/list-simple/sll2n_update_all_true-unreach-call_true-valid-memsafety.i
+++ b/c/list-simple/sll2n_update_all_true-unreach-call_true-valid-memsafety.i
@@ -557,13 +557,13 @@ typedef struct node {
   int data;
   struct node* next;
 } *SLL;
-void exit(int s) {
+void myexit(int s) {
  _EXIT: goto _EXIT;
 }
 SLL node_create(int data) {
   SLL temp = (SLL) malloc(sizeof(struct node));
   if(((void *)0) == temp) {
-    exit(1);
+    myexit(1);
   }
   temp->next = ((void *)0);
   temp->data = data;


### PR DESCRIPTION
From C99 standard:
> If the  program  declares  or  defines  an  identifier  in  a context  in  which  it  is  reserved  (other  than  as  allowed  by  7.1.4),  or  defines  a  reserved identifier as a macro name, the behavior is undefined

This PR renames custom `exit` function used in list- benchmarks to `myexit`, because `exit` is reserved by the standard header files included in the benchmarks.