### PR TITLE
Adding missing init stmt for lock and the conditional variables

### DIFF
--- a/c/pthread-divine/condvar_spurious_wakeup_false-unreach-call.c
+++ b/c/pthread-divine/condvar_spurious_wakeup_false-unreach-call.c
@@ -24,6 +24,8 @@ void *thread( void *arg ) {
 
 int main() {
     pthread_t t;
+    pthread_mutex_init(&lock,0);
+    pthread_cond_init(&cond,0);
     pthread_create( &t, NULL, thread, NULL );
     for ( int i = 0; i <= 42; i++ )
         x = i;

--- a/c/pthread-divine/condvar_spurious_wakeup_false-unreach-call.i
+++ b/c/pthread-divine/condvar_spurious_wakeup_false-unreach-call.i
@@ -696,6 +696,8 @@ void *thread( void *arg ) {
 }
 int main() {
     pthread_t t;
+    pthread_mutex_init(&lock,0);
+    pthread_cond_init(&cond,0);
     pthread_create( &t, ((void *)0), thread, ((void *)0) );
     for ( int i = 0; i <= 42; i++ )
         x = i;


### PR DESCRIPTION
Conditional variables and mutexes must be initialised before use (see pthread documentation, e.g. pthread_mutex_lock()).