### PR TITLE
Fix invalid dereference in termination benchmark

### DIFF
--- a/c/loop-acceleration/array_false-unreach-call3_true-termination.c
+++ b/c/loop-acceleration/array_false-unreach-call3_true-termination.c
@@ -19,7 +19,7 @@ int main(void) {
     A[i] = __VERIFIER_nondet_int();
   }
 
-  for (i = 0; A[i] != 0 && i < N; i++) {
+  for (i = 0; i < N && A[i] != 0; i++) {
   }
 
   __VERIFIER_assert(i <= N / 2);

--- a/c/loop-acceleration/array_false-unreach-call3_true-termination.i
+++ b/c/loop-acceleration/array_false-unreach-call3_true-termination.i
@@ -12,7 +12,7 @@ int main(void) {
   for (i = 0; i < 1024; i++) {
     A[i] = __VERIFIER_nondet_int();
   }
-  for (i = 0; A[i] != 0 && i < 1024; i++) {
+  for (i = 0; i < 1024 && A[i] != 0; i++) {
   }
   __VERIFIER_assert(i <= 1024 / 2);
 }


### PR DESCRIPTION
Fixes possible invalid dereference in termination benchmark.
