### PR TITLE
Add a model of default_wake_function

### DIFF
--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -33651,6 +33651,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
@@ -17686,6 +17686,10 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
@@ -18183,6 +18183,10 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-hostap-hostap_true-unreach-call.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-hostap-hostap_true-unreach-call.cil.i
@@ -33940,6 +33940,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -33636,6 +33636,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.i
@@ -33997,6 +33997,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.i
@@ -33997,6 +33997,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.i
@@ -33997,6 +33997,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1155,3 +1155,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
@@ -663,3 +663,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
@@ -695,3 +695,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-hostap-hostap_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-hostap-hostap_true-unreach-call.cil.env.c
@@ -1025,3 +1025,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1172,3 +1172,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -1821,3 +1821,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
@@ -1821,3 +1821,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -1821,3 +1821,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
@@ -478,3 +478,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
@@ -831,3 +831,12 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
@@ -388,3 +388,12 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.env.c
@@ -368,3 +368,12 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -2345,3 +2345,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
@@ -790,3 +790,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
@@ -762,3 +762,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
@@ -1755,3 +1755,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
@@ -300,3 +300,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.0/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.i
@@ -10703,6 +10703,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.i
@@ -10127,6 +10127,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.i
@@ -8074,6 +8074,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.i
@@ -7200,6 +7200,10 @@ void wait_for_completion(struct completion *arg0) {
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.i
@@ -72452,6 +72452,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.i
@@ -11250,6 +11250,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.i
@@ -15006,6 +15006,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.i
@@ -33519,6 +33519,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.i
@@ -9700,6 +9700,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.i
@@ -14118,6 +14118,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.i
@@ -14422,6 +14422,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.env.c
@@ -723,3 +723,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -736,3 +736,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.i
@@ -18191,6 +18191,10 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -24030,6 +24030,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -31807,6 +31807,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -24311,6 +24311,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -32251,6 +32251,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-tun_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-tun_true-unreach-call.cil.i
@@ -17288,6 +17288,10 @@ int __VERIFIER_nondet_int(void);
 int zerocopy_sg_from_iovec(struct sk_buff *arg0, const struct iovec *arg1, int arg2, size_t arg3) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -25412,6 +25412,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-cw1200-cw1200_wlan_spi_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-cw1200-cw1200_wlan_spi_true-unreach-call.cil.i
@@ -11465,6 +11465,10 @@ int spi_sync(struct spi_device *arg0, struct spi_message *arg1) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__fs-nfs-blocklayout-blocklayoutdriver_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__fs-nfs-blocklayout-blocklayoutdriver_true-unreach-call.cil.i
@@ -19902,6 +19902,10 @@ __be32 *xdr_reserve_space(struct xdr_stream *arg0, size_t arg1) {
 void xdr_set_scratch_buffer(struct xdr_stream *arg0, void *arg1, size_t arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -24188,6 +24188,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -31950,6 +31950,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__linux-alloc-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__linux-alloc-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -23743,6 +23743,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -22357,6 +22357,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.i
@@ -28689,6 +28689,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -23739,6 +23739,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/linux-3.14__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.i
@@ -22515,6 +22515,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-common-saa7146-saa7146_vv_true-unreach-call.cil.env.c
@@ -687,3 +687,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -903,3 +903,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1173,3 +1173,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -895,3 +895,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1149,3 +1149,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-tun_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-tun_true-unreach-call.cil.env.c
@@ -1141,3 +1141,12 @@ int zerocopy_sg_from_iovec(struct sk_buff *arg0, const struct iovec *arg1, int a
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -902,3 +902,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-cw1200-cw1200_wlan_spi_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-cw1200-cw1200_wlan_spi_true-unreach-call.cil.env.c
@@ -325,3 +325,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__fs-nfs-blocklayout-blocklayoutdriver_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__fs-nfs-blocklayout-blocklayoutdriver_true-unreach-call.cil.env.c
@@ -833,3 +833,12 @@ void xdr_set_scratch_buffer(struct xdr_stream *arg0, void *arg1, size_t arg2) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -895,3 +895,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1165,3 +1165,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-alloc-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-alloc-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -885,3 +885,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -903,3 +903,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-libertas-libertas_true-unreach-call.cil.env.c
@@ -1149,3 +1149,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -902,3 +902,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-airo_true-unreach-call.cil.env.c
@@ -895,3 +895,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point_false-unreach-call.cil.out.i
@@ -11829,6 +11829,10 @@ void up_write(struct rw_semaphore *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point_true-unreach-call.cil.out.i
@@ -10796,6 +10796,10 @@ void tasklet_init(struct tasklet_struct *arg0, void (*arg1)(unsigned long), unsi
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point_true-unreach-call.cil.out.i
@@ -10342,6 +10342,10 @@ void *external_alloc(void);
 void *vzalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--usb--hso.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--usb--hso.ko-entry_point_true-unreach-call.cil.out.i
@@ -11527,6 +11527,10 @@ int usb_unlink_urb(struct urb *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--dpt_i2o.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--dpt_i2o.ko-entry_point_true-unreach-call.cil.out.i
@@ -10058,6 +10058,10 @@ struct scatterlist *sg_next(struct scatterlist *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point_true-unreach-call.cil.out.i
@@ -17048,6 +17048,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.i
@@ -8348,6 +8348,10 @@ int __VERIFIER_nondet_int(void);
 int usb_submit_urb(struct urb *arg0, gfp_t arg1) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.i
@@ -32552,6 +32552,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -813,3 +813,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -613,3 +613,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -647,3 +647,12 @@ void *vzalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--usb--hso.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--usb--hso.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -723,3 +723,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--dpt_i2o.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--dpt_i2o.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -577,3 +577,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1179,3 +1179,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -679,3 +679,12 @@ int usb_submit_urb(struct urb *arg0, gfp_t arg1) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1373,3 +1373,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4853,6 +4853,10 @@ void *external_alloc(void);
 void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -11258,6 +11258,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--mtd--chips--cfi_cmdset_0001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--mtd--chips--cfi_cmdset_0001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -14177,6 +14177,10 @@ int __VERIFIER_nondet_int(void);
 int unregister_reboot_notifier(struct notifier_block *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--scsi--dpt_i2o.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--scsi--dpt_i2o.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -19971,6 +19971,10 @@ void warn_slowpath_fmt(char *arg0, int arg1, const char *arg2, ...) {
 void warn_slowpath_null(char *arg0, int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4762,6 +4762,10 @@ void *external_alloc(void);
 void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4518,6 +4518,10 @@ void *external_alloc(void);
 void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -208,3 +208,12 @@ void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -535,3 +535,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--mtd--chips--cfi_cmdset_0001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--mtd--chips--cfi_cmdset_0001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -203,3 +203,12 @@ int unregister_reboot_notifier(struct notifier_block *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--scsi--dpt_i2o.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--scsi--dpt_i2o.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -529,3 +529,12 @@ void warn_slowpath_null(char *arg0, int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -210,3 +210,12 @@ void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -242,3 +242,12 @@ void *vmalloc(unsigned long arg0) {
   return (void *)external_alloc();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.7.3/linux-3.10-rc1-43_1a-bitvector-drivers--atm--he.ko-ldv_main0_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.7.3/linux-3.10-rc1-43_1a-bitvector-drivers--atm--he.ko-ldv_main0_true-unreach-call.cil.out.i
@@ -9833,6 +9833,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.7.3/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34695,6 +34695,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.7.3/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34695,6 +34695,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.7.3/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34695,6 +34695,10 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
 void yield() {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-3.7.3/model/linux-3.10-rc1-43_1a-bitvector-drivers--atm--he.ko-ldv_main0_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.7.3/model/linux-3.10-rc1-43_1a-bitvector-drivers--atm--he.ko-ldv_main0_true-unreach-call.cil.out.env.c
@@ -646,3 +646,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.7.3/model/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -1760,3 +1760,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.7.3/model/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -1760,3 +1760,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-3.7.3/model/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -1760,3 +1760,12 @@ void yield() {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.i
@@ -19711,6 +19711,10 @@ void up_write(struct rw_semaphore *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.i
@@ -29201,6 +29201,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.0-rc1-mav/linux-4_true-termination.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4_true-termination.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.i
@@ -12170,6 +12170,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.env.c
@@ -667,3 +667,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.env.c
@@ -815,3 +815,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4_true-termination.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4_true-termination.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.env.c
@@ -366,3 +366,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.i
@@ -7722,6 +7722,10 @@ unsigned char *skb_put(struct sk_buff *arg0, unsigned int arg1) {
 void vcc_insert_socket(struct sock *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.i
@@ -55749,6 +55749,10 @@ int wbinvd_on_all_cpus() {
 void ww_mutex_unlock(struct ww_mutex *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--dm-multipath.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--dm-multipath.ko-entry_point_false-unreach-call.cil.out.i
@@ -8328,6 +8328,10 @@ void up_read(struct rw_semaphore *arg0) {
 void up_write(struct rw_semaphore *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--pci--ivtv--ivtv.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--pci--ivtv--ivtv.ko-entry_point_true-unreach-call.cil.out.i
@@ -32704,6 +32704,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--mtd--mtd.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--mtd--mtd.ko-entry_point_false-unreach-call.cil.out.i
@@ -12518,6 +12518,10 @@ int __VERIFIER_nondet_int(void);
 int unregister_reboot_notifier(struct notifier_block *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.i
@@ -22958,6 +22958,10 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {
   return __VERIFIER_nondet_ulong();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
@@ -18642,6 +18642,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
@@ -22971,6 +22971,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.i
@@ -14578,6 +14578,10 @@ void *vzalloc(unsigned long arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
@@ -34578,6 +34578,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-crypt.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-crypt.ko-entry_point_false-unreach-call.cil.out.i
@@ -10562,6 +10562,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
@@ -19122,6 +19122,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
@@ -24263,6 +24263,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
@@ -36723,6 +36723,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.i
@@ -33016,6 +33016,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.i
@@ -24996,6 +24996,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point_true-unreach-call.cil.out.i
@@ -10052,6 +10052,10 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.i
@@ -24398,6 +24398,10 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {
   return __VERIFIER_nondet_ulong();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point_true-unreach-call.cil.out.i
@@ -11707,6 +11707,10 @@ void up_read(struct rw_semaphore *arg0) {
 void up_write(struct rw_semaphore *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.i
@@ -18734,6 +18734,10 @@ void wireless_send_event(struct net_device *arg0, unsigned int arg1, union iwreq
 void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw_quality *arg2) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.i
@@ -24096,6 +24096,10 @@ int wiphy_register(struct wiphy *arg0) {
 void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.i
@@ -36738,6 +36738,10 @@ int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.i
@@ -70760,6 +70760,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.i
@@ -41995,6 +41995,10 @@ void up_write(struct rw_semaphore *arg0) {
 void wait_for_completion(struct completion *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.i
@@ -16347,6 +16347,10 @@ int wake_up_process(struct task_struct *arg0) {
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.i
@@ -15373,6 +15373,10 @@ void tty_wakeup(struct tty_struct *arg0) {
 void unregister_hdlc_device(struct net_device *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.i
@@ -14816,6 +14816,10 @@ void tty_wakeup(struct tty_struct *arg0) {
 void unregister_hdlc_device(struct net_device *arg0) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.i
@@ -8673,6 +8673,10 @@ int __VERIFIER_nondet_int(void);
 int usb_register_driver(struct usb_driver *arg0, struct module *arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -264,3 +264,12 @@ void vcc_insert_socket(struct sock *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -2219,3 +2219,12 @@ void ww_mutex_unlock(struct ww_mutex *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--md--dm-multipath.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--md--dm-multipath.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -608,3 +608,12 @@ void up_write(struct rw_semaphore *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--pci--ivtv--ivtv.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--pci--ivtv--ivtv.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1213,3 +1213,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--mtd--mtd.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--mtd--mtd.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -701,3 +701,12 @@ int unregister_reboot_notifier(struct notifier_block *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -983,3 +983,12 @@ unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned 
   return __VERIFIER_nondet_ulong();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -918,3 +918,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1134,3 +1134,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -710,3 +710,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -812,3 +812,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-crypt.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-crypt.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -716,3 +716,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -943,3 +943,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1143,3 +1143,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -821,3 +821,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1043,3 +1043,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1609,3 +1609,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -706,3 +706,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -974,3 +974,12 @@ unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned 
   return __VERIFIER_nondet_ulong();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -837,3 +837,12 @@ void up_write(struct rw_semaphore *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -917,3 +917,12 @@ void wireless_spy_update(struct net_device *arg0, unsigned char *arg1, struct iw
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--libertas--libertas.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1133,3 +1133,12 @@ void wiphy_unregister(struct wiphy *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -802,3 +802,12 @@ int wake_up_process(struct task_struct *arg0) {
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -3376,3 +3376,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2470,3 +2470,12 @@ void wait_for_completion(struct completion *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -639,3 +639,12 @@ void warn_slowpath_null(const char *arg0, const int arg1) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -924,3 +924,12 @@ void unregister_hdlc_device(struct net_device *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -854,3 +854,12 @@ void unregister_hdlc_device(struct net_device *arg0) {
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -702,3 +702,12 @@ int usb_register_driver(struct usb_driver *arg0, struct module *arg1, const char
   return __VERIFIER_nondet_int();
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-validator-v0.6/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_false-unreach-call.cil.out.i
@@ -7484,6 +7484,10 @@ int usb_submit_urb(struct urb *arg0, gfp_t arg1) {
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-validator-v0.6/model/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -578,3 +578,12 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+

--- a/c/ldv-validator-v0.8/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.i
@@ -7159,6 +7159,10 @@ int usb_submit_urb(struct urb *arg0, gfp_t arg1) {
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;
 }
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  return __VERIFIER_nondet_int();
+}
 void *__VERIFIER_external_alloc(void);
 void *external_alloc(void) {
   return __VERIFIER_external_alloc();

--- a/c/ldv-validator-v0.8/model/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -533,3 +533,12 @@ void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) 
   return;
 }
 
+// Function: default_wake_function
+// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
+// with return type: int
+int __VERIFIER_nondet_int(void);
+int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
+  // Simple type
+  return __VERIFIER_nondet_int();
+}
+


### PR DESCRIPTION
The address of this function is being taken, and it might get invoked via a
function pointer. Fixed using:

````bash

set -e

for f in $(git grep -l 'extern int default_wake_function' */*.c)
do
  echo $f
  dn=$(dirname $f)
  bn=$(basename $f .c)
  if [ -d $dn/model ]
  then
    if git grep -q "default_wake_function" $dn/model/$bn.env.c
    then
      continue
    fi
    cat >> $dn/model/$bn.env.c <<EOF
// Function: default_wake_function
// with type: int default_wake_function(wait_queue_t *, unsigned int, int, void *)
// with return type: int
int __VERIFIER_nondet_int(void);
int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {
  // Simple type
  return __VERIFIER_nondet_int();
}

EOF
    cd $dn
    gcc -I model -E -P $bn.c -o $bn.i
    cd ..
  else
    echo "No model dir in $dn"
  fi
done
````

This is the third commit from #741.