### PR TITLE
Remove uninitialized reads from sequentialized benchmarks.

### DIFF
--- a/c/seq-pthread/cs_fib_false-unreach-call.c
+++ b/c/seq-pthread/cs_fib_false-unreach-call.c
@@ -82,6 +82,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
 
 void __CS_cs(void)
 {
@@ -376,6 +377,14 @@ int main(int argc, char **argv)
 	__CS_type *__CS_cp___CS_thread_lockedon[__CS_ROUNDS][__CS_THREADS+1];
 	int __CS_cp_i[__CS_ROUNDS];
 	int __CS_cp_j[__CS_ROUNDS];
+	for (int i = 0; i < __CS_ROUNDS; ++i) {
+		for (int j = 0; j < __CS_THREADS+1; ++j) {
+			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+		}
+		__CS_cp_i[i] = __VERIFIER_nondet_int();
+		__CS_cp_j[i] = __VERIFIER_nondet_int();
+	}
 
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,

--- a/c/seq-pthread/cs_fib_false-unreach-call.i
+++ b/c/seq-pthread/cs_fib_false-unreach-call.i
@@ -662,6 +662,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[6][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -850,6 +851,14 @@ int main(int argc, char **argv)
  unsigned char *__CS_cp___CS_thread_lockedon[6][2 +1];
  int __CS_cp_i[6];
  int __CS_cp_j[6];
+ for (int i = 0; i < 6; ++i) {
+  for (int j = 0; j < 2 +1; ++j) {
+   __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+  }
+  __CS_cp_i[i] = __VERIFIER_nondet_int();
+  __CS_cp_j[i] = __VERIFIER_nondet_int();
+ }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];
  __CS_thread_status[2][0] = __CS_cp___CS_thread_status[2][0];
  __CS_thread_status[3][0] = __CS_cp___CS_thread_status[3][0];

--- a/c/seq-pthread/cs_fib_longer_false-unreach-call.c
+++ b/c/seq-pthread/cs_fib_longer_false-unreach-call.c
@@ -83,6 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
 
 void __CS_cs(void)
 {
@@ -377,6 +378,15 @@ int main(int argc, char **argv)
 	__CS_type *__CS_cp___CS_thread_lockedon[__CS_ROUNDS][__CS_THREADS+1];
 	int __CS_cp_i[__CS_ROUNDS];
 	int __CS_cp_j[__CS_ROUNDS];
+
+	for (int i = 0; i < __CS_ROUNDS; ++i) {
+		for (int j = 0; j < __CS_THREADS+1; ++j) {
+			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+		}
+		__CS_cp_i[i] = __VERIFIER_nondet_int();
+		__CS_cp_j[i] = __VERIFIER_nondet_int();
+	}
 
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,

--- a/c/seq-pthread/cs_fib_longer_false-unreach-call.i
+++ b/c/seq-pthread/cs_fib_longer_false-unreach-call.i
@@ -652,6 +652,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[7][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -834,6 +835,14 @@ int main(int argc, char **argv)
  unsigned char *__CS_cp___CS_thread_lockedon[7][2 +1];
  int __CS_cp_i[7];
  int __CS_cp_j[7];
+ for (int i = 0; i < 7; ++i) {
+  for (int j = 0; j < 2 +1; ++j) {
+   __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+  }
+  __CS_cp_i[i] = __VERIFIER_nondet_int();
+  __CS_cp_j[i] = __VERIFIER_nondet_int();
+ }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];
  __CS_thread_status[2][0] = __CS_cp___CS_thread_status[2][0];
  __CS_thread_status[3][0] = __CS_cp___CS_thread_status[3][0];

--- a/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.c
+++ b/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.c
@@ -83,6 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar(void);
+extern void *__VERIFIER_nondet_pointer(void);
 
 void __CS_cs(void)
 {
@@ -381,6 +382,15 @@ int main()
 	__CS_type *__CS_cp___CS_thread_lockedon[__CS_ROUNDS][__CS_THREADS+1];
 	__CS_pthread_mutex_t __CS_cp_mutex[__CS_ROUNDS];
 	int __CS_cp_data[__CS_ROUNDS];
+
+	for (int i = 0; i < __CS_ROUNDS; ++i) {
+		for (int j = 0; j < __CS_THREADS+1; ++j) {
+			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+		}
+		__CS_cp_mutex[i] = __VERIFIER_nondet_uchar();
+		__CS_cp_data[i] = __VERIFIER_nondet_int();
+	}
 
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,

--- a/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.i
+++ b/c/seq-pthread/cs_lazy_false-unreach-call_true-termination.i
@@ -641,6 +641,8 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][3 +1];
 int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar(void);
+extern void *__VERIFIER_nondet_pointer(void);
+
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -830,6 +832,16 @@ int main()
  unsigned char *__CS_cp___CS_thread_lockedon[2][3 +1];
  unsigned char __CS_cp_mutex[2];
  int __CS_cp_data[2];
+
+ for (int i = 0; i < 2; ++i) {
+  for (int j = 0; j < 3 +1; ++j) {
+   __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+  }
+  __CS_cp_mutex[i] = __VERIFIER_nondet_uchar();
+  __CS_cp_data[i] = __VERIFIER_nondet_int();
+ }
+
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];
  __CS_thread_status[1][1] = __CS_cp___CS_thread_status[1][1];
  __CS_thread_status[1][2] = __CS_cp___CS_thread_status[1][2];

--- a/c/seq-pthread/cs_stateful_false-unreach-call_true-termination.c
+++ b/c/seq-pthread/cs_stateful_false-unreach-call_true-termination.c
@@ -83,6 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
 
 void __CS_cs(void)
 {
@@ -391,6 +392,17 @@ int main()
 	__CS_pthread_mutex_t __CS_cp_mb[__CS_ROUNDS];
 	int __CS_cp_data1[__CS_ROUNDS];
 	int __CS_cp_data2[__CS_ROUNDS];
+
+	for (int i = 0; i < __CS_ROUNDS; ++i) {
+		for (int j = 0; j < __CS_THREADS+1; ++j) {
+			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+		}
+		__CS_cp_ma[i] = __VERIFIER_nondet_uchar();
+		__CS_cp_mb[i] = __VERIFIER_nondet_uchar();
+		__CS_cp_data1[i] = __VERIFIER_nondet_int();
+		__CS_cp_data2[i] = __VERIFIER_nondet_int();
+	}
 
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,

--- a/c/seq-pthread/cs_stateful_false-unreach-call_true-termination.i
+++ b/c/seq-pthread/cs_stateful_false-unreach-call_true-termination.i
@@ -652,6 +652,8 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
+extern void *__VERIFIER_nondet_pointer(void);
+
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -852,6 +854,18 @@ int main()
  unsigned char __CS_cp_mb[2];
  int __CS_cp_data1[2];
  int __CS_cp_data2[2];
+
+ for (int i = 0; i < 2; ++i) {
+  for (int j = 0; j < 2 +1; ++j) {
+   __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+  }
+  __CS_cp_ma[i] = __VERIFIER_nondet_uchar();
+  __CS_cp_mb[i] = __VERIFIER_nondet_uchar();
+  __CS_cp_data1[i] = __VERIFIER_nondet_int();
+  __CS_cp_data2[i] = __VERIFIER_nondet_int();
+ }
+
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];
  __CS_thread_status[1][1] = __CS_cp___CS_thread_status[1][1];
  __CS_thread_status[1][2] = __CS_cp___CS_thread_status[1][2];


### PR DESCRIPTION
Fix reads of uninitialized (automatic storage) variables, as such reads are undefined behavior. This PR fixes this problem in these benchmarks:

```
seq-pthread/cs_fib_false-unreach-call.i
seq-pthread/cs_fib_longer_false-unreach-call.i
seq-pthread/cs_lazy_false-unreach-call_true-termination.i
seq-pthread/cs_stateful_false-unreach-call_true-termination.i
```

The "true" versions of these benchmarks contain the fix already, but the "false" versions did not have it for some reason.