### PR TITLE
Revert removing a directory from benchmark set

### DIFF
--- a/c/Systems_DeviceDriversLinux64_ReachSafety.set
+++ b/c/Systems_DeviceDriversLinux64_ReachSafety.set
@@ -8,6 +8,8 @@ ldv-commit-tester/*_false-unreach-call*.c
 ldv-commit-tester/*_true-unreach-call*.c
 ldv-consumption/*_false-unreach-call*.i
 ldv-consumption/*_true-unreach-call*.i
+ldv-linux-3.12-rc1/*_false-unreach-call*.c
+ldv-linux-3.12-rc1/*_true-unreach-call*.c
 ldv-linux-3.16-rc1/*_false-unreach-call*.i
 ldv-linux-3.16-rc1/*_true-unreach-call*.i
 ldv-validator-v0.6/*_false-unreach-call*.i


### PR DESCRIPTION
The directory ldv-linux-3.12-rc1 was removed from a benchmark set Systems_DeviceDriversLinux64_ReachSafety, that leads to failures in checks. 
The PR reverts the undesired change,