### PR TITLE
cs_lazy: fix read from uninitialized variable

### DIFF
--- a/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.c
+++ b/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.c
@@ -82,10 +82,11 @@ unsigned int __CS_SwitchDone;
 
 //cseq: function declarations
 int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar(void);
 
 void __CS_cs(void)
 {
-	__CS_type k;
+	__CS_type k = __VERIFIER_nondet_uchar();
 
 	__VERIFIER_assume(__CS_round+k < __CS_ROUNDS);   // k==0 --> no switch
 	__CS_round += k;

--- a/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.i
+++ b/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.i
@@ -640,9 +640,10 @@ const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][3 +1];
 int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar(void);
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 2);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 2 -1)?__CS_ret_PREEMPTED:__CS_ret;


### PR DESCRIPTION
Remove read from uninitialized variable (initialize the variable with call to __VERIFIER_nondet)