### PR TITLE
Whitespace change only: fix preprocessing difference

### DIFF
--- a/c/ldv-commit-tester/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-1.i
+++ b/c/ldv-commit-tester/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-1.i
@@ -3515,7 +3515,7 @@ int usb_gadget_get_string(struct usb_gadget_strings *table , int id , u8 *buf )
   return ((int )*buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int usb_descriptor_fillbuf(void *buf , unsigned int buflen , struct usb_descriptor_header const **src )
 {
   u8 *dest ;

--- a/c/ldv-commit-tester/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.i
+++ b/c/ldv-commit-tester/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.i
@@ -3515,7 +3515,7 @@ int usb_gadget_get_string(struct usb_gadget_strings *table , int id , u8 *buf )
   return ((int )*buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int usb_descriptor_fillbuf(void *buf , unsigned int buflen , struct usb_descriptor_header const **src )
 {
   u8 *dest ;

--- a/c/ldv-commit-tester/m0_true-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.i
+++ b/c/ldv-commit-tester/m0_true-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.i
@@ -3515,7 +3515,7 @@ int usb_gadget_get_string(struct usb_gadget_strings *table , int id , u8 *buf )
   return ((int )*buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int usb_descriptor_fillbuf(void *buf , unsigned int buflen , struct usb_descriptor_header const **src )
 {
   u8 *dest ;

--- a/c/ldv-commit-tester/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
+++ b/c/ldv-commit-tester/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
@@ -8025,7 +8025,7 @@ __inline static void mux_init(struct oprofile_operations *ops )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mux_clone(int cpu )
 {
   int tmp ;

--- a/c/ldv-commit-tester/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
+++ b/c/ldv-commit-tester/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
@@ -8040,7 +8040,7 @@ __inline static void mux_init(struct oprofile_operations *ops )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mux_clone(int cpu )
 {
   int tmp ;

--- a/c/ldv-commit-tester/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
+++ b/c/ldv-commit-tester/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
@@ -8025,7 +8025,7 @@ __inline static void mux_init(struct oprofile_operations *ops )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mux_clone(int cpu )
 {
   int tmp ;

--- a/c/ldv-commit-tester/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
+++ b/c/ldv-commit-tester/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
@@ -8040,7 +8040,7 @@ __inline static void mux_init(struct oprofile_operations *ops )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mux_clone(int cpu )
 {
   int tmp ;

--- a/c/ldv-consumption/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--media--usb--cpia2--cpia2.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--media--usb--cpia2--cpia2.ko-main.cil.out.i
@@ -5558,7 +5558,7 @@ static int cpia2_s_ctrl(struct v4l2_ctrl *ctrl )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int cpia2_g_jpegcomp(struct file *file , void *fh , struct v4l2_jpegcompression *parms )
 { struct camera_data *cam ;
   void *tmp ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
@@ -8151,7 +8151,7 @@ extern unsigned int ioread32(void * ) ;
 extern void iowrite32(u32 , void * ) ;
 extern void *vmap(struct page ** , unsigned int , unsigned long , pgprot_t ) ;
 extern void vunmap(void const * ) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 {
   size_t __len ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--misc--sgi-xp--xpc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--misc--sgi-xp--xpc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -9289,7 +9289,7 @@ static void xpc_handle_notify_mq_ack_uv(struct xpc_channel *ch , struct xpc_noti
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void xpc_handle_notify_mq_msg_uv(struct xpc_partition *part , struct xpc_notify_mq_msg_uv *msg )
 {
   struct xpc_partition_uv *part_uv ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--mmc--host--sdhci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--mmc--host--sdhci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5030,7 +5030,7 @@ static void sdhci_set_adma_desc(u8 *desc , u32 addr , int len , unsigned int cmd
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sdhci_adma_table_pre(struct sdhci_host *host , struct mmc_data *data )
 {
   int direction ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--tty--mxser.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--tty--mxser.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4702,7 +4702,7 @@ static void mxser_close(struct tty_struct *tty , struct file *filp )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int mxser_write(struct tty_struct *tty , unsigned char const *buf , int count )
 {
   int c ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-sound--core--snd-rawmidi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-sound--core--snd-rawmidi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4651,7 +4651,7 @@ static int snd_rawmidi_control_ioctl(struct snd_card *card , struct snd_ctl_file
   return (-515);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int snd_rawmidi_receive(struct snd_rawmidi_substream *substream , unsigned char const *buffer ,
                         int count )
 {

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--firewire--firedtv.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--firewire--firedtv.ko-main.cil.out.i
@@ -6131,7 +6131,7 @@ static bool is_register_rc(struct avc_response_frame *r )
   return ((bool )(((((unsigned int )r->opcode == 0U && (unsigned int )r->operand[0] == 0U) && (unsigned int )r->operand[1] == 18U) && (unsigned int )r->operand[2] == 135U) && (unsigned int )r->operand[3] == 10U));
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int avc_recv(struct firedtv *fdtv , void *data , size_t length )
 { struct avc_response_frame *r ;
   long tmp ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--sgi-xp--xpc.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--sgi-xp--xpc.ko-main.cil.out.i
@@ -9286,7 +9286,7 @@ static void xpc_handle_notify_mq_ack_uv(struct xpc_channel *ch , struct xpc_noti
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void xpc_handle_notify_mq_msg_uv(struct xpc_partition *part , struct xpc_notify_mq_msg_uv *msg )
 { struct xpc_partition_uv *part_uv ;
   struct xpc_channel *ch ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.i
@@ -7502,7 +7502,7 @@ int vhost_vq_access_ok(struct vhost_virtqueue *vq )
   return (tmp___9);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static bool __warned___25 ;
 static long vhost_set_memory(struct vhost_dev *d , struct vhost_memory *m )
 { struct vhost_memory mem ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point_false-unreach-call.cil.out.i
@@ -5546,7 +5546,7 @@ static int stk_initialise(struct stk_camera *dev )
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void stk_isoc_handler(struct urb *urb )
 {
   int i ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--usb--serial--mos7840.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--usb--serial--mos7840.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -9539,7 +9539,7 @@ static int mos7840_write_room(struct tty_struct *tty )
   return (room);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static bool __print_once ;
 static bool __print_once___0 ;
 static int mos7840_write(struct tty_struct *tty , struct usb_serial_port *port , unsigned char const *data ,

--- a/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--input--mousedev_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--input--mousedev_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7325,7 +7325,7 @@ static ssize_t mousedev_write(struct file *file , char *buffer , size_t count ,
   return ((ssize_t )count);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ssize_t mousedev_read(struct file *file , char *buffer , size_t count , loff_t *ppos )
 { struct mousedev_client *client ;
   struct mousedev *mousedev ;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--vhost--vhost_net.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--vhost--vhost_net.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -9729,7 +9729,7 @@ int vhost_vq_access_ok(struct vhost_virtqueue *vq )
   return (tmp___9);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static long vhost_set_memory(struct vhost_dev *d , struct vhost_memory *m )
 { struct vhost_memory mem ;
   struct vhost_memory *newmem ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--misc--sgi-xp--xpc.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--misc--sgi-xp--xpc.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -18533,7 +18533,7 @@ static void xpc_handle_notify_mq_ack_uv(struct xpc_channel *ch , struct xpc_noti
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void xpc_handle_notify_mq_msg_uv(struct xpc_partition *part , struct xpc_notify_mq_msg_uv *msg )
 { struct xpc_partition_uv *part_uv ;
   struct xpc_channel *ch ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--mos7840_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--mos7840_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -9251,7 +9251,7 @@ static int mos7840_write_room(struct tty_struct *tty )
   return (room);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int mos7840_write(struct tty_struct *tty , struct usb_serial_port *port , unsigned char const *data ,
                          int count )
 { int status ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--raid456.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--md--raid456.ko-entry_point_true-unreach-call.cil.out.i
@@ -4723,7 +4723,7 @@ struct raid5_plug_cb {
    struct list_head list ;
    struct list_head temp_inactive_list[8U] ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef bool ldv_func_ret_type;
 typedef bool ldv_func_ret_type___0;
 typedef bool ldv_func_ret_type___1;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--raid456.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--raid456.ko-entry_point_false-unreach-call.cil.out.i
@@ -4650,7 +4650,7 @@ struct raid5_plug_cb {
    struct list_head list ;
    struct list_head temp_inactive_list[8U] ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef bool ldv_func_ret_type;
 typedef bool ldv_func_ret_type___0;
 typedef bool ldv_func_ret_type___1;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point_true-unreach-call.cil.out.i
@@ -4723,7 +4723,7 @@ struct raid5_plug_cb {
    struct list_head list ;
    struct list_head temp_inactive_list[8U] ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef bool ldv_func_ret_type___2;
 typedef bool ldv_func_ret_type___3;
 typedef bool ldv_func_ret_type___4;

--- a/c/ldv-validator-v0.6/linux-stable-2b9ec6c-1-106_1a-drivers--usb--gadget--g_printer.ko-entry_point_false-unreach-call.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-2b9ec6c-1-106_1a-drivers--usb--gadget--g_printer.ko-entry_point_false-unreach-call.cil.out.i
@@ -3608,7 +3608,7 @@ int usb_gadget_get_string(struct usb_gadget_strings *table , int id , u8 *buf )
   return ((int )*buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int usb_descriptor_fillbuf(void *buf , unsigned int buflen , struct usb_descriptor_header const **src )
 {
   u8 *dest ;

--- a/c/ldv-validator-v0.8/linux-stable-2b9ec6c-1-106_1a-drivers--usb--gadget--g_printer.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-2b9ec6c-1-106_1a-drivers--usb--gadget--g_printer.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.i
@@ -3364,7 +3364,7 @@ int usb_gadget_get_string(struct usb_gadget_strings *table , int id , u8 *buf )
   return ((int )*buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 int usb_descriptor_fillbuf(void *buf , unsigned int buflen , struct usb_descriptor_header const **src )
 {
   u8 *dest ;


### PR DESCRIPTION
Running gcc -E -P had resulted in files with whitespace differences. No changes
other than whitespace in memcpy declarations in this commit.

This is just cleanup to make sure future PRs are not polluted with whitespace changes.