### PR TITLE
Replace all uses of memcpy by memmove where CBMC reports a violation

### DIFF
--- a/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
+++ b/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
@@ -3834,7 +3834,7 @@ long ldv__builtin_expect(long exp , long c ) ;
 extern int printk(char const   *  , ...) ;
 extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , ...) ;
 extern void might_fault(void) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 unsigned long strlen(char const   *str ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;
@@ -4148,7 +4148,7 @@ static int si4713_send_command(struct si4713_device *sdev , u8 const   command ,
   }
   data1[0] = command;
   __len = (size_t )argn;
-  __ret = memcpy((void *)(& data1) + 1U, (void const   *)args, __len);
+  __ret = memmove((void *)(& data1) + 1U, (void const   *)args, __len);
   err = i2c_master_send((struct i2c_client  const  *)client, (char const   *)(& data1),
                         (int )argn + 1);
   if ((int )argn + 1 != err) {
@@ -5200,9 +5200,9 @@ static int si4713_setup(struct si4713_device *sdev )
   mutex_lock_nested(& sdev->mutex, 0U);
   __len = 2616UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)tmp, (void const   *)sdev, __len);
+    __ret = memmove((void *)tmp, (void const   *)sdev, __len);
   } else {
-    __ret = memcpy((void *)tmp, (void const   *)sdev, __len);
+    __ret = memmove((void *)tmp, (void const   *)sdev, __len);
   }
   mutex_unlock(& sdev->mutex);
   ctrl.id = 10160386U;

--- a/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
+++ b/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
@@ -3828,7 +3828,7 @@ long ldv__builtin_expect(long exp , long c ) ;
 extern int printk(char const * , ...) ;
 extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
 extern void might_fault(void) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 unsigned long strlen(char const *str ) ;
 extern char *strncpy(char * , char const * , __kernel_size_t ) ;
@@ -4115,7 +4115,7 @@ static int si4713_send_command(struct si4713_device *sdev , u8 const command , u
   }
   data1[0] = command;
   __len = (size_t )argn;
-  __ret = memcpy((void *)(& data1) + 1U, (void const *)args, __len);
+  __ret = memmove((void *)(& data1) + 1U, (void const *)args, __len);
   err = i2c_master_send((struct i2c_client const *)client, (char const *)(& data1),
                         (int )argn + 1);
   if ((int )argn + 1 != err) {
@@ -5062,9 +5062,9 @@ static int si4713_setup(struct si4713_device *sdev )
   mutex_lock_nested(& sdev->mutex, 0U);
   __len = 2616UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)tmp, (void const *)sdev, __len);
+    __ret = memmove((void *)tmp, (void const *)sdev, __len);
   } else {
-    __ret = memcpy((void *)tmp, (void const *)sdev, __len);
+    __ret = memmove((void *)tmp, (void const *)sdev, __len);
   }
   mutex_unlock(& sdev->mutex);
   ctrl.id = 10160386U;

--- a/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.c
+++ b/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.c
@@ -6082,7 +6082,7 @@ __inline static int list_empty(struct list_head  const  *head )
   return ((unsigned long )((struct list_head  const  *)head->next) == (unsigned long )head);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int bitmap_find_free_region(unsigned long * , int  , int  ) ;
 extern void bitmap_release_region(unsigned long * , int  , int  ) ;
@@ -6621,9 +6621,9 @@ __inline static void SET_IEEE80211_PERM_ADDR(struct ieee80211_hw *hw , u8 *addr 
   {
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, __len);
+    __ret = memmove((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr, __len);
   } else {
-    __ret = memcpy((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr,
+    __ret = memmove((void *)(& (hw->wiphy)->perm_addr), (void const   *)addr,
                              __len);
   }
   return;
@@ -7590,9 +7590,9 @@ static int carl9170_init_interface(struct ar9170 *ar , struct ieee80211_vif *vif
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& common->macaddr), (void const   *)(& vif->addr), __len);
+    __ret = memmove((void *)(& common->macaddr), (void const   *)(& vif->addr), __len);
   } else {
-    __ret = memcpy((void *)(& common->macaddr), (void const   *)(& vif->addr),
+    __ret = memmove((void *)(& common->macaddr), (void const   *)(& vif->addr),
                              __len);
   }
   if (modparam_nohwcrypt != 0 || ((unsigned int )vif->type != 2U && (unsigned int )vif->type != 3U)) {
@@ -8287,10 +8287,10 @@ static void carl9170_op_bss_info_changed(struct ieee80211_hw *hw , struct ieee80
   if ((changed & 128U) != 0U) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& common->curbssid), (void const   *)bss_conf->bssid,
+      __ret = memmove((void *)(& common->curbssid), (void const   *)bss_conf->bssid,
                        __len);
     } else {
-      __ret = memcpy((void *)(& common->curbssid), (void const   *)bss_conf->bssid,
+      __ret = memmove((void *)(& common->curbssid), (void const   *)bss_conf->bssid,
                                __len);
     }
     err = carl9170_set_operating_mode(ar);
@@ -8674,10 +8674,10 @@ static int carl9170_op_conf_tx(struct ieee80211_hw *hw , u16 queue , struct ieee
   if ((int )(ar->hw)->queues > (int )queue) {
     __len = 8UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
+      __ret = memmove((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
                        (void const   *)param, __len);
     } else {
-      __ret = memcpy((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
+      __ret = memmove((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
                                (void const   *)param, __len);
     }
     ret = carl9170_set_qos(ar);
@@ -11126,7 +11126,7 @@ int carl9170_exec_cmd(struct ar9170 *ar , enum carl9170_cmd_oids  const  cmd , u
   ar->ldv_39847.cmd.hdr.ldv_39068.ldv_39066.cmd = (u8 )cmd;
   if (plen != 0U && (unsigned long )((void *)(& ar->ldv_39847.cmd.ldv_39082.data)) != (unsigned long )payload) {
     __len = (size_t )plen;
-    __ret = memcpy((void *)(& ar->ldv_39847.cmd.ldv_39082.data), (void const   *)payload,
+    __ret = memmove((void *)(& ar->ldv_39847.cmd.ldv_39082.data), (void const   *)payload,
                              __len);
   } else {
 
@@ -11300,7 +11300,7 @@ static int carl9170_usb_load_firmware(struct ar9170 *ar )
   __min2 = 4096U;
   transfer = __min1 < __min2 ? __min1 : __min2;
   __len = (size_t )transfer;
-  __ret = memcpy((void *)buf, (void const   *)data, __len);
+  __ret = memmove((void *)buf, (void const   *)data, __len);
   tmp___0 = __create_pipe(ar->udev, 0U);
   err = usb_control_msg(ar->udev, tmp___0 | 2147483648U, 48, 64, (int )((__u16 )(addr >> 8)),
                         0, (void *)buf, (int )((__u16 )transfer), 100);
@@ -14073,13 +14073,13 @@ int carl9170_upload_key(struct ar9170 *ar , u8 const   id , u8 const   *mac , u8
   key.type = (unsigned short )ktype;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& key.macAddr), (void const   *)mac, __len);
+    __ret = memmove((void *)(& key.macAddr), (void const   *)mac, __len);
   } else {
-    __ret = memcpy((void *)(& key.macAddr), (void const   *)mac, __len);
+    __ret = memmove((void *)(& key.macAddr), (void const   *)mac, __len);
   }
   if ((unsigned long )keydata != (unsigned long )((u8 const   *)0)) {
     __len___0 = (size_t )keylen;
-    __ret___0 = memcpy((void *)(& key.key), (void const   *)keydata, __len___0);
+    __ret___0 = memmove((void *)(& key.key), (void const   *)keydata, __len___0);
   } else {
 
   }
@@ -20536,7 +20536,7 @@ static void carl9170_cmd_callback(struct ar9170 *ar , u32 len , void *buffer )
   if ((unsigned long )ar->readbuf != (unsigned long )((u8 *)0)) {
     if (len > 3U) {
       __len = (size_t )(len - 4U);
-      __ret = memcpy((void *)ar->readbuf, (void const   *)buffer + 4U, __len);
+      __ret = memmove((void *)ar->readbuf, (void const   *)buffer + 4U, __len);
     } else {
 
     }
@@ -20970,7 +20970,7 @@ static struct sk_buff *carl9170_rx_copy_data(u8 *buf , int len )
     skb_reserve(skb, reserved);
     __len = (size_t )len;
     tmp___3 = skb_put(skb, (unsigned int )len);
-    __ret = memcpy((void *)tmp___3, (void const   *)buf, __len);
+    __ret = memmove((void *)tmp___3, (void const   *)buf, __len);
   } else {
 
   }
@@ -21208,9 +21208,9 @@ static void carl9170_handle_mpdu(struct ar9170 *ar , u8 *buf , int len )
     head = (struct ar9170_rx_head *)buf;
     __len = 12UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& ar->rx_plcp), (void const   *)buf, __len);
+      __ret = memmove((void *)(& ar->rx_plcp), (void const   *)buf, __len);
     } else {
-      __ret = memcpy((void *)(& ar->rx_plcp), (void const   *)buf, __len);
+      __ret = memmove((void *)(& ar->rx_plcp), (void const   *)buf, __len);
     }
     mpdu_len = (int )((unsigned int )mpdu_len - 12U);
     buf = buf + 12UL;
@@ -21310,10 +21310,10 @@ static void carl9170_handle_mpdu(struct ar9170 *ar , u8 *buf , int len )
   __len___0 = 40UL;
   if (__len___0 > 63UL) {
     tmp___11 = IEEE80211_SKB_RXCB(skb);
-    __ret___0 = memcpy((void *)tmp___11, (void const   *)(& status), __len___0);
+    __ret___0 = memmove((void *)tmp___11, (void const   *)(& status), __len___0);
   } else {
     tmp___12 = IEEE80211_SKB_RXCB(skb);
-    __ret___0 = memcpy((void *)tmp___12, (void const   *)(& status), __len___0);
+    __ret___0 = memmove((void *)tmp___12, (void const   *)(& status), __len___0);
   }
   ieee80211_rx(ar->hw, skb);
   return;
@@ -21452,7 +21452,7 @@ static void carl9170_rx_stream(struct ar9170 *ar , void *buf , unsigned int len 
     }
     __len = (size_t )tlen;
     tmp___2 = skb_put(ar->rx_failover, tlen);
-    __ret = memcpy((void *)tmp___2, (void const   *)tbuf, __len);
+    __ret = memmove((void *)tmp___2, (void const   *)tbuf, __len);
     ar->rx_failover_missing = (int )((unsigned int )ar->rx_failover_missing - tlen);
     if (ar->rx_failover_missing <= 0) {
       ar->rx_failover_missing = 0;
@@ -21480,7 +21480,7 @@ static void carl9170_rx_stream(struct ar9170 *ar , void *buf , unsigned int len 
     }
     __len___0 = (size_t )tlen;
     tmp___5 = skb_put(ar->rx_failover, tlen);
-    __ret___0 = memcpy((void *)tmp___5, (void const   *)tbuf, __len___0);
+    __ret___0 = memmove((void *)tmp___5, (void const   *)tbuf, __len___0);
     ar->rx_failover_missing = (int )(clen - tlen);
     return;
   } else {

--- a/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
+++ b/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
@@ -6064,7 +6064,7 @@ __inline static int list_empty(struct list_head const *head )
   return ((unsigned long )((struct list_head const *)head->next) == (unsigned long )head);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern int bitmap_find_free_region(unsigned long * , int , int ) ;
 extern void bitmap_release_region(unsigned long * , int , int ) ;
@@ -6533,9 +6533,9 @@ __inline static void SET_IEEE80211_PERM_ADDR(struct ieee80211_hw *hw , u8 *addr 
   {
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (hw->wiphy)->perm_addr), (void const *)addr, __len);
+    __ret = memmove((void *)(& (hw->wiphy)->perm_addr), (void const *)addr, __len);
   } else {
-    __ret = memcpy((void *)(& (hw->wiphy)->perm_addr), (void const *)addr,
+    __ret = memmove((void *)(& (hw->wiphy)->perm_addr), (void const *)addr,
                              __len);
   }
   return;
@@ -7421,9 +7421,9 @@ static int carl9170_init_interface(struct ar9170 *ar , struct ieee80211_vif *vif
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& common->macaddr), (void const *)(& vif->addr), __len);
+    __ret = memmove((void *)(& common->macaddr), (void const *)(& vif->addr), __len);
   } else {
-    __ret = memcpy((void *)(& common->macaddr), (void const *)(& vif->addr),
+    __ret = memmove((void *)(& common->macaddr), (void const *)(& vif->addr),
                              __len);
   }
   if (modparam_nohwcrypt != 0 || ((unsigned int )vif->type != 2U && (unsigned int )vif->type != 3U)) {
@@ -8039,10 +8039,10 @@ static void carl9170_op_bss_info_changed(struct ieee80211_hw *hw , struct ieee80
   if ((changed & 128U) != 0U) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& common->curbssid), (void const *)bss_conf->bssid,
+      __ret = memmove((void *)(& common->curbssid), (void const *)bss_conf->bssid,
                        __len);
     } else {
-      __ret = memcpy((void *)(& common->curbssid), (void const *)bss_conf->bssid,
+      __ret = memmove((void *)(& common->curbssid), (void const *)bss_conf->bssid,
                                __len);
     }
     err = carl9170_set_operating_mode(ar);
@@ -8381,10 +8381,10 @@ static int carl9170_op_conf_tx(struct ieee80211_hw *hw , u16 queue , struct ieee
   if ((int )(ar->hw)->queues > (int )queue) {
     __len = 8UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
+      __ret = memmove((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
                        (void const *)param, __len);
     } else {
-      __ret = memcpy((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
+      __ret = memmove((void *)(& ar->edcf) + (unsigned long )ar9170_qmap[(int )queue],
                                (void const *)param, __len);
     }
     ret = carl9170_set_qos(ar);
@@ -10574,7 +10574,7 @@ int carl9170_exec_cmd(struct ar9170 *ar , enum carl9170_cmd_oids const cmd , uns
   ar->ldv_39847.cmd.hdr.ldv_39068.ldv_39066.cmd = (u8 )cmd;
   if (plen != 0U && (unsigned long )((void *)(& ar->ldv_39847.cmd.ldv_39082.data)) != (unsigned long )payload) {
     __len = (size_t )plen;
-    __ret = memcpy((void *)(& ar->ldv_39847.cmd.ldv_39082.data), (void const *)payload,
+    __ret = memmove((void *)(& ar->ldv_39847.cmd.ldv_39082.data), (void const *)payload,
                              __len);
   } else {
   }
@@ -10731,7 +10731,7 @@ static int carl9170_usb_load_firmware(struct ar9170 *ar )
   __min2 = 4096U;
   transfer = __min1 < __min2 ? __min1 : __min2;
   __len = (size_t )transfer;
-  __ret = memcpy((void *)buf, (void const *)data, __len);
+  __ret = memmove((void *)buf, (void const *)data, __len);
   tmp___0 = __create_pipe(ar->udev, 0U);
   err = usb_control_msg(ar->udev, tmp___0 | 2147483648U, 48, 64, (int )((__u16 )(addr >> 8)),
                         0, (void *)buf, (int )((__u16 )transfer), 100);
@@ -13210,13 +13210,13 @@ int carl9170_upload_key(struct ar9170 *ar , u8 const id , u8 const *mac , u8 con
   key.type = (unsigned short )ktype;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& key.macAddr), (void const *)mac, __len);
+    __ret = memmove((void *)(& key.macAddr), (void const *)mac, __len);
   } else {
-    __ret = memcpy((void *)(& key.macAddr), (void const *)mac, __len);
+    __ret = memmove((void *)(& key.macAddr), (void const *)mac, __len);
   }
   if ((unsigned long )keydata != (unsigned long )((u8 const *)0)) {
     __len___0 = (size_t )keylen;
-    __ret___0 = memcpy((void *)(& key.key), (void const *)keydata, __len___0);
+    __ret___0 = memmove((void *)(& key.key), (void const *)keydata, __len___0);
   } else {
   }
   tmp = carl9170_exec_cmd(ar, 16, 28U, (void *)(& key), 0U, 0);
@@ -19046,7 +19046,7 @@ static void carl9170_cmd_callback(struct ar9170 *ar , u32 len , void *buffer )
   if ((unsigned long )ar->readbuf != (unsigned long )((u8 *)0)) {
     if (len > 3U) {
       __len = (size_t )(len - 4U);
-      __ret = memcpy((void *)ar->readbuf, (void const *)buffer + 4U, __len);
+      __ret = memmove((void *)ar->readbuf, (void const *)buffer + 4U, __len);
     } else {
     }
     ar->readbuf = 0;
@@ -19438,7 +19438,7 @@ static struct sk_buff *carl9170_rx_copy_data(u8 *buf , int len )
     skb_reserve(skb, reserved);
     __len = (size_t )len;
     tmp___3 = skb_put(skb, (unsigned int )len);
-    __ret = memcpy((void *)tmp___3, (void const *)buf, __len);
+    __ret = memmove((void *)tmp___3, (void const *)buf, __len);
   } else {
   }
   return (skb);
@@ -19650,9 +19650,9 @@ static void carl9170_handle_mpdu(struct ar9170 *ar , u8 *buf , int len )
     head = (struct ar9170_rx_head *)buf;
     __len = 12UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& ar->rx_plcp), (void const *)buf, __len);
+      __ret = memmove((void *)(& ar->rx_plcp), (void const *)buf, __len);
     } else {
-      __ret = memcpy((void *)(& ar->rx_plcp), (void const *)buf, __len);
+      __ret = memmove((void *)(& ar->rx_plcp), (void const *)buf, __len);
     }
     mpdu_len = (int )((unsigned int )mpdu_len - 12U);
     buf = buf + 12UL;
@@ -19743,10 +19743,10 @@ static void carl9170_handle_mpdu(struct ar9170 *ar , u8 *buf , int len )
   __len___0 = 40UL;
   if (__len___0 > 63UL) {
     tmp___11 = IEEE80211_SKB_RXCB(skb);
-    __ret___0 = memcpy((void *)tmp___11, (void const *)(& status), __len___0);
+    __ret___0 = memmove((void *)tmp___11, (void const *)(& status), __len___0);
   } else {
     tmp___12 = IEEE80211_SKB_RXCB(skb);
-    __ret___0 = memcpy((void *)tmp___12, (void const *)(& status), __len___0);
+    __ret___0 = memmove((void *)tmp___12, (void const *)(& status), __len___0);
   }
   ieee80211_rx(ar->hw, skb);
   return;
@@ -19873,7 +19873,7 @@ static void carl9170_rx_stream(struct ar9170 *ar , void *buf , unsigned int len 
     }
     __len = (size_t )tlen;
     tmp___2 = skb_put(ar->rx_failover, tlen);
-    __ret = memcpy((void *)tmp___2, (void const *)tbuf, __len);
+    __ret = memmove((void *)tmp___2, (void const *)tbuf, __len);
     ar->rx_failover_missing = (int )((unsigned int )ar->rx_failover_missing - tlen);
     if (ar->rx_failover_missing <= 0) {
       ar->rx_failover_missing = 0;
@@ -19898,7 +19898,7 @@ static void carl9170_rx_stream(struct ar9170 *ar , void *buf , unsigned int len 
     }
     __len___0 = (size_t )tlen;
     tmp___5 = skb_put(ar->rx_failover, tlen);
-    __ret___0 = memcpy((void *)tmp___5, (void const *)tbuf, __len___0);
+    __ret___0 = memmove((void *)tmp___5, (void const *)tbuf, __len___0);
     ar->rx_failover_missing = (int )(clen - tlen);
     return;
   } else {

--- a/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.c
+++ b/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.c
@@ -5759,7 +5759,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
     }
     __len = (size_t )video->prev_left;
-    __ret = memcpy((void *)video->dst, (void const   *)src, __len);
+    __ret = memmove((void *)video->dst, (void const   *)src, __len);
     video->dst = video->dst + (unsigned long )(video->prev_left + video->lines_size);
     src = src + (unsigned long )video->prev_left;
     count = count - (unsigned int )video->prev_left;
@@ -5775,7 +5775,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
   }
   __len___0 = (size_t )video->lines_size;
-  __ret___0 = memcpy((void *)video->dst, (void const   *)src, __len___0);
+  __ret___0 = memmove((void *)video->dst, (void const   *)src, __len___0);
   video->dst = video->dst + (unsigned long )(video->lines_size + video->lines_size);
   src = src + (unsigned long )video->lines_size;
   count = count - (unsigned int )video->lines_size;
@@ -5788,7 +5788,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
   if (count != 0U && (unsigned int )video->lines_size > count) {
     __len___1 = (size_t )count;
-    __ret___1 = memcpy((void *)video->dst, (void const   *)src, __len___1);
+    __ret___1 = memmove((void *)video->dst, (void const   *)src, __len___1);
     video->prev_left = (int )((unsigned int )video->lines_size - count);
     video->dst = video->dst + (unsigned long )count;
   } else {
@@ -5862,7 +5862,7 @@ __inline static void copy_vbi_data(struct vbi_data *vbi , char *src , unsigned i
 
       }
       __len = (size_t )count;
-      __ret = memcpy((void *)buf + (unsigned long )vbi->copied, (void const   *)src,
+      __ret = memmove((void *)buf + (unsigned long )vbi->copied, (void const   *)src,
                                __len);
     } else {
 
@@ -8735,14 +8735,14 @@ __inline static void handle_audio_data(struct urb *urb , int *period_elapsed )
   if ((snd_pcm_uframes_t )(oldptr + (unsigned int )len) >= runtime->buffer_size) {
     cnt = (unsigned int )runtime->buffer_size - oldptr;
     __len = (size_t )(cnt * (unsigned int )stride);
-    __ret = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                              (void const   *)cp, __len);
     __len___0 = (size_t )((unsigned int )(len * stride) - cnt * (unsigned int )stride);
-    __ret___0 = memcpy((void *)runtime->dma_area, (void const   *)cp + (unsigned long )(cnt * (unsigned int )stride),
+    __ret___0 = memmove((void *)runtime->dma_area, (void const   *)cp + (unsigned long )(cnt * (unsigned int )stride),
                                  __len___0);
   } else {
     __len___1 = (size_t )(len * stride);
-    __ret___1 = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret___1 = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                                  (void const   *)cp, __len___1);
   }
   snd_pcm_stream_lock(pa->capture_pcm_substream);
@@ -9145,7 +9145,7 @@ void ldv_mutex_unlock_67(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static int atomic_read(atomic_t const   *v ) 
 { 
@@ -9492,9 +9492,9 @@ static int poseidon_set_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
     }
     __len = 36UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const   *)fep, __len);
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const   *)fep, __len);
     } else {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const   *)fep,
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const   *)fep,
                                __len);
     }
     pd_dvb->bandwidth = bandwidth;
@@ -9559,9 +9559,9 @@ static int poseidon_get_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
   pd_dvb = & pd->dvb_data;
   __len = 36UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
   } else {
-    __ret = memcpy((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
   }
   return (0);
 }
@@ -9988,10 +9988,10 @@ int pd_dvb_usb_device_init(struct poseidon *pd )
   pd_dvb->dvb_fe.demodulator_priv = (void *)pd;
   __len = 752UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
                              __len);
   }
   ret = dvb_register_frontend(& pd_dvb->dvb_adap, & pd_dvb->dvb_fe);
@@ -11582,9 +11582,9 @@ int send_set_req(struct poseidon *pd , u8 cmdid , s32 param , s32 *cmd_status )
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     }
   }
   return (0);
@@ -11768,12 +11768,12 @@ int send_get_req(struct poseidon *pd , u8 cmdid , s32 param , void *buf , s32 *c
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     }
     __len___0 = (size_t )datalen;
-    __ret___0 = memcpy(buf, (void const   *)(& data) + 4U, __len___0);
+    __ret___0 = memmove(buf, (void const   *)(& data) + 4U, __len___0);
   }
   return (0);
 }

--- a/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.i
+++ b/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.i
@@ -5704,7 +5704,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
     } else {
     }
     __len = (size_t )video->prev_left;
-    __ret = memcpy((void *)video->dst, (void const *)src, __len);
+    __ret = memmove((void *)video->dst, (void const *)src, __len);
     video->dst = video->dst + (unsigned long )(video->prev_left + video->lines_size);
     src = src + (unsigned long )video->prev_left;
     count = count - (unsigned int )video->prev_left;
@@ -5718,7 +5718,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
   } else {
   }
   __len___0 = (size_t )video->lines_size;
-  __ret___0 = memcpy((void *)video->dst, (void const *)src, __len___0);
+  __ret___0 = memmove((void *)video->dst, (void const *)src, __len___0);
   video->dst = video->dst + (unsigned long )(video->lines_size + video->lines_size);
   src = src + (unsigned long )video->lines_size;
   count = count - (unsigned int )video->lines_size;
@@ -5729,7 +5729,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
   }
   if (count != 0U && (unsigned int )video->lines_size > count) {
     __len___1 = (size_t )count;
-    __ret___1 = memcpy((void *)video->dst, (void const *)src, __len___1);
+    __ret___1 = memmove((void *)video->dst, (void const *)src, __len___1);
     video->prev_left = (int )((unsigned int )video->lines_size - count);
     video->dst = video->dst + (unsigned long )count;
   } else {
@@ -5795,7 +5795,7 @@ __inline static void copy_vbi_data(struct vbi_data *vbi , char *src , unsigned i
       } else {
       }
       __len = (size_t )count;
-      __ret = memcpy((void *)buf + (unsigned long )vbi->copied, (void const *)src,
+      __ret = memmove((void *)buf + (unsigned long )vbi->copied, (void const *)src,
                                __len);
     } else {
     }
@@ -8381,14 +8381,14 @@ __inline static void handle_audio_data(struct urb *urb , int *period_elapsed )
   if ((snd_pcm_uframes_t )(oldptr + (unsigned int )len) >= runtime->buffer_size) {
     cnt = (unsigned int )runtime->buffer_size - oldptr;
     __len = (size_t )(cnt * (unsigned int )stride);
-    __ret = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                              (void const *)cp, __len);
     __len___0 = (size_t )((unsigned int )(len * stride) - cnt * (unsigned int )stride);
-    __ret___0 = memcpy((void *)runtime->dma_area, (void const *)cp + (unsigned long )(cnt * (unsigned int )stride),
+    __ret___0 = memmove((void *)runtime->dma_area, (void const *)cp + (unsigned long )(cnt * (unsigned int )stride),
                                  __len___0);
   } else {
     __len___1 = (size_t )(len * stride);
-    __ret___1 = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret___1 = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                                  (void const *)cp, __len___1);
   }
   snd_pcm_stream_lock(pa->capture_pcm_substream);
@@ -8743,7 +8743,7 @@ void ldv_mutex_unlock_67(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static int atomic_read(atomic_t const *v )
 {
@@ -9057,9 +9057,9 @@ static int poseidon_set_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
     }
     __len = 36UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const *)fep, __len);
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const *)fep, __len);
     } else {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const *)fep,
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const *)fep,
                                __len);
     }
     pd_dvb->bandwidth = bandwidth;
@@ -9119,9 +9119,9 @@ static int poseidon_get_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
   pd_dvb = & pd->dvb_data;
   __len = 36UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
   } else {
-    __ret = memcpy((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
   }
   return (0);
 }
@@ -9499,10 +9499,10 @@ int pd_dvb_usb_device_init(struct poseidon *pd )
   pd_dvb->dvb_fe.demodulator_priv = (void *)pd;
   __len = 752UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
                              __len);
   }
   ret = dvb_register_frontend(& pd_dvb->dvb_adap, & pd_dvb->dvb_fe);
@@ -10929,9 +10929,9 @@ int send_set_req(struct poseidon *pd , u8 cmdid , s32 param , s32 *cmd_status )
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     }
   }
   return (0);
@@ -11111,12 +11111,12 @@ int send_get_req(struct poseidon *pd , u8 cmdid , s32 param , void *buf , s32 *c
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     }
     __len___0 = (size_t )datalen;
-    __ret___0 = memcpy(buf, (void const *)(& data) + 4U, __len___0);
+    __ret___0 = memmove(buf, (void const *)(& data) + 4U, __len___0);
   }
   return (0);
 }

--- a/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.c
+++ b/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.c
@@ -5758,7 +5758,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
     }
     __len = (size_t )video->prev_left;
-    __ret = memcpy((void *)video->dst, (void const   *)src, __len);
+    __ret = memmove((void *)video->dst, (void const   *)src, __len);
     video->dst = video->dst + (unsigned long )(video->prev_left + video->lines_size);
     src = src + (unsigned long )video->prev_left;
     count = count - (unsigned int )video->prev_left;
@@ -5774,7 +5774,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
   }
   __len___0 = (size_t )video->lines_size;
-  __ret___0 = memcpy((void *)video->dst, (void const   *)src, __len___0);
+  __ret___0 = memmove((void *)video->dst, (void const   *)src, __len___0);
   video->dst = video->dst + (unsigned long )(video->lines_size + video->lines_size);
   src = src + (unsigned long )video->lines_size;
   count = count - (unsigned int )video->lines_size;
@@ -5787,7 +5787,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
 
   if (count != 0U && (unsigned int )video->lines_size > count) {
     __len___1 = (size_t )count;
-    __ret___1 = memcpy((void *)video->dst, (void const   *)src, __len___1);
+    __ret___1 = memmove((void *)video->dst, (void const   *)src, __len___1);
     video->prev_left = (int )((unsigned int )video->lines_size - count);
     video->dst = video->dst + (unsigned long )count;
   } else {
@@ -5861,7 +5861,7 @@ __inline static void copy_vbi_data(struct vbi_data *vbi , char *src , unsigned i
 
       }
       __len = (size_t )count;
-      __ret = memcpy((void *)buf + (unsigned long )vbi->copied, (void const   *)src,
+      __ret = memmove((void *)buf + (unsigned long )vbi->copied, (void const   *)src,
                                __len);
     } else {
 
@@ -8723,14 +8723,14 @@ __inline static void handle_audio_data(struct urb *urb , int *period_elapsed )
   if ((snd_pcm_uframes_t )(oldptr + (unsigned int )len) >= runtime->buffer_size) {
     cnt = (unsigned int )runtime->buffer_size - oldptr;
     __len = (size_t )(cnt * (unsigned int )stride);
-    __ret = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                              (void const   *)cp, __len);
     __len___0 = (size_t )((unsigned int )(len * stride) - cnt * (unsigned int )stride);
-    __ret___0 = memcpy((void *)runtime->dma_area, (void const   *)cp + (unsigned long )(cnt * (unsigned int )stride),
+    __ret___0 = memmove((void *)runtime->dma_area, (void const   *)cp + (unsigned long )(cnt * (unsigned int )stride),
                                  __len___0);
   } else {
     __len___1 = (size_t )(len * stride);
-    __ret___1 = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret___1 = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                                  (void const   *)cp, __len___1);
   }
   snd_pcm_stream_lock(pa->capture_pcm_substream);
@@ -9133,7 +9133,7 @@ void ldv_mutex_unlock_65(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static int atomic_read(atomic_t const   *v ) 
 { 
@@ -9480,9 +9480,9 @@ static int poseidon_set_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
     }
     __len = 36UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const   *)fep, __len);
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const   *)fep, __len);
     } else {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const   *)fep,
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const   *)fep,
                                __len);
     }
     pd_dvb->bandwidth = bandwidth;
@@ -9547,9 +9547,9 @@ static int poseidon_get_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
   pd_dvb = & pd->dvb_data;
   __len = 36UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
   } else {
-    __ret = memcpy((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const   *)(& pd_dvb->fe_param), __len);
   }
   return (0);
 }
@@ -9976,10 +9976,10 @@ int pd_dvb_usb_device_init(struct poseidon *pd )
   pd_dvb->dvb_fe.demodulator_priv = (void *)pd;
   __len = 752UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const   *)(& poseidon_frontend_ops),
                              __len);
   }
   ret = dvb_register_frontend(& pd_dvb->dvb_adap, & pd_dvb->dvb_fe);
@@ -11570,9 +11570,9 @@ int send_set_req(struct poseidon *pd , u8 cmdid , s32 param , s32 *cmd_status )
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     }
   }
   return (0);
@@ -11756,12 +11756,12 @@ int send_get_req(struct poseidon *pd , u8 cmdid , s32 param , void *buf , s32 *c
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const   *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const   *)(& data), __len);
     }
     __len___0 = (size_t )datalen;
-    __ret___0 = memcpy(buf, (void const   *)(& data) + 4U, __len___0);
+    __ret___0 = memmove(buf, (void const   *)(& data) + 4U, __len___0);
   }
   return (0);
 }

--- a/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.i
+++ b/c/ldv-commit-tester/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.i
@@ -5703,7 +5703,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
     } else {
     }
     __len = (size_t )video->prev_left;
-    __ret = memcpy((void *)video->dst, (void const *)src, __len);
+    __ret = memmove((void *)video->dst, (void const *)src, __len);
     video->dst = video->dst + (unsigned long )(video->prev_left + video->lines_size);
     src = src + (unsigned long )video->prev_left;
     count = count - (unsigned int )video->prev_left;
@@ -5717,7 +5717,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
   } else {
   }
   __len___0 = (size_t )video->lines_size;
-  __ret___0 = memcpy((void *)video->dst, (void const *)src, __len___0);
+  __ret___0 = memmove((void *)video->dst, (void const *)src, __len___0);
   video->dst = video->dst + (unsigned long )(video->lines_size + video->lines_size);
   src = src + (unsigned long )video->lines_size;
   count = count - (unsigned int )video->lines_size;
@@ -5728,7 +5728,7 @@ static void copy_video_data(struct video_data *video , char *src , unsigned int 
   }
   if (count != 0U && (unsigned int )video->lines_size > count) {
     __len___1 = (size_t )count;
-    __ret___1 = memcpy((void *)video->dst, (void const *)src, __len___1);
+    __ret___1 = memmove((void *)video->dst, (void const *)src, __len___1);
     video->prev_left = (int )((unsigned int )video->lines_size - count);
     video->dst = video->dst + (unsigned long )count;
   } else {
@@ -5794,7 +5794,7 @@ __inline static void copy_vbi_data(struct vbi_data *vbi , char *src , unsigned i
       } else {
       }
       __len = (size_t )count;
-      __ret = memcpy((void *)buf + (unsigned long )vbi->copied, (void const *)src,
+      __ret = memmove((void *)buf + (unsigned long )vbi->copied, (void const *)src,
                                __len);
     } else {
     }
@@ -8371,14 +8371,14 @@ __inline static void handle_audio_data(struct urb *urb , int *period_elapsed )
   if ((snd_pcm_uframes_t )(oldptr + (unsigned int )len) >= runtime->buffer_size) {
     cnt = (unsigned int )runtime->buffer_size - oldptr;
     __len = (size_t )(cnt * (unsigned int )stride);
-    __ret = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                              (void const *)cp, __len);
     __len___0 = (size_t )((unsigned int )(len * stride) - cnt * (unsigned int )stride);
-    __ret___0 = memcpy((void *)runtime->dma_area, (void const *)cp + (unsigned long )(cnt * (unsigned int )stride),
+    __ret___0 = memmove((void *)runtime->dma_area, (void const *)cp + (unsigned long )(cnt * (unsigned int )stride),
                                  __len___0);
   } else {
     __len___1 = (size_t )(len * stride);
-    __ret___1 = memcpy((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
+    __ret___1 = memmove((void *)runtime->dma_area + (unsigned long )(oldptr * (unsigned int )stride),
                                  (void const *)cp, __len___1);
   }
   snd_pcm_stream_lock(pa->capture_pcm_substream);
@@ -8733,7 +8733,7 @@ void ldv_mutex_unlock_65(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static int atomic_read(atomic_t const *v )
 {
@@ -9047,9 +9047,9 @@ static int poseidon_set_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
     }
     __len = 36UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const *)fep, __len);
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const *)fep, __len);
     } else {
-      __ret = memcpy((void *)(& pd_dvb->fe_param), (void const *)fep,
+      __ret = memmove((void *)(& pd_dvb->fe_param), (void const *)fep,
                                __len);
     }
     pd_dvb->bandwidth = bandwidth;
@@ -9109,9 +9109,9 @@ static int poseidon_get_fe(struct dvb_frontend *fe , struct dvb_frontend_paramet
   pd_dvb = & pd->dvb_data;
   __len = 36UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
   } else {
-    __ret = memcpy((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
+    __ret = memmove((void *)fep, (void const *)(& pd_dvb->fe_param), __len);
   }
   return (0);
 }
@@ -9489,10 +9489,10 @@ int pd_dvb_usb_device_init(struct poseidon *pd )
   pd_dvb->dvb_fe.demodulator_priv = (void *)pd;
   __len = 752UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
+    __ret = memmove((void *)(& pd_dvb->dvb_fe.ops), (void const *)(& poseidon_frontend_ops),
                              __len);
   }
   ret = dvb_register_frontend(& pd_dvb->dvb_adap, & pd_dvb->dvb_fe);
@@ -10919,9 +10919,9 @@ int send_set_req(struct poseidon *pd , u8 cmdid , s32 param , s32 *cmd_status )
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     }
   }
   return (0);
@@ -11101,12 +11101,12 @@ int send_get_req(struct poseidon *pd , u8 cmdid , s32 param , void *buf , s32 *c
   } else {
     __len = 4UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     } else {
-      __ret = memcpy((void *)cmd_status, (void const *)(& data), __len);
+      __ret = memmove((void *)cmd_status, (void const *)(& data), __len);
     }
     __len___0 = (size_t )datalen;
-    __ret___0 = memcpy(buf, (void const *)(& data) + 4U, __len___0);
+    __ret___0 = memmove(buf, (void const *)(& data) + 4U, __len___0);
   }
   return (0);
 }

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.env.c
@@ -200,7 +200,7 @@ void ldv_initialize() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
+++ b/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
@@ -794,7 +794,7 @@ void lockdep_rcu_dereference(const char *arg0, const int arg1) {
 
 // Skip function: memcmp
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
@@ -273,7 +273,7 @@ void lockdep_init_map(struct lockdep_map *arg0, const char *arg1, struct lock_cl
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
@@ -273,7 +273,7 @@ void lockdep_init_map(struct lockdep_map *arg0, const char *arg1, struct lock_cl
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--pci--bt8xx--dst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--pci--bt8xx--dst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3617,7 +3617,7 @@ struct dst_config {
 };
 typedef int ldv_func_ret_type___4;
 extern int printk(char const   *  , ...) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;
@@ -5044,10 +5044,10 @@ static int dst_get_mac(struct dst_state *state )
   memset((void *)(& state->mac_address), 0, 8UL);
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->mac_address), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->mac_address), (void const   *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->mac_address), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->mac_address), (void const   *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5114,10 +5114,10 @@ static int dst_fw_ver(struct dst_state *state )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->fw_version), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->fw_version), (void const   *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->fw_version), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->fw_version), (void const   *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5202,10 +5202,10 @@ static int dst_card_type(struct dst_state *state )
   memset((void *)(& state->card_info), 0, 8UL);
   __len = 7UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->card_info), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->card_info), (void const   *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->card_info), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->card_info), (void const   *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5315,10 +5315,10 @@ static int dst_get_vendor(struct dst_state *state )
   memset((void *)(& state->vendor), 0, 8UL);
   __len = 7UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->vendor), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->vendor), (void const   *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->vendor), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->vendor), (void const   *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5599,10 +5599,10 @@ static int dst_get_tuner_info(struct dst_state *state )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->board_info), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->board_info), (void const   *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->board_info), (void const   *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->board_info), (void const   *)(& state->rxbuffer),
                              __len);
   }
   if ((state->type_flags & 512U) != 0U) {
@@ -6965,12 +6965,12 @@ static int dst_set_diseqc(struct dvb_frontend *fe , struct dvb_diseqc_master_cmd
   }
   if ((unsigned int )cmd->msg_len != 0U && (unsigned int )cmd->msg_len <= 4U) {
     __len = (size_t )cmd->msg_len;
-    __ret = memcpy((void *)(& paket) + 3U, (void const   *)(& cmd->msg),
+    __ret = memmove((void *)(& paket) + 3U, (void const   *)(& cmd->msg),
                              __len);
   } else
   if ((unsigned int )cmd->msg_len == 5U && (state->dst_hw_cap & 8U) != 0U) {
     __len___0 = (size_t )cmd->msg_len;
-    __ret___0 = memcpy((void *)(& paket) + 2U, (void const   *)(& cmd->msg),
+    __ret___0 = memmove((void *)(& paket) + 2U, (void const   *)(& cmd->msg),
                                  __len___0);
   } else {
     return (-22);
@@ -7183,40 +7183,40 @@ static int dst_init(struct dvb_frontend *fe )
   if ((unsigned int )state->dst_type == 0U) {
     __len = 10UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
+      __ret = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
                        __len);
     } else {
-      __ret = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
+      __ret = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
                                __len);
     }
   } else
   if ((unsigned int )state->dst_type == 1U) {
     __len___0 = 10UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
+      __ret___0 = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
                            __len___0);
     } else {
-      __ret___0 = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
+      __ret___0 = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
                                    __len___0);
     }
   } else
   if ((unsigned int )state->dst_type == 2U) {
     __len___1 = 10UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
+      __ret___1 = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
+      __ret___1 = memmove((void *)(& state->tx_tuna), (void const   *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
                                    __len___1);
     }
   } else
   if ((unsigned int )state->dst_type == 3U) {
     __len___2 = 10UL;
     if (__len___2 > 63UL) {
-      __ret___2 = memcpy((void *)(& state->tx_tuna), (void const   *)(& atsc_tuner),
+      __ret___2 = memmove((void *)(& state->tx_tuna), (void const   *)(& atsc_tuner),
                            __len___2);
     } else {
-      __ret___2 = memcpy((void *)(& state->tx_tuna), (void const   *)(& atsc_tuner),
+      __ret___2 = memmove((void *)(& state->tx_tuna), (void const   *)(& atsc_tuner),
                                    __len___2);
     }
   } else {
@@ -7527,40 +7527,40 @@ struct dst_state *dst_attach(struct dst_state *state , struct dvb_adapter *dvb_a
   case 1: 
   __len = 768UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbt_ops),
+    __ret = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbt_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbt_ops),
+    __ret = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbt_ops),
                              __len);
   }
   goto ldv_33077;
   case 2: 
   __len___0 = 768UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbc_ops),
+    __ret___0 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbc_ops),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbc_ops),
+    __ret___0 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbc_ops),
                                  __len___0);
   }
   goto ldv_33077;
   case 0: 
   __len___1 = 768UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbs_ops),
+    __ret___1 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbs_ops),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_dvbs_ops),
+    __ret___1 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_dvbs_ops),
                                  __len___1);
   }
   goto ldv_33077;
   case 3: 
   __len___2 = 768UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_atsc_ops),
+    __ret___2 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_atsc_ops),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& state->frontend.ops), (void const   *)(& dst_atsc_ops),
+    __ret___2 = memmove((void *)(& state->frontend.ops), (void const   *)(& dst_atsc_ops),
                                  __len___2);
   }
   goto ldv_33077;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--pci--bt8xx--dst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--pci--bt8xx--dst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3612,7 +3612,7 @@ struct dst_config {
 };
 typedef int ldv_func_ret_type___4;
 extern int printk(char const * , ...) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern int memcmp(void const * , void const * , size_t ) ;
 extern size_t strlen(char const * ) ;
@@ -4927,10 +4927,10 @@ static int dst_get_mac(struct dst_state *state )
   memset((void *)(& state->mac_address), 0, 8UL);
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->mac_address), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->mac_address), (void const *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->mac_address), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->mac_address), (void const *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -4993,10 +4993,10 @@ static int dst_fw_ver(struct dst_state *state )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->fw_version), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->fw_version), (void const *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->fw_version), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->fw_version), (void const *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5077,10 +5077,10 @@ static int dst_card_type(struct dst_state *state )
   memset((void *)(& state->card_info), 0, 8UL);
   __len = 7UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->card_info), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->card_info), (void const *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->card_info), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->card_info), (void const *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5182,10 +5182,10 @@ static int dst_get_vendor(struct dst_state *state )
   memset((void *)(& state->vendor), 0, 8UL);
   __len = 7UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->vendor), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->vendor), (void const *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->vendor), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->vendor), (void const *)(& state->rxbuffer),
                              __len);
   }
   if (verbose != 0U && verbose != 0U) {
@@ -5446,10 +5446,10 @@ static int dst_get_tuner_info(struct dst_state *state )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->board_info), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->board_info), (void const *)(& state->rxbuffer),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->board_info), (void const *)(& state->rxbuffer),
+    __ret = memmove((void *)(& state->board_info), (void const *)(& state->rxbuffer),
                              __len);
   }
   if ((state->type_flags & 512U) != 0U) {
@@ -6699,12 +6699,12 @@ static int dst_set_diseqc(struct dvb_frontend *fe , struct dvb_diseqc_master_cmd
   }
   if ((unsigned int )cmd->msg_len != 0U && (unsigned int )cmd->msg_len <= 4U) {
     __len = (size_t )cmd->msg_len;
-    __ret = memcpy((void *)(& paket) + 3U, (void const *)(& cmd->msg),
+    __ret = memmove((void *)(& paket) + 3U, (void const *)(& cmd->msg),
                              __len);
   } else
   if ((unsigned int )cmd->msg_len == 5U && (state->dst_hw_cap & 8U) != 0U) {
     __len___0 = (size_t )cmd->msg_len;
-    __ret___0 = memcpy((void *)(& paket) + 2U, (void const *)(& cmd->msg),
+    __ret___0 = memmove((void *)(& paket) + 2U, (void const *)(& cmd->msg),
                                  __len___0);
   } else {
     return (-22);
@@ -6908,40 +6908,40 @@ static int dst_init(struct dvb_frontend *fe )
   if ((unsigned int )state->dst_type == 0U) {
     __len = 10UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
+      __ret = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
                        __len);
     } else {
-      __ret = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
+      __ret = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & sat_tuna_188 : & sat_tuna_204),
                                __len);
     }
   } else
   if ((unsigned int )state->dst_type == 1U) {
     __len___0 = 10UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
+      __ret___0 = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
                            __len___0);
     } else {
-      __ret___0 = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
+      __ret___0 = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & ter_tuna_188 : & ter_tuna_204),
                                    __len___0);
     }
   } else
   if ((unsigned int )state->dst_type == 2U) {
     __len___1 = 10UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
+      __ret___1 = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
+      __ret___1 = memmove((void *)(& state->tx_tuna), (void const *)((state->type_flags & 4096U) != 0U ? & cab_tuna_188 : & cab_tuna_204),
                                    __len___1);
     }
   } else
   if ((unsigned int )state->dst_type == 3U) {
     __len___2 = 10UL;
     if (__len___2 > 63UL) {
-      __ret___2 = memcpy((void *)(& state->tx_tuna), (void const *)(& atsc_tuner),
+      __ret___2 = memmove((void *)(& state->tx_tuna), (void const *)(& atsc_tuner),
                            __len___2);
     } else {
-      __ret___2 = memcpy((void *)(& state->tx_tuna), (void const *)(& atsc_tuner),
+      __ret___2 = memmove((void *)(& state->tx_tuna), (void const *)(& atsc_tuner),
                                    __len___2);
     }
   } else {
@@ -7223,40 +7223,40 @@ struct dst_state *dst_attach(struct dst_state *state , struct dvb_adapter *dvb_a
   case 1:
   __len = 768UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbt_ops),
+    __ret = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbt_ops),
                      __len);
   } else {
-    __ret = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbt_ops),
+    __ret = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbt_ops),
                              __len);
   }
   goto ldv_33077;
   case 2:
   __len___0 = 768UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbc_ops),
+    __ret___0 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbc_ops),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbc_ops),
+    __ret___0 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbc_ops),
                                  __len___0);
   }
   goto ldv_33077;
   case 0:
   __len___1 = 768UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbs_ops),
+    __ret___1 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbs_ops),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_dvbs_ops),
+    __ret___1 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_dvbs_ops),
                                  __len___1);
   }
   goto ldv_33077;
   case 3:
   __len___2 = 768UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_atsc_ops),
+    __ret___2 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_atsc_ops),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& state->frontend.ops), (void const *)(& dst_atsc_ops),
+    __ret___2 = memmove((void *)(& state->frontend.ops), (void const *)(& dst_atsc_ops),
                                  __len___2);
   }
   goto ldv_33077;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--aty--radeonfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--aty--radeonfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3909,7 +3909,7 @@ extern void might_fault(void) ;
 extern int snprintf(char * , size_t  , char const   *  , ...) ;
 extern int oops_in_progress ;
 extern struct pv_irq_ops pv_irq_ops ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern ssize_t memory_read_from_buffer(void * , size_t  , loff_t * , void const   * ,
                                        size_t  ) ;
@@ -5238,9 +5238,9 @@ static int radeonfb_check_var(struct fb_var_screeninfo *var , struct fb_info *in
   v.red.msb_right = v.green.msb_right;
   __len = 160UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)var, (void const   *)(& v), __len);
+    __ret = memmove((void *)var, (void const   *)(& v), __len);
   } else {
-    __ret = memcpy((void *)var, (void const   *)(& v), __len);
+    __ret = memmove((void *)var, (void const   *)(& v), __len);
   }
   return (0);
 }
@@ -6477,9 +6477,9 @@ static int radeonfb_set_par(struct fb_info *info )
   if (rinfo->asleep == 0) {
     __len = 396UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& rinfo->state), (void const   *)newmode, __len);
+      __ret = memmove((void *)(& rinfo->state), (void const   *)newmode, __len);
     } else {
-      __ret = memcpy((void *)(& rinfo->state), (void const   *)newmode,
+      __ret = memmove((void *)(& rinfo->state), (void const   *)newmode,
                                __len);
     }
     radeon_write_mode(rinfo, newmode, 0);
@@ -6925,10 +6925,10 @@ static int radeonfb_pci_register(struct pci_dev *pdev , struct pci_device_id  co
   radeon_save_state(rinfo, & rinfo->init_state);
   __len = 396UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& rinfo->state), (void const   *)(& rinfo->init_state),
+    __ret = memmove((void *)(& rinfo->state), (void const   *)(& rinfo->init_state),
                      __len);
   } else {
-    __ret = memcpy((void *)(& rinfo->state), (void const   *)(& rinfo->init_state),
+    __ret = memmove((void *)(& rinfo->state), (void const   *)(& rinfo->init_state),
                              __len);
   }
   if (default_dynclk < -1) {
@@ -11523,9 +11523,9 @@ int radeon_match_mode(struct radeonfb_info *rinfo , struct fb_var_screeninfo *de
   candidate = 0;
   __len = 160UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dest, (void const   *)src, __len);
+    __ret = memmove((void *)dest, (void const   *)src, __len);
   } else {
-    __ret = memcpy((void *)dest, (void const   *)src, __len);
+    __ret = memmove((void *)dest, (void const   *)src, __len);
   }
   if ((unsigned long )rinfo->mon1_modedb != (unsigned long )((struct fb_videomode *)0)) {
     db = (struct fb_videomode  const  *)rinfo->mon1_modedb;
@@ -11831,9 +11831,9 @@ void radeonfb_fillrect(struct fb_info *info , struct fb_fillrect  const  *region
   vyres = (int )info->var.yres_virtual;
   __len = 24UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& modded), (void const   *)region, __len);
+    __ret = memmove((void *)(& modded), (void const   *)region, __len);
   } else {
-    __ret = memcpy((void *)(& modded), (void const   *)region, __len);
+    __ret = memmove((void *)(& modded), (void const   *)region, __len);
   }
   if (((modded.width == 0U || modded.height == 0U) || modded.dx >= (__u32 )vxres) || modded.dy >= (__u32 )vyres) {
     return;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--aty--radeonfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--aty--radeonfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3904,7 +3904,7 @@ extern void might_fault(void) ;
 extern int snprintf(char * , size_t , char const * , ...) ;
 extern int oops_in_progress ;
 extern struct pv_irq_ops pv_irq_ops ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern size_t strlcpy(char * , char const * , size_t ) ;
 extern ssize_t memory_read_from_buffer(void * , size_t , loff_t * , void const * ,
                                        size_t ) ;
@@ -5141,9 +5141,9 @@ static int radeonfb_check_var(struct fb_var_screeninfo *var , struct fb_info *in
   v.red.msb_right = v.green.msb_right;
   __len = 160UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)var, (void const *)(& v), __len);
+    __ret = memmove((void *)var, (void const *)(& v), __len);
   } else {
-    __ret = memcpy((void *)var, (void const *)(& v), __len);
+    __ret = memmove((void *)var, (void const *)(& v), __len);
   }
   return (0);
 }
@@ -6285,9 +6285,9 @@ static int radeonfb_set_par(struct fb_info *info )
   if (rinfo->asleep == 0) {
     __len = 396UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& rinfo->state), (void const *)newmode, __len);
+      __ret = memmove((void *)(& rinfo->state), (void const *)newmode, __len);
     } else {
-      __ret = memcpy((void *)(& rinfo->state), (void const *)newmode,
+      __ret = memmove((void *)(& rinfo->state), (void const *)newmode,
                                __len);
     }
     radeon_write_mode(rinfo, newmode, 0);
@@ -6702,10 +6702,10 @@ static int radeonfb_pci_register(struct pci_dev *pdev , struct pci_device_id con
   radeon_save_state(rinfo, & rinfo->init_state);
   __len = 396UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& rinfo->state), (void const *)(& rinfo->init_state),
+    __ret = memmove((void *)(& rinfo->state), (void const *)(& rinfo->init_state),
                      __len);
   } else {
-    __ret = memcpy((void *)(& rinfo->state), (void const *)(& rinfo->init_state),
+    __ret = memmove((void *)(& rinfo->state), (void const *)(& rinfo->init_state),
                              __len);
   }
   if (default_dynclk < -1) {
@@ -10924,9 +10924,9 @@ int radeon_match_mode(struct radeonfb_info *rinfo , struct fb_var_screeninfo *de
   candidate = 0;
   __len = 160UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dest, (void const *)src, __len);
+    __ret = memmove((void *)dest, (void const *)src, __len);
   } else {
-    __ret = memcpy((void *)dest, (void const *)src, __len);
+    __ret = memmove((void *)dest, (void const *)src, __len);
   }
   if ((unsigned long )rinfo->mon1_modedb != (unsigned long )((struct fb_videomode *)0)) {
     db = (struct fb_videomode const *)rinfo->mon1_modedb;
@@ -11190,9 +11190,9 @@ void radeonfb_fillrect(struct fb_info *info , struct fb_fillrect const *region )
   vyres = (int )info->var.yres_virtual;
   __len = 24UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& modded), (void const *)region, __len);
+    __ret = memmove((void *)(& modded), (void const *)region, __len);
   } else {
-    __ret = memcpy((void *)(& modded), (void const *)region, __len);
+    __ret = memmove((void *)(& modded), (void const *)region, __len);
   }
   if (((modded.width == 0U || modded.height == 0U) || modded.dx >= (__u32 )vxres) || modded.dy >= (__u32 )vyres) {
     return;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3902,7 +3902,7 @@ __inline static int list_empty(struct list_head  const  *head )
 }
 }
 extern struct pv_cpu_ops pv_cpu_ops ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , ...) ;
@@ -4865,7 +4865,7 @@ static int dlfb_render_hline(struct dlfb_data *dev , struct urb **urb_ptr , char
     back_start = back_start + (unsigned long )offset;
     line_start = line_start + (unsigned long )offset;
     __len = (size_t )byte_width;
-    __ret = memcpy((void *)back_start, (void const   *)line_start, __len);
+    __ret = memmove((void *)back_start, (void const   *)line_start, __len);
   } else {
 
   }
@@ -5612,7 +5612,7 @@ static int dlfb_realloc_framebuffer(struct dlfb_data *dev , struct fb_info *info
     }
     if ((unsigned long )info->screen_base != (unsigned long )((char *)0)) {
       __len = (size_t )old_len;
-      __ret = memcpy((void *)new_fb, (void const   *)old_fb, __len);
+      __ret = memmove((void *)new_fb, (void const   *)old_fb, __len);
       vfree((void const   *)info->screen_base);
     } else {
 
@@ -5726,7 +5726,7 @@ static int dlfb_setup_modes(struct dlfb_data *dev , struct fb_info *info , char 
       fb_edid_to_monspecs((unsigned char *)default_edid, & info->monspecs);
       if (info->monspecs.modedb_len != 0U) {
         __len = default_edid_size;
-        __ret = memcpy((void *)edid, (void const   *)default_edid, __len);
+        __ret = memmove((void *)edid, (void const   *)default_edid, __len);
         dev->edid = edid;
         dev->edid_size = default_edid_size;
         printk("\vudlfb: Using default/backup EDID\n");
@@ -5811,9 +5811,9 @@ static int dlfb_setup_modes(struct dlfb_data *dev , struct fb_info *info , char 
     dlfb_var_color_format(& info->var);
     __len___0 = 80UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)(& info->fix), (void const   *)(& dlfb_fix), __len___0);
+      __ret___0 = memmove((void *)(& info->fix), (void const   *)(& dlfb_fix), __len___0);
     } else {
-      __ret___0 = memcpy((void *)(& info->fix), (void const   *)(& dlfb_fix),
+      __ret___0 = memmove((void *)(& info->fix), (void const   *)(& dlfb_fix),
                                    __len___0);
     }
     info->fix.line_length = info->var.xres * (info->var.bits_per_pixel / 8U);
@@ -5941,7 +5941,7 @@ static ssize_t edid_show(struct file *filp , struct kobject *kobj , struct bin_a
   }
   printk("\016udlfb: sysfs edid copy %p to %p, %d bytes\n", dev->edid, buf, (int )count);
   __len = count;
-  __ret = memcpy((void *)buf, (void const   *)dev->edid, __len);
+  __ret = memmove((void *)buf, (void const   *)dev->edid, __len);
   return ((ssize_t )count);
 }
 }

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3884,7 +3884,7 @@ __inline static int list_empty(struct list_head const *head )
 }
 }
 extern struct pv_cpu_ops pv_cpu_ops ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern int memcmp(void const * , void const * , size_t ) ;
 extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
@@ -4764,7 +4764,7 @@ static int dlfb_render_hline(struct dlfb_data *dev , struct urb **urb_ptr , char
     back_start = back_start + (unsigned long )offset;
     line_start = line_start + (unsigned long )offset;
     __len = (size_t )byte_width;
-    __ret = memcpy((void *)back_start, (void const *)line_start, __len);
+    __ret = memmove((void *)back_start, (void const *)line_start, __len);
   } else {
   }
   goto ldv_30535;
@@ -5437,7 +5437,7 @@ static int dlfb_realloc_framebuffer(struct dlfb_data *dev , struct fb_info *info
     }
     if ((unsigned long )info->screen_base != (unsigned long )((char *)0)) {
       __len = (size_t )old_len;
-      __ret = memcpy((void *)new_fb, (void const *)old_fb, __len);
+      __ret = memmove((void *)new_fb, (void const *)old_fb, __len);
       vfree((void const *)info->screen_base);
     } else {
     }
@@ -5538,7 +5538,7 @@ static int dlfb_setup_modes(struct dlfb_data *dev , struct fb_info *info , char 
       fb_edid_to_monspecs((unsigned char *)default_edid, & info->monspecs);
       if (info->monspecs.modedb_len != 0U) {
         __len = default_edid_size;
-        __ret = memcpy((void *)edid, (void const *)default_edid, __len);
+        __ret = memmove((void *)edid, (void const *)default_edid, __len);
         dev->edid = edid;
         dev->edid_size = default_edid_size;
         printk("\vudlfb: Using default/backup EDID\n");
@@ -5614,9 +5614,9 @@ static int dlfb_setup_modes(struct dlfb_data *dev , struct fb_info *info , char 
     dlfb_var_color_format(& info->var);
     __len___0 = 80UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)(& info->fix), (void const *)(& dlfb_fix), __len___0);
+      __ret___0 = memmove((void *)(& info->fix), (void const *)(& dlfb_fix), __len___0);
     } else {
-      __ret___0 = memcpy((void *)(& info->fix), (void const *)(& dlfb_fix),
+      __ret___0 = memmove((void *)(& info->fix), (void const *)(& dlfb_fix),
                                    __len___0);
     }
     info->fix.line_length = info->var.xres * (info->var.bits_per_pixel / 8U);
@@ -5734,7 +5734,7 @@ static ssize_t edid_show(struct file *filp , struct kobject *kobj , struct bin_a
   }
   printk("\016udlfb: sysfs edid copy %p to %p, %d bytes\n", dev->edid, buf, (int )count);
   __len = count;
-  __ret = memcpy((void *)buf, (void const *)dev->edid, __len);
+  __ret = memmove((void *)buf, (void const *)dev->edid, __len);
   return ((ssize_t )count);
 }
 }

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.c
@@ -9504,7 +9504,7 @@ void ldv_mutex_unlock_68(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern char *strcpy(char * , char const   * ) ;
 int ldv_mutex_trylock_84(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_unlock_82(struct mutex *ldv_func_arg1 ) ;
@@ -9526,7 +9526,7 @@ __inline static void memcpy_toio(void volatile   *dst , void const   *src , size
 
   {
   __len = count;
-  __ret = memcpy((void *)dst, src, __len);
+  __ret = memmove((void *)dst, src, __len);
   return;
 }
 }

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
@@ -9104,7 +9104,7 @@ void ldv_mutex_unlock_68(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern char *strcpy(char * , char const * ) ;
 int ldv_mutex_trylock_84(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_unlock_82(struct mutex *ldv_func_arg1 ) ;
@@ -9125,7 +9125,7 @@ __inline static void memcpy_toio(void volatile *dst , void const *src , size_t c
   void *__ret ;
   {
   __len = count;
-  __ret = memcpy((void *)dst, src, __len);
+  __ret = memmove((void *)dst, src, __len);
   return;
 }
 }

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.c
@@ -6448,7 +6448,7 @@ __inline static struct task_struct *get_current(void)
   return (pfo_ret__);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void *memmove(void * , void const   * , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
@@ -6829,7 +6829,7 @@ __inline static void memcpy_toio(void volatile   *dst , void const   *src , size
 
   {
   __len = count;
-  __ret = memcpy((void *)dst, src, __len);
+  __ret = memmove((void *)dst, src, __len);
   return;
 }
 }
@@ -7268,7 +7268,7 @@ __inline static void skb_copy_from_linear_data(struct sk_buff  const  *skb , voi
 
   {
   __len = (size_t )len;
-  __ret = memcpy(to, (void const   *)skb->data, __len);
+  __ret = memmove(to, (void const   *)skb->data, __len);
   return;
 }
 }
@@ -11199,10 +11199,10 @@ static void notify_wx_assoc_event(struct ipw_priv *priv )
   if ((priv->status & 128U) != 0U) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& wrqu.ap_addr.sa_data), (void const   *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu.ap_addr.sa_data), (void const   *)(& priv->bssid),
                        __len);
     } else {
-      __ret = memcpy((void *)(& wrqu.ap_addr.sa_data), (void const   *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu.ap_addr.sa_data), (void const   *)(& priv->bssid),
                                __len);
     }
   } else {
@@ -11681,7 +11681,7 @@ static int __ipw_send_cmd(struct ipw_priv *priv , struct host_cmd *cmd )
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.cmd = cmd->cmd;
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.len = cmd->len;
     __len = (size_t )cmd->len;
-    __ret = memcpy((void *)(& (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.param),
+    __ret = memmove((void *)(& (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.param),
                              (void const   *)cmd->param, __len);
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->retcode = -1;
   } else {
@@ -12412,9 +12412,9 @@ static void eeprom_parse_mac(struct ipw_priv *priv , u8 *mac )
   {
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)mac, (void const   *)(& priv->eeprom) + 66U, __len);
+    __ret = memmove((void *)mac, (void const   *)(& priv->eeprom) + 66U, __len);
   } else {
-    __ret = memcpy((void *)mac, (void const   *)(& priv->eeprom) + 66U,
+    __ret = memmove((void *)mac, (void const   *)(& priv->eeprom) + 66U,
                              __len);
   }
   return;
@@ -13635,10 +13635,10 @@ static int ipw_load_ucode(struct ipw_priv *priv , u8 *data , size_t len )
     ldv_46794: 
     __len = 26UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& priv->dino_alive), (void const   *)(& response_buffer),
+      __ret = memmove((void *)(& priv->dino_alive), (void const   *)(& response_buffer),
                        __len);
     } else {
-      __ret = memcpy((void *)(& priv->dino_alive), (void const   *)(& response_buffer),
+      __ret = memmove((void *)(& priv->dino_alive), (void const   *)(& response_buffer),
                                __len);
     }
     if ((unsigned int )priv->dino_alive.alive_command == 1U && (unsigned int )priv->dino_alive.ucode_valid == 1U) {
@@ -13793,7 +13793,7 @@ static int ipw_load_firmware(struct ipw_priv *priv , u8 *data , size_t len )
   }
   size = (int )tmp___5;
   __len = (size_t )size;
-  __ret = memcpy(*(virts + (unsigned long )total_nr), (void const   *)start,
+  __ret = memmove(*(virts + (unsigned long )total_nr), (void const   *)start,
                            __len);
   start = start + (unsigned long )size;
   total_nr = total_nr + 1;
@@ -14815,16 +14815,16 @@ static u8 ipw_add_station(struct ipw_priv *priv , u8 *bssid )
   entry.support_mode = 0U;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& entry.mac_addr), (void const   *)bssid, __len);
+    __ret = memmove((void *)(& entry.mac_addr), (void const   *)bssid, __len);
   } else {
-    __ret = memcpy((void *)(& entry.mac_addr), (void const   *)bssid, __len);
+    __ret = memmove((void *)(& entry.mac_addr), (void const   *)bssid, __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& priv->stations) + (unsigned long )i, (void const   *)bssid,
+    __ret___0 = memmove((void *)(& priv->stations) + (unsigned long )i, (void const   *)bssid,
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& priv->stations) + (unsigned long )i, (void const   *)bssid,
+    __ret___0 = memmove((void *)(& priv->stations) + (unsigned long )i, (void const   *)bssid,
                                  __len___0);
   }
   ipw_write_direct(priv, (u32 )((unsigned long )i) * 8U + 3084U, (void *)(& entry),
@@ -15847,20 +15847,20 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
   case 2: 
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
+    __ret = memmove((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
                      __len);
   } else {
-    __ret = memcpy((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
+    __ret = memmove((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
                              __len);
   }
   goto ldv_47149;
   case 1: 
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
+    __ret___0 = memmove((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
+    __ret___0 = memmove((void *)(& (priv->ieee)->bssid), (void const   *)(& priv->bssid),
                                  __len___0);
   }
   priv->num_stations = 0U;
@@ -16338,10 +16338,10 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
     }
     __len___1 = 145UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& priv->last_link_deterioration), (void const   *)x___2,
+      __ret___1 = memmove((void *)(& priv->last_link_deterioration), (void const   *)x___2,
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& priv->last_link_deterioration), (void const   *)x___2,
+      __ret___1 = memmove((void *)(& priv->last_link_deterioration), (void const   *)x___2,
                                    __len___1);
     }
   } else {
@@ -16388,9 +16388,9 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
   if ((unsigned int )size == 104U) {
     __len___2 = 104UL;
     if (__len___2 > 63UL) {
-      __ret___2 = memcpy((void *)(& priv->calib), (void const   *)x___5, __len___2);
+      __ret___2 = memmove((void *)(& priv->calib), (void const   *)x___5, __len___2);
     } else {
-      __ret___2 = memcpy((void *)(& priv->calib), (void const   *)x___5,
+      __ret___2 = memmove((void *)(& priv->calib), (void const   *)x___5,
                                    __len___2);
     }
     if ((ipw_debug_level & 4U) != 0U) {
@@ -16595,7 +16595,7 @@ static int ipw_queue_tx_hcmd(struct ipw_priv *priv , int hcmd , void *buf , int 
   tfd->u.cmd.index = (u8 )hcmd;
   tfd->u.cmd.length = (u8 )len;
   __len = (size_t )len;
-  __ret = memcpy((void *)(& tfd->u.cmd.payload), (void const   *)buf, __len);
+  __ret = memmove((void *)(& tfd->u.cmd.payload), (void const   *)buf, __len);
   q->first_empty = ipw_queue_inc_wrap(q->first_empty, q->n_bd);
   if ((ipw_debug_level & 134217728U) != 0U) {
     tmp___3 = current_thread_info();
@@ -18104,7 +18104,7 @@ static void ipw_adhoc_create(struct ipw_priv *priv , struct libipw_network *netw
   ipw_create_bssid(priv, (u8 *)(& network->bssid));
   network->ssid_len = priv->essid_len;
   __len = (size_t )priv->essid_len;
-  __ret = memcpy((void *)(& network->ssid), (void const   *)(& priv->essid),
+  __ret = memmove((void *)(& network->ssid), (void const   *)(& priv->essid),
                            __len);
   memset((void *)(& network->stats), 0, 32UL);
   network->capability = 2U;
@@ -18127,11 +18127,11 @@ static void ipw_adhoc_create(struct ipw_priv *priv , struct libipw_network *netw
   }
   network->rates_len = (u8 )tmp___3;
   __len___0 = (size_t )network->rates_len;
-  __ret___0 = memcpy((void *)(& network->rates), (void const   *)(& priv->rates.supported_rates),
+  __ret___0 = memmove((void *)(& network->rates), (void const   *)(& priv->rates.supported_rates),
                                __len___0);
   network->rates_ex_len = (int )priv->rates.num_rates - (int )network->rates_len;
   __len___1 = (size_t )network->rates_ex_len;
-  __ret___1 = memcpy((void *)(& network->rates_ex), (void const   *)(& priv->rates.supported_rates) + (unsigned long )network->rates_len,
+  __ret___1 = memmove((void *)(& network->rates_ex), (void const   *)(& priv->rates.supported_rates) + (unsigned long )network->rates_len,
                                __len___1);
   network->last_scanned = 0UL;
   network->flags = 0U;
@@ -18160,10 +18160,10 @@ static void ipw_send_tgi_tx_key(struct ipw_priv *priv , int type , int index )
   key.key_id = (u8 )index;
   __len = 16UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
+    __ret = memmove((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
                      __len);
   } else {
-    __ret = memcpy((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
+    __ret = memmove((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
                              __len);
   }
   key.security_type = (u8 )type;
@@ -18196,7 +18196,7 @@ static void ipw_send_wep_keys(struct ipw_priv *priv , int type )
   }
   key.key_size = (priv->ieee)->sec.key_sizes[i];
   __len = (size_t )key.key_size;
-  __ret = memcpy((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
+  __ret = memmove((void *)(& key.key), (void const   *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
                            __len);
   ipw_send_cmd_pdu(priv, 18, 20, (void *)(& key));
   ldv_47470: 
@@ -19416,7 +19416,7 @@ static int ipw_wx_get_genie(struct net_device *dev , struct iw_request_info *inf
   }
   wrqu->data.length = (__u16 )ieee->wpa_ie_len;
   __len = ieee->wpa_ie_len;
-  __ret = memcpy((void *)extra, (void const   *)ieee->wpa_ie, __len);
+  __ret = memmove((void *)extra, (void const   *)ieee->wpa_ie, __len);
   out: ;
   return (err);
 }
@@ -19871,11 +19871,11 @@ static int ipw_qos_handle_probe_response(struct ipw_priv *priv , int active_netw
   } else {
     if ((priv->ieee)->mode == 2 || (unsigned int )network->mode == 2U) {
       __len = (size_t )size;
-      __ret = memcpy((void *)(& network->qos_data.parameters), (void const   *)(& def_parameters_CCK),
+      __ret = memmove((void *)(& network->qos_data.parameters), (void const   *)(& def_parameters_CCK),
                                __len);
     } else {
       __len___0 = (size_t )size;
-      __ret___0 = memcpy((void *)(& network->qos_data.parameters), (void const   *)(& def_parameters_OFDM),
+      __ret___0 = memmove((void *)(& network->qos_data.parameters), (void const   *)(& def_parameters_OFDM),
                                    __len___0);
     }
     if (network->qos_data.active == 1 && active_network == 1) {
@@ -19962,11 +19962,11 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
   type = ipw_qos_current_mode(priv);
   active_one = (struct libipw_qos_parameters *)(& qos_parameters) + 1UL;
   __len = (size_t )size;
-  __ret = memcpy((void *)active_one, (void const   *)priv->qos_data.def_qos_parm_CCK,
+  __ret = memmove((void *)active_one, (void const   *)priv->qos_data.def_qos_parm_CCK,
                            __len);
   active_one = (struct libipw_qos_parameters *)(& qos_parameters) + 2UL;
   __len___0 = (size_t )size;
-  __ret___0 = memcpy((void *)active_one, (void const   *)priv->qos_data.def_qos_parm_OFDM,
+  __ret___0 = memmove((void *)active_one, (void const   *)priv->qos_data.def_qos_parm_OFDM,
                                __len___0);
   if ((unsigned long )qos_network_data == (unsigned long )((struct libipw_qos_data *)0)) {
     if ((unsigned int )type == 2U) {
@@ -19987,7 +19987,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
       active_one = & def_parameters_OFDM;
     }
     __len___1 = (size_t )size;
-    __ret___1 = memcpy((void *)(& qos_parameters), (void const   *)active_one,
+    __ret___1 = memmove((void *)(& qos_parameters), (void const   *)active_one,
                                  __len___1);
     burst_duration = ipw_qos_get_burst_duration(priv);
     i = 0;
@@ -20029,7 +20029,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
       active_one = priv->qos_data.def_qos_parm_OFDM;
     }
     __len___2 = (size_t )size;
-    __ret___2 = memcpy((void *)(& qos_parameters), (void const   *)active_one,
+    __ret___2 = memmove((void *)(& qos_parameters), (void const   *)active_one,
                                  __len___2);
   } else {
     tmp___5 = spinlock_check(& (priv->ieee)->lock);
@@ -20037,7 +20037,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
     active_one = & qos_network_data->parameters;
     qos_network_data->old_param_count = qos_network_data->param_count;
     __len___3 = (size_t )size;
-    __ret___3 = memcpy((void *)(& qos_parameters), (void const   *)active_one,
+    __ret___3 = memmove((void *)(& qos_parameters), (void const   *)active_one,
                                  __len___3);
     active = qos_network_data->supported;
     spin_unlock_irqrestore(& (priv->ieee)->lock, flags);
@@ -20110,9 +20110,9 @@ static int ipw_qos_set_info_element(struct ipw_priv *priv )
   qos_info.ac_info = 0U;
   __len = 3UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& qos_info.qui), (void const   *)(& qos_oui), __len);
+    __ret = memmove((void *)(& qos_info.qui), (void const   *)(& qos_oui), __len);
   } else {
-    __ret = memcpy((void *)(& qos_info.qui), (void const   *)(& qos_oui),
+    __ret = memmove((void *)(& qos_info.qui), (void const   *)(& qos_oui),
                              __len);
   }
   qos_info.qui_type = 2U;
@@ -20262,10 +20262,10 @@ static int ipw_qos_association_resp(struct ipw_priv *priv , struct libipw_networ
   if ((network->flags & 8U) != 0U) {
     __len = 44UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& (priv->assoc_network)->qos_data), (void const   *)(& network->qos_data),
+      __ret = memmove((void *)(& (priv->assoc_network)->qos_data), (void const   *)(& network->qos_data),
                        __len);
     } else {
-      __ret = memcpy((void *)(& (priv->assoc_network)->qos_data), (void const   *)(& network->qos_data),
+      __ret = memmove((void *)(& (priv->assoc_network)->qos_data), (void const   *)(& network->qos_data),
                                __len);
     }
     (priv->assoc_network)->qos_data.active = 1;
@@ -20278,11 +20278,11 @@ static int ipw_qos_association_resp(struct ipw_priv *priv , struct libipw_networ
   } else {
     if ((unsigned int )network->mode == 2U || (priv->ieee)->mode == 2) {
       __len___0 = (size_t )size;
-      __ret___0 = memcpy((void *)(& (priv->assoc_network)->qos_data.parameters),
+      __ret___0 = memmove((void *)(& (priv->assoc_network)->qos_data.parameters),
                                    (void const   *)(& def_parameters_CCK), __len___0);
     } else {
       __len___1 = (size_t )size;
-      __ret___1 = memcpy((void *)(& (priv->assoc_network)->qos_data.parameters),
+      __ret___1 = memmove((void *)(& (priv->assoc_network)->qos_data.parameters),
                                    (void const   *)(& def_parameters_OFDM), __len___1);
     }
     (priv->assoc_network)->qos_data.active = 0;
@@ -20587,7 +20587,7 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
     }
     priv->essid_len = (u8 )tmp;
     __len = (size_t )priv->essid_len;
-    __ret = memcpy((void *)(& priv->essid), (void const   *)(& network->ssid),
+    __ret = memmove((void *)(& priv->essid), (void const   *)(& network->ssid),
                              __len);
   } else {
 
@@ -20716,10 +20716,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& priv->assoc_request.bssid), (void const   *)(& network->bssid),
+    __ret___0 = memmove((void *)(& priv->assoc_request.bssid), (void const   *)(& network->bssid),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& priv->assoc_request.bssid), (void const   *)(& network->bssid),
+    __ret___0 = memmove((void *)(& priv->assoc_request.bssid), (void const   *)(& network->bssid),
                                  __len___0);
   }
   if ((priv->ieee)->iw_mode == 1) {
@@ -20728,10 +20728,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   } else {
     __len___1 = 6UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& priv->assoc_request.dest), (void const   *)(& network->bssid),
+      __ret___1 = memmove((void *)(& priv->assoc_request.dest), (void const   *)(& network->bssid),
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& priv->assoc_request.dest), (void const   *)(& network->bssid),
+      __ret___1 = memmove((void *)(& priv->assoc_request.dest), (void const   *)(& network->bssid),
                                    __len___1);
     }
     priv->assoc_request.atim_window = 0U;
@@ -20819,10 +20819,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   priv->channel = network->channel;
   __len___2 = 6UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& priv->bssid), (void const   *)(& network->bssid),
+    __ret___2 = memmove((void *)(& priv->bssid), (void const   *)(& network->bssid),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& priv->bssid), (void const   *)(& network->bssid),
+    __ret___2 = memmove((void *)(& priv->bssid), (void const   *)(& network->bssid),
                                  __len___2);
   }
   priv->status = priv->status | 256U;
@@ -21727,7 +21727,7 @@ static void ipw_handle_promiscuous_rx(struct ipw_priv *priv , struct ipw_rx_mem_
 
   }
   __len = (size_t )len;
-  __ret = memcpy((void *)(& ipw_rt->payload), (void const   *)hdr, __len);
+  __ret = memmove((void *)(& ipw_rt->payload), (void const   *)hdr, __len);
   ipw_rt->rt_hdr.it_version = 0U;
   ipw_rt->rt_hdr.it_pad = 0U;
   ipw_rt->rt_hdr.it_len = 25U;
@@ -21935,9 +21935,9 @@ static int is_duplicate_packet(struct ipw_priv *priv , struct libipw_hdr_4addr *
     }
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& entry->mac), (void const   *)mac, __len);
+      __ret = memmove((void *)(& entry->mac), (void const   *)mac, __len);
     } else {
-      __ret = memcpy((void *)(& entry->mac), (void const   *)mac, __len);
+      __ret = memmove((void *)(& entry->mac), (void const   *)mac, __len);
     }
     entry->seq_num = seq;
     entry->frag_num = frag;
@@ -22027,10 +22027,10 @@ static void ipw_handle_mgmt_packet(struct ipw_priv *priv , struct ipw_rx_mem_buf
     __len = 32UL;
     if (__len > 63UL) {
       tmp___3 = skb_push(skb, 32U);
-      __ret = memcpy((void *)tmp___3, (void const   *)stats, __len);
+      __ret = memmove((void *)tmp___3, (void const   *)stats, __len);
     } else {
       tmp___4 = skb_push(skb, 32U);
-      __ret = memcpy((void *)tmp___4, (void const   *)stats, __len);
+      __ret = memmove((void *)tmp___4, (void const   *)stats, __len);
     }
     skb->dev = (priv->ieee)->dev;
     skb_reset_mac_header(skb);
@@ -23170,10 +23170,10 @@ static int ipw_wx_set_wap(struct net_device *dev , struct iw_request_info *info 
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& priv->bssid), (void const   *)(& wrqu->ap_addr.sa_data),
+    __ret = memmove((void *)(& priv->bssid), (void const   *)(& wrqu->ap_addr.sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)(& priv->bssid), (void const   *)(& wrqu->ap_addr.sa_data),
+    __ret = memmove((void *)(& priv->bssid), (void const   *)(& wrqu->ap_addr.sa_data),
                              __len);
   }
   if ((ipw_debug_level & 4100U) != 0U) {
@@ -23215,10 +23215,10 @@ static int ipw_wx_get_wap(struct net_device *dev , struct iw_request_info *info 
     wrqu->ap_addr.sa_family = 1U;
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& wrqu->ap_addr.sa_data), (void const   *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu->ap_addr.sa_data), (void const   *)(& priv->bssid),
                        __len);
     } else {
-      __ret = memcpy((void *)(& wrqu->ap_addr.sa_data), (void const   *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu->ap_addr.sa_data), (void const   *)(& priv->bssid),
                                __len);
     }
   } else {
@@ -23337,7 +23337,7 @@ static int ipw_wx_set_essid(struct net_device *dev , struct iw_request_info *inf
   }
   priv->essid_len = (u8 )length;
   __len = (size_t )priv->essid_len;
-  __ret = memcpy((void *)(& priv->essid), (void const   *)extra, __len);
+  __ret = memmove((void *)(& priv->essid), (void const   *)extra, __len);
   if ((ipw_debug_level & 4100U) != 0U) {
     tmp___14 = current_thread_info();
     if (((unsigned long )tmp___14->preempt_count & 134217472UL) != 0UL) {
@@ -23392,7 +23392,7 @@ static int ipw_wx_get_essid(struct net_device *dev , struct iw_request_info *inf
 
     }
     __len = (size_t )priv->essid_len;
-    __ret = memcpy((void *)extra, (void const   *)(& priv->essid), __len);
+    __ret = memmove((void *)extra, (void const   *)(& priv->essid), __len);
     wrqu->essid.length = (__u16 )priv->essid_len;
     wrqu->essid.flags = 1U;
   } else {
@@ -23459,7 +23459,7 @@ static int ipw_wx_set_nick(struct net_device *dev , struct iw_request_info *info
   wrqu->data.length = (__u16 )tmp___3;
   memset((void *)(& priv->nick), 0, 32UL);
   __len = (size_t )wrqu->data.length;
-  __ret = memcpy((void *)(& priv->nick), (void const   *)extra, __len);
+  __ret = memmove((void *)(& priv->nick), (void const   *)extra, __len);
   if ((ipw_debug_level & 268435456U) != 0U) {
     tmp___6 = current_thread_info();
     if (((unsigned long )tmp___6->preempt_count & 134217472UL) != 0UL) {
@@ -23503,7 +23503,7 @@ static int ipw_wx_get_nick(struct net_device *dev , struct iw_request_info *info
   tmp___3 = strlen((char const   *)(& priv->nick));
   wrqu->data.length = (__u16 )tmp___3;
   __len = (size_t )wrqu->data.length;
-  __ret = memcpy((void *)extra, (void const   *)(& priv->nick), __len);
+  __ret = memmove((void *)extra, (void const   *)(& priv->nick), __len);
   wrqu->data.flags = 1U;
   ldv_mutex_unlock_65(& priv->mutex);
   return (0);
@@ -24207,7 +24207,7 @@ static int ipw_wx_set_scan(struct net_device *dev , struct iw_request_info *info
       }
       len = tmp___0;
       __len = (size_t )len;
-      __ret = memcpy((void *)(& priv->direct_scan_ssid), (void const   *)(& req->essid),
+      __ret = memmove((void *)(& priv->direct_scan_ssid), (void const   *)(& req->essid),
                                __len);
       priv->direct_scan_ssid_len = (u8 )len;
       work = & priv->request_direct_scan;
@@ -25175,7 +25175,7 @@ static int ipw_tx_skb(struct ipw_priv *priv , struct libipw_txb *txb , int pri )
   fc = (int )hdr->frame_ctl;
   hdr->frame_ctl = (unsigned int )((unsigned short )fc) & 64511U;
   __len = (size_t )hdr_len;
-  __ret = memcpy((void *)(& tfd->u.data.tfd.tfd_24.mchdr), (void const   *)hdr,
+  __ret = memmove((void *)(& tfd->u.data.tfd.tfd_24.mchdr), (void const   *)hdr,
                            __len);
   tmp___5 = ldv__builtin_expect((unsigned int )unicast != 0U, 1L);
   if (tmp___5 != 0L) {
@@ -25314,7 +25314,7 @@ static int ipw_tx_skb(struct ipw_priv *priv , struct libipw_txb *txb , int pri )
       printk("\016Adding frag %d %d...\n", j, size);
       __len___0 = (size_t )size;
       tmp___18 = skb_put(skb, (unsigned int )size);
-      __ret___0 = memcpy((void *)tmp___18, (void const   *)(txb->fragments[j])->data + (unsigned long )hdr_len,
+      __ret___0 = memmove((void *)tmp___18, (void const   *)(txb->fragments[j])->data + (unsigned long )hdr_len,
                                    __len___0);
       j = j + 1;
       ldv_48682: ;
@@ -25614,10 +25614,10 @@ static int ipw_net_set_mac_address(struct net_device *dev , void *p )
   priv->config = priv->config | 8U;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& priv->mac_addr), (void const   *)(& addr->sa_data),
+    __ret = memmove((void *)(& priv->mac_addr), (void const   *)(& addr->sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)(& priv->mac_addr), (void const   *)(& addr->sa_data),
+    __ret = memmove((void *)(& priv->mac_addr), (void const   *)(& addr->sa_data),
                              __len);
   }
   printk("\016%s: Setting MAC to %pM\n", (char *)(& (priv->net_dev)->name), (u8 *)(& priv->mac_addr));
@@ -25684,7 +25684,7 @@ static int ipw_ethtool_get_eeprom(struct net_device *dev , struct ethtool_eeprom
   }
   ldv_mutex_lock_128(& p->mutex);
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)bytes, (void const   *)(& p->eeprom) + (unsigned long )eeprom->offset,
+  __ret = memmove((void *)bytes, (void const   *)(& p->eeprom) + (unsigned long )eeprom->offset,
                            __len);
   ldv_mutex_unlock_129(& p->mutex);
   return (0);
@@ -25710,7 +25710,7 @@ static int ipw_ethtool_set_eeprom(struct net_device *dev , struct ethtool_eeprom
   }
   ldv_mutex_lock_130(& p->mutex);
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)(& p->eeprom) + (unsigned long )eeprom->offset,
+  __ret = memmove((void *)(& p->eeprom) + (unsigned long )eeprom->offset,
                            (void const   *)bytes, __len);
   i = 0;
   goto ldv_48768;
@@ -26289,7 +26289,7 @@ static void shim__set_security(struct net_device *dev , struct libipw_security *
       (priv->ieee)->sec.flags = (u16 )((int )((short )(priv->ieee)->sec.flags) & ~ ((int )((short )(1 << i))));
     } else {
       __len = (size_t )sec->key_sizes[i];
-      __ret = memcpy((void *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
+      __ret = memmove((void *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
                                (void const   *)(& sec->keys) + (unsigned long )i,
                                __len);
       (priv->ieee)->sec.flags = (u16 )((int )((short )(priv->ieee)->sec.flags) | (int )((short )(1 << i)));
@@ -27981,18 +27981,18 @@ static int ipw_up(struct ipw_priv *priv )
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(priv->net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(priv->net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
                              __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& (priv->net_dev)->perm_addr), (void const   *)(& priv->mac_addr),
+    __ret___0 = memmove((void *)(& (priv->net_dev)->perm_addr), (void const   *)(& priv->mac_addr),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& (priv->net_dev)->perm_addr), (void const   *)(& priv->mac_addr),
+    __ret___0 = memmove((void *)(& (priv->net_dev)->perm_addr), (void const   *)(& priv->mac_addr),
                                  __len___0);
   }
   ipw_set_geo(priv);
@@ -28228,10 +28228,10 @@ static int ipw_wdev_init(struct net_device *dev )
   wdev = & (priv->ieee)->wdev;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (wdev->wiphy)->perm_addr), (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(& (wdev->wiphy)->perm_addr), (void const   *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(& (wdev->wiphy)->perm_addr), (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(& (wdev->wiphy)->perm_addr), (void const   *)(& priv->mac_addr),
                              __len);
   }
   if ((unsigned int )((unsigned char )geo->bg_channels) != 0U) {
@@ -28497,10 +28497,10 @@ static int ipw_prom_alloc(struct ipw_priv *priv )
   strcpy((char *)(& (priv->prom_net_dev)->name), "rtap%d");
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(priv->prom_net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->prom_net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(priv->prom_net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->prom_net_dev)->dev_addr, (void const   *)(& priv->mac_addr),
                              __len);
   }
   (priv->prom_net_dev)->type = 803U;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.i
@@ -6430,7 +6430,7 @@ __inline static struct task_struct *get_current(void)
   return (pfo_ret__);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern void *memmove(void * , void const * , size_t ) ;
 extern int memcmp(void const * , void const * , size_t ) ;
@@ -6796,7 +6796,7 @@ __inline static void memcpy_toio(void volatile *dst , void const *src , size_t c
   void *__ret ;
   {
   __len = count;
-  __ret = memcpy((void *)dst, src, __len);
+  __ret = memmove((void *)dst, src, __len);
   return;
 }
 }
@@ -7191,7 +7191,7 @@ __inline static void skb_copy_from_linear_data(struct sk_buff const *skb , void 
   void *__ret ;
   {
   __len = (size_t )len;
-  __ret = memcpy(to, (void const *)skb->data, __len);
+  __ret = memmove(to, (void const *)skb->data, __len);
   return;
 }
 }
@@ -10858,10 +10858,10 @@ static void notify_wx_assoc_event(struct ipw_priv *priv )
   if ((priv->status & 128U) != 0U) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& wrqu.ap_addr.sa_data), (void const *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu.ap_addr.sa_data), (void const *)(& priv->bssid),
                        __len);
     } else {
-      __ret = memcpy((void *)(& wrqu.ap_addr.sa_data), (void const *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu.ap_addr.sa_data), (void const *)(& priv->bssid),
                                __len);
     }
   } else {
@@ -11306,7 +11306,7 @@ static int __ipw_send_cmd(struct ipw_priv *priv , struct host_cmd *cmd )
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.cmd = cmd->cmd;
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.len = cmd->len;
     __len = (size_t )cmd->len;
-    __ret = memcpy((void *)(& (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.param),
+    __ret = memmove((void *)(& (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->cmd.param),
                              (void const *)cmd->param, __len);
     (priv->cmdlog + (unsigned long )priv->cmdlog_pos)->retcode = -1;
   } else {
@@ -11970,9 +11970,9 @@ static void eeprom_parse_mac(struct ipw_priv *priv , u8 *mac )
   {
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)mac, (void const *)(& priv->eeprom) + 66U, __len);
+    __ret = memmove((void *)mac, (void const *)(& priv->eeprom) + 66U, __len);
   } else {
-    __ret = memcpy((void *)mac, (void const *)(& priv->eeprom) + 66U,
+    __ret = memmove((void *)mac, (void const *)(& priv->eeprom) + 66U,
                              __len);
   }
   return;
@@ -13119,10 +13119,10 @@ static int ipw_load_ucode(struct ipw_priv *priv , u8 *data , size_t len )
     ldv_46794:
     __len = 26UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& priv->dino_alive), (void const *)(& response_buffer),
+      __ret = memmove((void *)(& priv->dino_alive), (void const *)(& response_buffer),
                        __len);
     } else {
-      __ret = memcpy((void *)(& priv->dino_alive), (void const *)(& response_buffer),
+      __ret = memmove((void *)(& priv->dino_alive), (void const *)(& response_buffer),
                                __len);
     }
     if ((unsigned int )priv->dino_alive.alive_command == 1U && (unsigned int )priv->dino_alive.ucode_valid == 1U) {
@@ -13267,7 +13267,7 @@ static int ipw_load_firmware(struct ipw_priv *priv , u8 *data , size_t len )
   }
   size = (int )tmp___5;
   __len = (size_t )size;
-  __ret = memcpy(*(virts + (unsigned long )total_nr), (void const *)start,
+  __ret = memmove(*(virts + (unsigned long )total_nr), (void const *)start,
                            __len);
   start = start + (unsigned long )size;
   total_nr = total_nr + 1;
@@ -14202,16 +14202,16 @@ static u8 ipw_add_station(struct ipw_priv *priv , u8 *bssid )
   entry.support_mode = 0U;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& entry.mac_addr), (void const *)bssid, __len);
+    __ret = memmove((void *)(& entry.mac_addr), (void const *)bssid, __len);
   } else {
-    __ret = memcpy((void *)(& entry.mac_addr), (void const *)bssid, __len);
+    __ret = memmove((void *)(& entry.mac_addr), (void const *)bssid, __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& priv->stations) + (unsigned long )i, (void const *)bssid,
+    __ret___0 = memmove((void *)(& priv->stations) + (unsigned long )i, (void const *)bssid,
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& priv->stations) + (unsigned long )i, (void const *)bssid,
+    __ret___0 = memmove((void *)(& priv->stations) + (unsigned long )i, (void const *)bssid,
                                  __len___0);
   }
   ipw_write_direct(priv, (u32 )((unsigned long )i) * 8U + 3084U, (void *)(& entry),
@@ -15163,20 +15163,20 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
   case 2:
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
+    __ret = memmove((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
                      __len);
   } else {
-    __ret = memcpy((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
+    __ret = memmove((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
                              __len);
   }
   goto ldv_47149;
   case 1:
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
+    __ret___0 = memmove((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
+    __ret___0 = memmove((void *)(& (priv->ieee)->bssid), (void const *)(& priv->bssid),
                                  __len___0);
   }
   priv->num_stations = 0U;
@@ -15618,10 +15618,10 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
     }
     __len___1 = 145UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& priv->last_link_deterioration), (void const *)x___2,
+      __ret___1 = memmove((void *)(& priv->last_link_deterioration), (void const *)x___2,
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& priv->last_link_deterioration), (void const *)x___2,
+      __ret___1 = memmove((void *)(& priv->last_link_deterioration), (void const *)x___2,
                                    __len___1);
     }
   } else {
@@ -15664,9 +15664,9 @@ static void ipw_rx_notification(struct ipw_priv *priv , struct ipw_rx_notificati
   if ((unsigned int )size == 104U) {
     __len___2 = 104UL;
     if (__len___2 > 63UL) {
-      __ret___2 = memcpy((void *)(& priv->calib), (void const *)x___5, __len___2);
+      __ret___2 = memmove((void *)(& priv->calib), (void const *)x___5, __len___2);
     } else {
-      __ret___2 = memcpy((void *)(& priv->calib), (void const *)x___5,
+      __ret___2 = memmove((void *)(& priv->calib), (void const *)x___5,
                                    __len___2);
     }
     if ((ipw_debug_level & 4U) != 0U) {
@@ -15854,7 +15854,7 @@ static int ipw_queue_tx_hcmd(struct ipw_priv *priv , int hcmd , void *buf , int 
   tfd->u.cmd.index = (u8 )hcmd;
   tfd->u.cmd.length = (u8 )len;
   __len = (size_t )len;
-  __ret = memcpy((void *)(& tfd->u.cmd.payload), (void const *)buf, __len);
+  __ret = memmove((void *)(& tfd->u.cmd.payload), (void const *)buf, __len);
   q->first_empty = ipw_queue_inc_wrap(q->first_empty, q->n_bd);
   if ((ipw_debug_level & 134217728U) != 0U) {
     tmp___3 = current_thread_info();
@@ -17254,7 +17254,7 @@ static void ipw_adhoc_create(struct ipw_priv *priv , struct libipw_network *netw
   ipw_create_bssid(priv, (u8 *)(& network->bssid));
   network->ssid_len = priv->essid_len;
   __len = (size_t )priv->essid_len;
-  __ret = memcpy((void *)(& network->ssid), (void const *)(& priv->essid),
+  __ret = memmove((void *)(& network->ssid), (void const *)(& priv->essid),
                            __len);
   memset((void *)(& network->stats), 0, 32UL);
   network->capability = 2U;
@@ -17275,11 +17275,11 @@ static void ipw_adhoc_create(struct ipw_priv *priv , struct libipw_network *netw
   }
   network->rates_len = (u8 )tmp___3;
   __len___0 = (size_t )network->rates_len;
-  __ret___0 = memcpy((void *)(& network->rates), (void const *)(& priv->rates.supported_rates),
+  __ret___0 = memmove((void *)(& network->rates), (void const *)(& priv->rates.supported_rates),
                                __len___0);
   network->rates_ex_len = (int )priv->rates.num_rates - (int )network->rates_len;
   __len___1 = (size_t )network->rates_ex_len;
-  __ret___1 = memcpy((void *)(& network->rates_ex), (void const *)(& priv->rates.supported_rates) + (unsigned long )network->rates_len,
+  __ret___1 = memmove((void *)(& network->rates_ex), (void const *)(& priv->rates.supported_rates) + (unsigned long )network->rates_len,
                                __len___1);
   network->last_scanned = 0UL;
   network->flags = 0U;
@@ -17306,10 +17306,10 @@ static void ipw_send_tgi_tx_key(struct ipw_priv *priv , int type , int index )
   key.key_id = (u8 )index;
   __len = 16UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
+    __ret = memmove((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
                      __len);
   } else {
-    __ret = memcpy((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
+    __ret = memmove((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )index,
                              __len);
   }
   key.security_type = (u8 )type;
@@ -17340,7 +17340,7 @@ static void ipw_send_wep_keys(struct ipw_priv *priv , int type )
   }
   key.key_size = (priv->ieee)->sec.key_sizes[i];
   __len = (size_t )key.key_size;
-  __ret = memcpy((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
+  __ret = memmove((void *)(& key.key), (void const *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
                            __len);
   ipw_send_cmd_pdu(priv, 18, 20, (void *)(& key));
   ldv_47470:
@@ -18476,7 +18476,7 @@ static int ipw_wx_get_genie(struct net_device *dev , struct iw_request_info *inf
   }
   wrqu->data.length = (__u16 )ieee->wpa_ie_len;
   __len = ieee->wpa_ie_len;
-  __ret = memcpy((void *)extra, (void const *)ieee->wpa_ie, __len);
+  __ret = memmove((void *)extra, (void const *)ieee->wpa_ie, __len);
   out: ;
   return (err);
 }
@@ -18914,11 +18914,11 @@ static int ipw_qos_handle_probe_response(struct ipw_priv *priv , int active_netw
   } else {
     if ((priv->ieee)->mode == 2 || (unsigned int )network->mode == 2U) {
       __len = (size_t )size;
-      __ret = memcpy((void *)(& network->qos_data.parameters), (void const *)(& def_parameters_CCK),
+      __ret = memmove((void *)(& network->qos_data.parameters), (void const *)(& def_parameters_CCK),
                                __len);
     } else {
       __len___0 = (size_t )size;
-      __ret___0 = memcpy((void *)(& network->qos_data.parameters), (void const *)(& def_parameters_OFDM),
+      __ret___0 = memmove((void *)(& network->qos_data.parameters), (void const *)(& def_parameters_OFDM),
                                    __len___0);
     }
     if (network->qos_data.active == 1 && active_network == 1) {
@@ -18997,11 +18997,11 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
   type = ipw_qos_current_mode(priv);
   active_one = (struct libipw_qos_parameters *)(& qos_parameters) + 1UL;
   __len = (size_t )size;
-  __ret = memcpy((void *)active_one, (void const *)priv->qos_data.def_qos_parm_CCK,
+  __ret = memmove((void *)active_one, (void const *)priv->qos_data.def_qos_parm_CCK,
                            __len);
   active_one = (struct libipw_qos_parameters *)(& qos_parameters) + 2UL;
   __len___0 = (size_t )size;
-  __ret___0 = memcpy((void *)active_one, (void const *)priv->qos_data.def_qos_parm_OFDM,
+  __ret___0 = memmove((void *)active_one, (void const *)priv->qos_data.def_qos_parm_OFDM,
                                __len___0);
   if ((unsigned long )qos_network_data == (unsigned long )((struct libipw_qos_data *)0)) {
     if ((unsigned int )type == 2U) {
@@ -19021,7 +19021,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
       active_one = & def_parameters_OFDM;
     }
     __len___1 = (size_t )size;
-    __ret___1 = memcpy((void *)(& qos_parameters), (void const *)active_one,
+    __ret___1 = memmove((void *)(& qos_parameters), (void const *)active_one,
                                  __len___1);
     burst_duration = ipw_qos_get_burst_duration(priv);
     i = 0;
@@ -19062,7 +19062,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
       active_one = priv->qos_data.def_qos_parm_OFDM;
     }
     __len___2 = (size_t )size;
-    __ret___2 = memcpy((void *)(& qos_parameters), (void const *)active_one,
+    __ret___2 = memmove((void *)(& qos_parameters), (void const *)active_one,
                                  __len___2);
   } else {
     tmp___5 = spinlock_check(& (priv->ieee)->lock);
@@ -19070,7 +19070,7 @@ static int ipw_qos_activate(struct ipw_priv *priv , struct libipw_qos_data *qos_
     active_one = & qos_network_data->parameters;
     qos_network_data->old_param_count = qos_network_data->param_count;
     __len___3 = (size_t )size;
-    __ret___3 = memcpy((void *)(& qos_parameters), (void const *)active_one,
+    __ret___3 = memmove((void *)(& qos_parameters), (void const *)active_one,
                                  __len___3);
     active = qos_network_data->supported;
     spin_unlock_irqrestore(& (priv->ieee)->lock, flags);
@@ -19137,9 +19137,9 @@ static int ipw_qos_set_info_element(struct ipw_priv *priv )
   qos_info.ac_info = 0U;
   __len = 3UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& qos_info.qui), (void const *)(& qos_oui), __len);
+    __ret = memmove((void *)(& qos_info.qui), (void const *)(& qos_oui), __len);
   } else {
-    __ret = memcpy((void *)(& qos_info.qui), (void const *)(& qos_oui),
+    __ret = memmove((void *)(& qos_info.qui), (void const *)(& qos_oui),
                              __len);
   }
   qos_info.qui_type = 2U;
@@ -19278,10 +19278,10 @@ static int ipw_qos_association_resp(struct ipw_priv *priv , struct libipw_networ
   if ((network->flags & 8U) != 0U) {
     __len = 44UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& (priv->assoc_network)->qos_data), (void const *)(& network->qos_data),
+      __ret = memmove((void *)(& (priv->assoc_network)->qos_data), (void const *)(& network->qos_data),
                        __len);
     } else {
-      __ret = memcpy((void *)(& (priv->assoc_network)->qos_data), (void const *)(& network->qos_data),
+      __ret = memmove((void *)(& (priv->assoc_network)->qos_data), (void const *)(& network->qos_data),
                                __len);
     }
     (priv->assoc_network)->qos_data.active = 1;
@@ -19293,11 +19293,11 @@ static int ipw_qos_association_resp(struct ipw_priv *priv , struct libipw_networ
   } else {
     if ((unsigned int )network->mode == 2U || (priv->ieee)->mode == 2) {
       __len___0 = (size_t )size;
-      __ret___0 = memcpy((void *)(& (priv->assoc_network)->qos_data.parameters),
+      __ret___0 = memmove((void *)(& (priv->assoc_network)->qos_data.parameters),
                                    (void const *)(& def_parameters_CCK), __len___0);
     } else {
       __len___1 = (size_t )size;
-      __ret___1 = memcpy((void *)(& (priv->assoc_network)->qos_data.parameters),
+      __ret___1 = memmove((void *)(& (priv->assoc_network)->qos_data.parameters),
                                    (void const *)(& def_parameters_OFDM), __len___1);
     }
     (priv->assoc_network)->qos_data.active = 0;
@@ -19578,7 +19578,7 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
     }
     priv->essid_len = (u8 )tmp;
     __len = (size_t )priv->essid_len;
-    __ret = memcpy((void *)(& priv->essid), (void const *)(& network->ssid),
+    __ret = memmove((void *)(& priv->essid), (void const *)(& network->ssid),
                              __len);
   } else {
   }
@@ -19701,10 +19701,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& priv->assoc_request.bssid), (void const *)(& network->bssid),
+    __ret___0 = memmove((void *)(& priv->assoc_request.bssid), (void const *)(& network->bssid),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& priv->assoc_request.bssid), (void const *)(& network->bssid),
+    __ret___0 = memmove((void *)(& priv->assoc_request.bssid), (void const *)(& network->bssid),
                                  __len___0);
   }
   if ((priv->ieee)->iw_mode == 1) {
@@ -19713,10 +19713,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   } else {
     __len___1 = 6UL;
     if (__len___1 > 63UL) {
-      __ret___1 = memcpy((void *)(& priv->assoc_request.dest), (void const *)(& network->bssid),
+      __ret___1 = memmove((void *)(& priv->assoc_request.dest), (void const *)(& network->bssid),
                            __len___1);
     } else {
-      __ret___1 = memcpy((void *)(& priv->assoc_request.dest), (void const *)(& network->bssid),
+      __ret___1 = memmove((void *)(& priv->assoc_request.dest), (void const *)(& network->bssid),
                                    __len___1);
     }
     priv->assoc_request.atim_window = 0U;
@@ -19797,10 +19797,10 @@ static int ipw_associate_network(struct ipw_priv *priv , struct libipw_network *
   priv->channel = network->channel;
   __len___2 = 6UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& priv->bssid), (void const *)(& network->bssid),
+    __ret___2 = memmove((void *)(& priv->bssid), (void const *)(& network->bssid),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& priv->bssid), (void const *)(& network->bssid),
+    __ret___2 = memmove((void *)(& priv->bssid), (void const *)(& network->bssid),
                                  __len___2);
   }
   priv->status = priv->status | 256U;
@@ -20643,7 +20643,7 @@ static void ipw_handle_promiscuous_rx(struct ipw_priv *priv , struct ipw_rx_mem_
   } else {
   }
   __len = (size_t )len;
-  __ret = memcpy((void *)(& ipw_rt->payload), (void const *)hdr, __len);
+  __ret = memmove((void *)(& ipw_rt->payload), (void const *)hdr, __len);
   ipw_rt->rt_hdr.it_version = 0U;
   ipw_rt->rt_hdr.it_pad = 0U;
   ipw_rt->rt_hdr.it_len = 25U;
@@ -20840,9 +20840,9 @@ static int is_duplicate_packet(struct ipw_priv *priv , struct libipw_hdr_4addr *
     }
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& entry->mac), (void const *)mac, __len);
+      __ret = memmove((void *)(& entry->mac), (void const *)mac, __len);
     } else {
-      __ret = memcpy((void *)(& entry->mac), (void const *)mac, __len);
+      __ret = memmove((void *)(& entry->mac), (void const *)mac, __len);
     }
     entry->seq_num = seq;
     entry->frag_num = frag;
@@ -20925,10 +20925,10 @@ static void ipw_handle_mgmt_packet(struct ipw_priv *priv , struct ipw_rx_mem_buf
     __len = 32UL;
     if (__len > 63UL) {
       tmp___3 = skb_push(skb, 32U);
-      __ret = memcpy((void *)tmp___3, (void const *)stats, __len);
+      __ret = memmove((void *)tmp___3, (void const *)stats, __len);
     } else {
       tmp___4 = skb_push(skb, 32U);
-      __ret = memcpy((void *)tmp___4, (void const *)stats, __len);
+      __ret = memmove((void *)tmp___4, (void const *)stats, __len);
     }
     skb->dev = (priv->ieee)->dev;
     skb_reset_mac_header(skb);
@@ -21984,10 +21984,10 @@ static int ipw_wx_set_wap(struct net_device *dev , struct iw_request_info *info 
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& priv->bssid), (void const *)(& wrqu->ap_addr.sa_data),
+    __ret = memmove((void *)(& priv->bssid), (void const *)(& wrqu->ap_addr.sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)(& priv->bssid), (void const *)(& wrqu->ap_addr.sa_data),
+    __ret = memmove((void *)(& priv->bssid), (void const *)(& wrqu->ap_addr.sa_data),
                              __len);
   }
   if ((ipw_debug_level & 4100U) != 0U) {
@@ -22026,10 +22026,10 @@ static int ipw_wx_get_wap(struct net_device *dev , struct iw_request_info *info 
     wrqu->ap_addr.sa_family = 1U;
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& wrqu->ap_addr.sa_data), (void const *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu->ap_addr.sa_data), (void const *)(& priv->bssid),
                        __len);
     } else {
-      __ret = memcpy((void *)(& wrqu->ap_addr.sa_data), (void const *)(& priv->bssid),
+      __ret = memmove((void *)(& wrqu->ap_addr.sa_data), (void const *)(& priv->bssid),
                                __len);
     }
   } else {
@@ -22139,7 +22139,7 @@ static int ipw_wx_set_essid(struct net_device *dev , struct iw_request_info *inf
   }
   priv->essid_len = (u8 )length;
   __len = (size_t )priv->essid_len;
-  __ret = memcpy((void *)(& priv->essid), (void const *)extra, __len);
+  __ret = memmove((void *)(& priv->essid), (void const *)extra, __len);
   if ((ipw_debug_level & 4100U) != 0U) {
     tmp___14 = current_thread_info();
     if (((unsigned long )tmp___14->preempt_count & 134217472UL) != 0UL) {
@@ -22190,7 +22190,7 @@ static int ipw_wx_get_essid(struct net_device *dev , struct iw_request_info *inf
     } else {
     }
     __len = (size_t )priv->essid_len;
-    __ret = memcpy((void *)extra, (void const *)(& priv->essid), __len);
+    __ret = memmove((void *)extra, (void const *)(& priv->essid), __len);
     wrqu->essid.length = (__u16 )priv->essid_len;
     wrqu->essid.flags = 1U;
   } else {
@@ -22253,7 +22253,7 @@ static int ipw_wx_set_nick(struct net_device *dev , struct iw_request_info *info
   wrqu->data.length = (__u16 )tmp___3;
   memset((void *)(& priv->nick), 0, 32UL);
   __len = (size_t )wrqu->data.length;
-  __ret = memcpy((void *)(& priv->nick), (void const *)extra, __len);
+  __ret = memmove((void *)(& priv->nick), (void const *)extra, __len);
   if ((ipw_debug_level & 268435456U) != 0U) {
     tmp___6 = current_thread_info();
     if (((unsigned long )tmp___6->preempt_count & 134217472UL) != 0UL) {
@@ -22294,7 +22294,7 @@ static int ipw_wx_get_nick(struct net_device *dev , struct iw_request_info *info
   tmp___3 = strlen((char const *)(& priv->nick));
   wrqu->data.length = (__u16 )tmp___3;
   __len = (size_t )wrqu->data.length;
-  __ret = memcpy((void *)extra, (void const *)(& priv->nick), __len);
+  __ret = memmove((void *)extra, (void const *)(& priv->nick), __len);
   wrqu->data.flags = 1U;
   ldv_mutex_unlock_65(& priv->mutex);
   return (0);
@@ -22931,7 +22931,7 @@ static int ipw_wx_set_scan(struct net_device *dev , struct iw_request_info *info
       }
       len = tmp___0;
       __len = (size_t )len;
-      __ret = memcpy((void *)(& priv->direct_scan_ssid), (void const *)(& req->essid),
+      __ret = memmove((void *)(& priv->direct_scan_ssid), (void const *)(& req->essid),
                                __len);
       priv->direct_scan_ssid_len = (u8 )len;
       work = & priv->request_direct_scan;
@@ -23835,7 +23835,7 @@ static int ipw_tx_skb(struct ipw_priv *priv , struct libipw_txb *txb , int pri )
   fc = (int )hdr->frame_ctl;
   hdr->frame_ctl = (unsigned int )((unsigned short )fc) & 64511U;
   __len = (size_t )hdr_len;
-  __ret = memcpy((void *)(& tfd->u.data.tfd.tfd_24.mchdr), (void const *)hdr,
+  __ret = memmove((void *)(& tfd->u.data.tfd.tfd_24.mchdr), (void const *)hdr,
                            __len);
   tmp___5 = ldv__builtin_expect((unsigned int )unicast != 0U, 1L);
   if (tmp___5 != 0L) {
@@ -23968,7 +23968,7 @@ static int ipw_tx_skb(struct ipw_priv *priv , struct libipw_txb *txb , int pri )
       printk("\016Adding frag %d %d...\n", j, size);
       __len___0 = (size_t )size;
       tmp___18 = skb_put(skb, (unsigned int )size);
-      __ret___0 = memcpy((void *)tmp___18, (void const *)(txb->fragments[j])->data + (unsigned long )hdr_len,
+      __ret___0 = memmove((void *)tmp___18, (void const *)(txb->fragments[j])->data + (unsigned long )hdr_len,
                                    __len___0);
       j = j + 1;
       ldv_48682: ;
@@ -24242,10 +24242,10 @@ static int ipw_net_set_mac_address(struct net_device *dev , void *p )
   priv->config = priv->config | 8U;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& priv->mac_addr), (void const *)(& addr->sa_data),
+    __ret = memmove((void *)(& priv->mac_addr), (void const *)(& addr->sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)(& priv->mac_addr), (void const *)(& addr->sa_data),
+    __ret = memmove((void *)(& priv->mac_addr), (void const *)(& addr->sa_data),
                              __len);
   }
   printk("\016%s: Setting MAC to %pM\n", (char *)(& (priv->net_dev)->name), (u8 *)(& priv->mac_addr));
@@ -24307,7 +24307,7 @@ static int ipw_ethtool_get_eeprom(struct net_device *dev , struct ethtool_eeprom
   }
   ldv_mutex_lock_128(& p->mutex);
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)bytes, (void const *)(& p->eeprom) + (unsigned long )eeprom->offset,
+  __ret = memmove((void *)bytes, (void const *)(& p->eeprom) + (unsigned long )eeprom->offset,
                            __len);
   ldv_mutex_unlock_129(& p->mutex);
   return (0);
@@ -24331,7 +24331,7 @@ static int ipw_ethtool_set_eeprom(struct net_device *dev , struct ethtool_eeprom
   }
   ldv_mutex_lock_130(& p->mutex);
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)(& p->eeprom) + (unsigned long )eeprom->offset,
+  __ret = memmove((void *)(& p->eeprom) + (unsigned long )eeprom->offset,
                            (void const *)bytes, __len);
   i = 0;
   goto ldv_48768;
@@ -24888,7 +24888,7 @@ static void shim__set_security(struct net_device *dev , struct libipw_security *
       (priv->ieee)->sec.flags = (u16 )((int )((short )(priv->ieee)->sec.flags) & ~ ((int )((short )(1 << i))));
     } else {
       __len = (size_t )sec->key_sizes[i];
-      __ret = memcpy((void *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
+      __ret = memmove((void *)(& (priv->ieee)->sec.keys) + (unsigned long )i,
                                (void const *)(& sec->keys) + (unsigned long )i,
                                __len);
       (priv->ieee)->sec.flags = (u16 )((int )((short )(priv->ieee)->sec.flags) | (int )((short )(1 << i)));
@@ -26547,18 +26547,18 @@ static int ipw_up(struct ipw_priv *priv )
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(priv->net_dev)->dev_addr, (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->net_dev)->dev_addr, (void const *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(priv->net_dev)->dev_addr, (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->net_dev)->dev_addr, (void const *)(& priv->mac_addr),
                              __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& (priv->net_dev)->perm_addr), (void const *)(& priv->mac_addr),
+    __ret___0 = memmove((void *)(& (priv->net_dev)->perm_addr), (void const *)(& priv->mac_addr),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& (priv->net_dev)->perm_addr), (void const *)(& priv->mac_addr),
+    __ret___0 = memmove((void *)(& (priv->net_dev)->perm_addr), (void const *)(& priv->mac_addr),
                                  __len___0);
   }
   ipw_set_geo(priv);
@@ -26776,10 +26776,10 @@ static int ipw_wdev_init(struct net_device *dev )
   wdev = & (priv->ieee)->wdev;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& (wdev->wiphy)->perm_addr), (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(& (wdev->wiphy)->perm_addr), (void const *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(& (wdev->wiphy)->perm_addr), (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(& (wdev->wiphy)->perm_addr), (void const *)(& priv->mac_addr),
                              __len);
   }
   if ((unsigned int )((unsigned char )geo->bg_channels) != 0U) {
@@ -27023,10 +27023,10 @@ static int ipw_prom_alloc(struct ipw_priv *priv )
   strcpy((char *)(& (priv->prom_net_dev)->name), "rtap%d");
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(priv->prom_net_dev)->dev_addr, (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->prom_net_dev)->dev_addr, (void const *)(& priv->mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)(priv->prom_net_dev)->dev_addr, (void const *)(& priv->mac_addr),
+    __ret = memmove((void *)(priv->prom_net_dev)->dev_addr, (void const *)(& priv->mac_addr),
                              __len);
   }
   (priv->prom_net_dev)->type = 803U;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--tty--synclink.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--tty--synclink.ko-main.cil.out.c
@@ -5271,7 +5271,7 @@ __inline static struct task_struct *get_current(void)
   return (pfo_ret__);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern char *strcat(char * , char const   * ) ;
@@ -7577,7 +7577,7 @@ static int mgsl_write(struct tty_struct *tty , unsigned char const   *buf , int 
 
     }
     __len = (size_t )c;
-    __ret = memcpy((void *)info->xmit_buf + (unsigned long )info->xmit_head,
+    __ret = memmove((void *)info->xmit_buf + (unsigned long )info->xmit_head,
                              (void const   *)buf, __len);
     info->xmit_head = (info->xmit_head + c) & 4095;
     info->xmit_cnt = info->xmit_cnt + c;
@@ -7935,9 +7935,9 @@ static int mgsl_set_params(struct mgsl_struct *info , MGSL_PARAMS *new_params )
   flags = _raw_spin_lock_irqsave(tmp___1);
   __len = 48UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& info->params), (void const   *)(& tmp_params), __len);
+    __ret = memmove((void *)(& info->params), (void const   *)(& tmp_params), __len);
   } else {
-    __ret = memcpy((void *)(& info->params), (void const   *)(& tmp_params),
+    __ret = memmove((void *)(& info->params), (void const   *)(& tmp_params),
                              __len);
   }
   spin_unlock_irqrestore(& info->irq_spinlock, flags);
@@ -9995,7 +9995,7 @@ static int save_tx_buffer_request(struct mgsl_struct *info , char const   *Buffe
   ptx = (struct tx_holding_buffer *)(& info->tx_holding_buffers) + (unsigned long )info->put_tx_holding_index;
   ptx->buffer_size = (int )BufferSize;
   __len = (size_t )BufferSize;
-  __ret = memcpy((void *)ptx->buffer, (void const   *)Buffer, __len);
+  __ret = memmove((void *)ptx->buffer, (void const   *)Buffer, __len);
   info->tx_holding_count = info->tx_holding_count + 1;
   info->put_tx_holding_index = info->put_tx_holding_index + 1;
   if (info->put_tx_holding_index >= info->num_tx_holding_buffers) {
@@ -10304,10 +10304,10 @@ static struct mgsl_struct *mgsl_allocate_device(void)
                          & __key___3);
     __len = 48UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& info->params), (void const   *)(& default_params),
+      __ret = memmove((void *)(& info->params), (void const   *)(& default_params),
                        __len);
     } else {
-      __ret = memcpy((void *)(& info->params), (void const   *)(& default_params),
+      __ret = memmove((void *)(& info->params), (void const   *)(& default_params),
                                __len);
     }
     info->idle_mode = 0U;
@@ -11867,7 +11867,7 @@ static bool mgsl_get_rx_frame(struct mgsl_struct *info )
       }
       pBufEntry = info->rx_buffer_list + (unsigned long )index;
       __len = (size_t )partial_count;
-      __ret = memcpy((void *)ptmp, (void const   *)pBufEntry->virt_addr,
+      __ret = memmove((void *)ptmp, (void const   *)pBufEntry->virt_addr,
                                __len);
       ptmp = ptmp + (unsigned long )partial_count;
       copy_count = copy_count - partial_count;
@@ -12004,7 +12004,7 @@ static bool mgsl_get_raw_rx_frame(struct mgsl_struct *info )
     if (framesize != 0U) {
       pBufEntry = info->rx_buffer_list + (unsigned long )CurrentIndex;
       __len = (size_t )framesize;
-      __ret = memcpy((void *)info->intermediate_rxbuffer, (void const   *)pBufEntry->virt_addr,
+      __ret = memmove((void *)info->intermediate_rxbuffer, (void const   *)pBufEntry->virt_addr,
                                __len);
       info->icount.rxok = info->icount.rxok + 1U;
       ldisc_receive_buf(tty, (__u8 const   *)info->intermediate_rxbuffer, (char *)(& info->flag_buf),
@@ -12087,7 +12087,7 @@ static void mgsl_load_tx_dma_buffer(struct mgsl_struct *info , char const   *Buf
     mgsl_load_pci_memory(pBufEntry->virt_addr, Buffer, (int )Copycount);
   } else {
     __len = (size_t )Copycount;
-    __ret = memcpy((void *)pBufEntry->virt_addr, (void const   *)Buffer,
+    __ret = memmove((void *)pBufEntry->virt_addr, (void const   *)Buffer,
                              __len);
   }
   pBufEntry->count = Copycount;
@@ -12304,17 +12304,17 @@ static bool mgsl_dma_test(struct mgsl_struct *info )
   status = 0U;
   __len = 48UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& tmp_params), (void const   *)(& info->params), __len);
+    __ret = memmove((void *)(& tmp_params), (void const   *)(& info->params), __len);
   } else {
-    __ret = memcpy((void *)(& tmp_params), (void const   *)(& info->params),
+    __ret = memmove((void *)(& tmp_params), (void const   *)(& info->params),
                              __len);
   }
   __len___0 = 48UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& info->params), (void const   *)(& default_params),
+    __ret___0 = memmove((void *)(& info->params), (void const   *)(& default_params),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& info->params), (void const   *)(& default_params),
+    __ret___0 = memmove((void *)(& info->params), (void const   *)(& default_params),
                                  __len___0);
   }
   tmp = spinlock_check(& info->irq_spinlock);
@@ -12508,10 +12508,10 @@ static bool mgsl_dma_test(struct mgsl_struct *info )
   spin_unlock_irqrestore(& info->irq_spinlock, flags);
   __len___1 = 48UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& info->params), (void const   *)(& tmp_params),
+    __ret___1 = memmove((void *)(& info->params), (void const   *)(& tmp_params),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& info->params), (void const   *)(& tmp_params),
+    __ret___1 = memmove((void *)(& info->params), (void const   *)(& tmp_params),
                                  __len___1);
   }
   return (rc);
@@ -12674,9 +12674,9 @@ static void mgsl_load_pci_memory(char *TargetPtr , char const   *SourcePtr , uns
   ldv_42861: 
   __len = 64UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)TargetPtr, (void const   *)SourcePtr, __len);
+    __ret = memmove((void *)TargetPtr, (void const   *)SourcePtr, __len);
   } else {
-    __ret = memcpy((void *)TargetPtr, (void const   *)SourcePtr, __len);
+    __ret = memmove((void *)TargetPtr, (void const   *)SourcePtr, __len);
   }
   Dummy = *((unsigned long volatile   *)TargetPtr);
   TargetPtr = TargetPtr + 64UL;
@@ -12690,7 +12690,7 @@ static void mgsl_load_pci_memory(char *TargetPtr , char const   *SourcePtr , uns
   }
   ldv_42863: 
   __len___0 = (size_t )count & 63UL;
-  __ret___0 = memcpy((void *)TargetPtr, (void const   *)SourcePtr, __len___0);
+  __ret___0 = memmove((void *)TargetPtr, (void const   *)SourcePtr, __len___0);
   return;
 }
 }
@@ -13241,7 +13241,7 @@ static void hdlcdev_rx(struct mgsl_struct *info , char *buf , int size )
   }
   __len = (size_t )size;
   tmp___1 = skb_put(skb, (unsigned int )size);
-  __ret = memcpy((void *)tmp___1, (void const   *)buf, __len);
+  __ret = memmove((void *)tmp___1, (void const   *)buf, __len);
   skb->protocol = hdlc_type_trans(skb, dev);
   dev->stats.rx_packets = dev->stats.rx_packets + 1UL;
   dev->stats.rx_bytes = dev->stats.rx_bytes + (unsigned long )size;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--tty--synclink.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--tty--synclink.ko-main.cil.out.i
@@ -5257,7 +5257,7 @@ __inline static struct task_struct *get_current(void)
   return (pfo_ret__);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern int memcmp(void const * , void const * , size_t ) ;
 extern char *strcat(char * , char const * ) ;
@@ -7339,7 +7339,7 @@ static int mgsl_write(struct tty_struct *tty , unsigned char const *buf , int co
     } else {
     }
     __len = (size_t )c;
-    __ret = memcpy((void *)info->xmit_buf + (unsigned long )info->xmit_head,
+    __ret = memmove((void *)info->xmit_buf + (unsigned long )info->xmit_head,
                              (void const *)buf, __len);
     info->xmit_head = (info->xmit_head + c) & 4095;
     info->xmit_cnt = info->xmit_cnt + c;
@@ -7655,9 +7655,9 @@ static int mgsl_set_params(struct mgsl_struct *info , MGSL_PARAMS *new_params )
   flags = _raw_spin_lock_irqsave(tmp___1);
   __len = 48UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& info->params), (void const *)(& tmp_params), __len);
+    __ret = memmove((void *)(& info->params), (void const *)(& tmp_params), __len);
   } else {
-    __ret = memcpy((void *)(& info->params), (void const *)(& tmp_params),
+    __ret = memmove((void *)(& info->params), (void const *)(& tmp_params),
                              __len);
   }
   spin_unlock_irqrestore(& info->irq_spinlock, flags);
@@ -9553,7 +9553,7 @@ static int save_tx_buffer_request(struct mgsl_struct *info , char const *Buffer 
   ptx = (struct tx_holding_buffer *)(& info->tx_holding_buffers) + (unsigned long )info->put_tx_holding_index;
   ptx->buffer_size = (int )BufferSize;
   __len = (size_t )BufferSize;
-  __ret = memcpy((void *)ptx->buffer, (void const *)Buffer, __len);
+  __ret = memmove((void *)ptx->buffer, (void const *)Buffer, __len);
   info->tx_holding_count = info->tx_holding_count + 1;
   info->put_tx_holding_index = info->put_tx_holding_index + 1;
   if (info->put_tx_holding_index >= info->num_tx_holding_buffers) {
@@ -9832,10 +9832,10 @@ static struct mgsl_struct *mgsl_allocate_device(void)
                          & __key___3);
     __len = 48UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)(& info->params), (void const *)(& default_params),
+      __ret = memmove((void *)(& info->params), (void const *)(& default_params),
                        __len);
     } else {
-      __ret = memcpy((void *)(& info->params), (void const *)(& default_params),
+      __ret = memmove((void *)(& info->params), (void const *)(& default_params),
                                __len);
     }
     info->idle_mode = 0U;
@@ -11289,7 +11289,7 @@ static bool mgsl_get_rx_frame(struct mgsl_struct *info )
       }
       pBufEntry = info->rx_buffer_list + (unsigned long )index;
       __len = (size_t )partial_count;
-      __ret = memcpy((void *)ptmp, (void const *)pBufEntry->virt_addr,
+      __ret = memmove((void *)ptmp, (void const *)pBufEntry->virt_addr,
                                __len);
       ptmp = ptmp + (unsigned long )partial_count;
       copy_count = copy_count - partial_count;
@@ -11415,7 +11415,7 @@ static bool mgsl_get_raw_rx_frame(struct mgsl_struct *info )
     if (framesize != 0U) {
       pBufEntry = info->rx_buffer_list + (unsigned long )CurrentIndex;
       __len = (size_t )framesize;
-      __ret = memcpy((void *)info->intermediate_rxbuffer, (void const *)pBufEntry->virt_addr,
+      __ret = memmove((void *)info->intermediate_rxbuffer, (void const *)pBufEntry->virt_addr,
                                __len);
       info->icount.rxok = info->icount.rxok + 1U;
       ldisc_receive_buf(tty, (__u8 const *)info->intermediate_rxbuffer, (char *)(& info->flag_buf),
@@ -11490,7 +11490,7 @@ static void mgsl_load_tx_dma_buffer(struct mgsl_struct *info , char const *Buffe
     mgsl_load_pci_memory(pBufEntry->virt_addr, Buffer, (int )Copycount);
   } else {
     __len = (size_t )Copycount;
-    __ret = memcpy((void *)pBufEntry->virt_addr, (void const *)Buffer,
+    __ret = memmove((void *)pBufEntry->virt_addr, (void const *)Buffer,
                              __len);
   }
   pBufEntry->count = Copycount;
@@ -11701,17 +11701,17 @@ static bool mgsl_dma_test(struct mgsl_struct *info )
   status = 0U;
   __len = 48UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& tmp_params), (void const *)(& info->params), __len);
+    __ret = memmove((void *)(& tmp_params), (void const *)(& info->params), __len);
   } else {
-    __ret = memcpy((void *)(& tmp_params), (void const *)(& info->params),
+    __ret = memmove((void *)(& tmp_params), (void const *)(& info->params),
                              __len);
   }
   __len___0 = 48UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& info->params), (void const *)(& default_params),
+    __ret___0 = memmove((void *)(& info->params), (void const *)(& default_params),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& info->params), (void const *)(& default_params),
+    __ret___0 = memmove((void *)(& info->params), (void const *)(& default_params),
                                  __len___0);
   }
   tmp = spinlock_check(& info->irq_spinlock);
@@ -11892,10 +11892,10 @@ static bool mgsl_dma_test(struct mgsl_struct *info )
   spin_unlock_irqrestore(& info->irq_spinlock, flags);
   __len___1 = 48UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& info->params), (void const *)(& tmp_params),
+    __ret___1 = memmove((void *)(& info->params), (void const *)(& tmp_params),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& info->params), (void const *)(& tmp_params),
+    __ret___1 = memmove((void *)(& info->params), (void const *)(& tmp_params),
                                  __len___1);
   }
   return (rc);
@@ -12047,9 +12047,9 @@ static void mgsl_load_pci_memory(char *TargetPtr , char const *SourcePtr , unsig
   ldv_42861:
   __len = 64UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)TargetPtr, (void const *)SourcePtr, __len);
+    __ret = memmove((void *)TargetPtr, (void const *)SourcePtr, __len);
   } else {
-    __ret = memcpy((void *)TargetPtr, (void const *)SourcePtr, __len);
+    __ret = memmove((void *)TargetPtr, (void const *)SourcePtr, __len);
   }
   Dummy = *((unsigned long volatile *)TargetPtr);
   TargetPtr = TargetPtr + 64UL;
@@ -12063,7 +12063,7 @@ static void mgsl_load_pci_memory(char *TargetPtr , char const *SourcePtr , unsig
   }
   ldv_42863:
   __len___0 = (size_t )count & 63UL;
-  __ret___0 = memcpy((void *)TargetPtr, (void const *)SourcePtr, __len___0);
+  __ret___0 = memmove((void *)TargetPtr, (void const *)SourcePtr, __len___0);
   return;
 }
 }
@@ -12573,7 +12573,7 @@ static void hdlcdev_rx(struct mgsl_struct *info , char *buf , int size )
   }
   __len = (size_t )size;
   tmp___1 = skb_put(skb, (unsigned int )size);
-  __ret = memcpy((void *)tmp___1, (void const *)buf, __len);
+  __ret = memmove((void *)tmp___1, (void const *)buf, __len);
   skb->protocol = hdlc_type_trans(skb, dev);
   dev->stats.rx_packets = dev->stats.rx_packets + 1UL;
   dev->stats.rx_bytes = dev->stats.rx_bytes + (unsigned long )size;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--dsa--mv88e6xxx_drv.ko-ldv_main2_true-unreach-call.cil.out.c
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--dsa--mv88e6xxx_drv.ko-ldv_main2_true-unreach-call.cil.out.c
@@ -4577,7 +4577,7 @@ __inline static void INIT_LIST_HEAD(struct list_head *list )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void lockdep_init_map(struct lockdep_map * , char const   * , struct lock_class_key * ,
                              int  ) ;
 extern void __mutex_init(struct mutex * , char const   * , struct lock_class_key * ) ;
@@ -5412,10 +5412,10 @@ void mv88e6xxx_get_strings(struct dsa_switch *ds , int nr_stats , struct mv88e6x
   ldv_39151: 
   __len = 32UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)data + (unsigned long )(i * 32), (void const   *)(& (stats + (unsigned long )i)->string),
+    __ret = memmove((void *)data + (unsigned long )(i * 32), (void const   *)(& (stats + (unsigned long )i)->string),
                      __len);
   } else {
-    __ret = memcpy((void *)data + (unsigned long )(i * 32), (void const   *)(& (stats + (unsigned long )i)->string),
+    __ret = memmove((void *)data + (unsigned long )(i * 32), (void const   *)(& (stats + (unsigned long )i)->string),
                              __len);
   }
   i = i + 1;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--dsa--mv88e6xxx_drv.ko-ldv_main2_true-unreach-call.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--dsa--mv88e6xxx_drv.ko-ldv_main2_true-unreach-call.cil.out.i
@@ -4567,7 +4567,7 @@ __inline static void INIT_LIST_HEAD(struct list_head *list )
   return;
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void lockdep_init_map(struct lockdep_map * , char const * , struct lock_class_key * ,
                              int ) ;
 extern void __mutex_init(struct mutex * , char const * , struct lock_class_key * ) ;
@@ -5305,10 +5305,10 @@ void mv88e6xxx_get_strings(struct dsa_switch *ds , int nr_stats , struct mv88e6x
   ldv_39151:
   __len = 32UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)data + (unsigned long )(i * 32), (void const *)(& (stats + (unsigned long )i)->string),
+    __ret = memmove((void *)data + (unsigned long )(i * 32), (void const *)(& (stats + (unsigned long )i)->string),
                      __len);
   } else {
-    __ret = memcpy((void *)data + (unsigned long )(i * 32), (void const *)(& (stats + (unsigned long )i)->string),
+    __ret = memmove((void *)data + (unsigned long )(i * 32), (void const *)(& (stats + (unsigned long )i)->string),
                              __len);
   }
   i = i + 1;

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
@@ -431,7 +431,7 @@ void lockdep_init_map(struct lockdep_map *arg0, const char *arg1, struct lock_cl
   return;
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
@@ -405,7 +405,7 @@ void lockdep_init_map(struct lockdep_map *arg0, const char *arg1, struct lock_cl
 
 // Skip function: memcmp
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.c
@@ -5119,7 +5119,7 @@ extern void warn_slowpath_null(char const * , int const ) ;
 extern unsigned long __phys_addr(unsigned long ) ;
 extern void __bad_percpu_size(void) ;
 extern struct pv_irq_ops pv_irq_ops ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned long arch_local_save_flags(void)
 { unsigned long __ret ;
@@ -7330,10 +7330,10 @@ static int atl1c_set_mac_addr(struct net_device *netdev , void *p )
   }
   {
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& addr->sa_data),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& addr->sa_data),
                            __len);
   __len___0 = (size_t )netdev->addr_len;
-  __ret___0 = memcpy((void *)(& adapter->hw.mac_addr), (void const *)(& addr->sa_data),
+  __ret___0 = memmove((void *)(& adapter->hw.mac_addr), (void const *)(& addr->sa_data),
                                __len___0);
   atl1c_hw_set_mac_addr(& adapter->hw);
   }
@@ -10109,11 +10109,11 @@ static void atl1c_tx_map(struct atl1c_adapter *adapter , struct sk_buff *skb , s
       }
       if (__len > 63UL) {
         {
-        __ret = memcpy((void *)use_tpd, (void const *)tpd, __len);
+        __ret = memmove((void *)use_tpd, (void const *)tpd, __len);
         }
       } else {
         {
-        __ret = memcpy((void *)use_tpd, (void const *)tpd, __len);
+        __ret = memmove((void *)use_tpd, (void const *)tpd, __len);
         }
       }
     }
@@ -10145,11 +10145,11 @@ static void atl1c_tx_map(struct atl1c_adapter *adapter , struct sk_buff *skb , s
   }
   if (__len___0 > 63UL) {
     {
-    __ret___0 = memcpy((void *)use_tpd, (void const *)tpd, __len___0);
+    __ret___0 = memmove((void *)use_tpd, (void const *)tpd, __len___0);
     }
   } else {
     {
-    __ret___0 = memcpy((void *)use_tpd, (void const *)tpd, __len___0);
+    __ret___0 = memmove((void *)use_tpd, (void const *)tpd, __len___0);
     }
   }
   {
@@ -11171,10 +11171,10 @@ static int atl1c_probe(struct pci_dev *pdev , struct pci_device_id const *ent )
   }
   {
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->hw.mac_addr),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->hw.mac_addr),
                            __len);
   __len___0 = (size_t )netdev->addr_len;
-  __ret___0 = memcpy((void *)(& netdev->perm_addr), (void const *)(& adapter->hw.mac_addr),
+  __ret___0 = memmove((void *)(& netdev->perm_addr), (void const *)(& adapter->hw.mac_addr),
                                __len___0);
   }
   if ((adapter->msg_enable & 2U) != 0U) {
@@ -11911,12 +11911,12 @@ static int atl1c_get_permanent_address(struct atl1c_hw *hw )
     __len = 6UL;
     if (__len > 63UL) {
       {
-      __ret = memcpy((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
+      __ret = memmove((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
                        __len);
       }
     } else {
       {
-      __ret = memcpy((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
+      __ret = memmove((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
                                __len);
       }
     }
@@ -12068,12 +12068,12 @@ int atl1c_read_mac_addr(struct atl1c_hw *hw )
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
+    __ret = memmove((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
+    __ret = memmove((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
                              __len);
     }
   }
@@ -13610,7 +13610,7 @@ static int atl1c_get_eeprom(struct net_device *netdev , struct ethtool_eeprom *e
   ldv_42448:
   {
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)bytes, (void const *)eeprom_buff + ((unsigned long )eeprom->offset & 3UL),
+  __ret = memmove((void *)bytes, (void const *)eeprom_buff + ((unsigned long )eeprom->offset & 3UL),
                            __len);
   kfree((void const *)eeprom_buff);
   }

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.i
@@ -5106,7 +5106,7 @@ extern void warn_slowpath_null(char const * , int const ) ;
 extern unsigned long __phys_addr(unsigned long ) ;
 extern void __bad_percpu_size(void) ;
 extern struct pv_irq_ops pv_irq_ops ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned long arch_local_save_flags(void)
 { unsigned long __ret ;
@@ -7154,10 +7154,10 @@ static int atl1c_set_mac_addr(struct net_device *netdev , void *p )
   }
   {
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& addr->sa_data),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& addr->sa_data),
                            __len);
   __len___0 = (size_t )netdev->addr_len;
-  __ret___0 = memcpy((void *)(& adapter->hw.mac_addr), (void const *)(& addr->sa_data),
+  __ret___0 = memmove((void *)(& adapter->hw.mac_addr), (void const *)(& addr->sa_data),
                                __len___0);
   atl1c_hw_set_mac_addr(& adapter->hw);
   }
@@ -9778,11 +9778,11 @@ static void atl1c_tx_map(struct atl1c_adapter *adapter , struct sk_buff *skb , s
       }
       if (__len > 63UL) {
         {
-        __ret = memcpy((void *)use_tpd, (void const *)tpd, __len);
+        __ret = memmove((void *)use_tpd, (void const *)tpd, __len);
         }
       } else {
         {
-        __ret = memcpy((void *)use_tpd, (void const *)tpd, __len);
+        __ret = memmove((void *)use_tpd, (void const *)tpd, __len);
         }
       }
     }
@@ -9813,11 +9813,11 @@ static void atl1c_tx_map(struct atl1c_adapter *adapter , struct sk_buff *skb , s
   }
   if (__len___0 > 63UL) {
     {
-    __ret___0 = memcpy((void *)use_tpd, (void const *)tpd, __len___0);
+    __ret___0 = memmove((void *)use_tpd, (void const *)tpd, __len___0);
     }
   } else {
     {
-    __ret___0 = memcpy((void *)use_tpd, (void const *)tpd, __len___0);
+    __ret___0 = memmove((void *)use_tpd, (void const *)tpd, __len___0);
     }
   }
   {
@@ -10778,10 +10778,10 @@ static int atl1c_probe(struct pci_dev *pdev , struct pci_device_id const *ent )
   }
   {
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->hw.mac_addr),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->hw.mac_addr),
                            __len);
   __len___0 = (size_t )netdev->addr_len;
-  __ret___0 = memcpy((void *)(& netdev->perm_addr), (void const *)(& adapter->hw.mac_addr),
+  __ret___0 = memmove((void *)(& netdev->perm_addr), (void const *)(& adapter->hw.mac_addr),
                                __len___0);
   }
   if ((adapter->msg_enable & 2U) != 0U) {
@@ -11468,12 +11468,12 @@ static int atl1c_get_permanent_address(struct atl1c_hw *hw )
     __len = 6UL;
     if (__len > 63UL) {
       {
-      __ret = memcpy((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
+      __ret = memmove((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
                        __len);
       }
     } else {
       {
-      __ret = memcpy((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
+      __ret = memmove((void *)(& hw->perm_mac_addr), (void const *)(& eth_addr),
                                __len);
       }
     }
@@ -11616,12 +11616,12 @@ int atl1c_read_mac_addr(struct atl1c_hw *hw )
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
+    __ret = memmove((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
+    __ret = memmove((void *)(& hw->mac_addr), (void const *)(& hw->perm_mac_addr),
                              __len);
     }
   }
@@ -13080,7 +13080,7 @@ static int atl1c_get_eeprom(struct net_device *netdev , struct ethtool_eeprom *e
   ldv_42448:
   {
   __len = (size_t )eeprom->len;
-  __ret = memcpy((void *)bytes, (void const *)eeprom_buff + ((unsigned long )eeprom->offset & 3UL),
+  __ret = memmove((void *)bytes, (void const *)eeprom_buff + ((unsigned long )eeprom->offset & 3UL),
                            __len);
   kfree((void const *)eeprom_buff);
   }

--- a/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.c
@@ -7810,7 +7810,7 @@ struct rfd *nic_rx_pkts(struct et131x_adapter *etdev )
     etdev->net_stats.rx_bytes = etdev->net_stats.rx_bytes + (unsigned long )rfd->len;
     __len = (size_t )rfd->len;
     tmp___3 = skb_put(skb, rfd->len);
-    __ret = memcpy((void *)tmp___3, (void const *)(rx_local->fbr[(int )rindex])->virt[(int )bindex],
+    __ret = memmove((void *)tmp___3, (void const *)(rx_local->fbr[(int )rindex])->virt[(int )bindex],
                              __len);
     skb->dev = etdev->netdev;
     skb->protocol = eth_type_trans(skb, etdev->netdev);
@@ -8854,7 +8854,7 @@ static int nic_send_packet(struct et131x_adapter *etdev , struct tcb *tcb )
   }
   {
   __len = (unsigned long )thiscopy * 16UL;
-  __ret = memcpy((void *)(etdev->tx_ring.tx_desc_ring + ((unsigned long )etdev->tx_ring.send_idx & 1023UL)),
+  __ret = memmove((void *)(etdev->tx_ring.tx_desc_ring + ((unsigned long )etdev->tx_ring.send_idx & 1023UL)),
                            (void const *)(& desc), __len);
   add_10bit(& etdev->tx_ring.send_idx, (int )thiscopy);
   }
@@ -8871,7 +8871,7 @@ static int nic_send_packet(struct et131x_adapter *etdev , struct tcb *tcb )
   if (remainder != 0U) {
     {
     __len___0 = (unsigned long )remainder * 16UL;
-    __ret___0 = memcpy((void *)etdev->tx_ring.tx_desc_ring, (void const *)(& desc) + (unsigned long )thiscopy,
+    __ret___0 = memmove((void *)etdev->tx_ring.tx_desc_ring, (void const *)(& desc) + (unsigned long )thiscopy,
                                  __len___0);
     add_10bit(& etdev->tx_ring.send_idx, (int )remainder);
     }
@@ -9168,7 +9168,7 @@ void et131x_handle_send_interrupt(struct et131x_adapter *etdev )
   return;
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void lockdep_init_map(struct lockdep_map * , char const * , struct lock_class_key * ,
                              int ) ;
 extern void __raw_spin_lock_init(raw_spinlock_t * , char const * , struct lock_class_key * ) ;
@@ -9294,12 +9294,12 @@ void et131x_hwaddr_init(struct et131x_adapter *adapter )
               }
               if (__len > 63UL) {
                 {
-                __ret = memcpy((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
+                __ret = memmove((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
                                  __len);
                 }
               } else {
                 {
-                __ret = memcpy((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
+                __ret = memmove((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
                                          __len);
                 }
               }
@@ -9323,12 +9323,12 @@ void et131x_hwaddr_init(struct et131x_adapter *adapter )
     __len___0 = 6UL;
     if (__len___0 > 63UL) {
       {
-      __ret___0 = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+      __ret___0 = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                            __len___0);
       }
     } else {
       {
-      __ret___0 = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+      __ret___0 = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                                    __len___0);
       }
     }
@@ -9472,12 +9472,12 @@ static int et131x_pci_init(struct et131x_adapter *adapter , struct pci_dev *pdev
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+    __ret = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+    __ret = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                              __len);
     }
   }
@@ -9806,11 +9806,11 @@ static struct et131x_adapter *et131x_adapter_init(struct net_device *netdev , st
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& etdev->addr), (void const *)(& default_mac), __len);
+    __ret = memmove((void *)(& etdev->addr), (void const *)(& default_mac), __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& etdev->addr), (void const *)(& default_mac),
+    __ret = memmove((void *)(& etdev->addr), (void const *)(& default_mac),
                              __len);
     }
   }
@@ -9973,12 +9973,12 @@ static int et131x_pci_setup(struct pci_dev *pdev , struct pci_device_id const *e
   }
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                              __len);
     }
   }
@@ -10961,14 +10961,14 @@ void et131x_multicast(struct net_device *netdev )
     {
     tmp___1 = i;
     i = i + 1;
-    __ret = memcpy((void *)(& adapter->MCList) + (unsigned long )tmp___1, (void const *)(& ha->addr),
+    __ret = memmove((void *)(& adapter->MCList) + (unsigned long )tmp___1, (void const *)(& ha->addr),
                      __len);
     }
   } else {
     {
     tmp___2 = i;
     i = i + 1;
-    __ret = memcpy((void *)(& adapter->MCList) + (unsigned long )tmp___2,
+    __ret = memmove((void *)(& adapter->MCList) + (unsigned long )tmp___2,
                              (void const *)(& ha->addr), __len);
     }
   }
@@ -11126,12 +11126,12 @@ int et131x_change_mtu(struct net_device *netdev , int new_mtu )
   }
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                              __len);
     }
   }
@@ -11190,7 +11190,7 @@ int et131x_set_mac_addr(struct net_device *netdev , void *new_mac )
   et131x_handle_send_interrupt(adapter);
   et131x_handle_recv_interrupt(adapter);
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& address->sa_data),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& address->sa_data),
                            __len);
   printk("<6>%s: Setting MAC address to %pM\n", (char *)(& netdev->name), netdev->dev_addr);
   et131x_adapter_memory_free(adapter);

--- a/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.i
@@ -7599,7 +7599,7 @@ struct rfd *nic_rx_pkts(struct et131x_adapter *etdev )
     etdev->net_stats.rx_bytes = etdev->net_stats.rx_bytes + (unsigned long )rfd->len;
     __len = (size_t )rfd->len;
     tmp___3 = skb_put(skb, rfd->len);
-    __ret = memcpy((void *)tmp___3, (void const *)(rx_local->fbr[(int )rindex])->virt[(int )bindex],
+    __ret = memmove((void *)tmp___3, (void const *)(rx_local->fbr[(int )rindex])->virt[(int )bindex],
                              __len);
     skb->dev = etdev->netdev;
     skb->protocol = eth_type_trans(skb, etdev->netdev);
@@ -8574,7 +8574,7 @@ static int nic_send_packet(struct et131x_adapter *etdev , struct tcb *tcb )
   }
   {
   __len = (unsigned long )thiscopy * 16UL;
-  __ret = memcpy((void *)(etdev->tx_ring.tx_desc_ring + ((unsigned long )etdev->tx_ring.send_idx & 1023UL)),
+  __ret = memmove((void *)(etdev->tx_ring.tx_desc_ring + ((unsigned long )etdev->tx_ring.send_idx & 1023UL)),
                            (void const *)(& desc), __len);
   add_10bit(& etdev->tx_ring.send_idx, (int )thiscopy);
   }
@@ -8590,7 +8590,7 @@ static int nic_send_packet(struct et131x_adapter *etdev , struct tcb *tcb )
   if (remainder != 0U) {
     {
     __len___0 = (unsigned long )remainder * 16UL;
-    __ret___0 = memcpy((void *)etdev->tx_ring.tx_desc_ring, (void const *)(& desc) + (unsigned long )thiscopy,
+    __ret___0 = memmove((void *)etdev->tx_ring.tx_desc_ring, (void const *)(& desc) + (unsigned long )thiscopy,
                                  __len___0);
     add_10bit(& etdev->tx_ring.send_idx, (int )remainder);
     }
@@ -8873,7 +8873,7 @@ void et131x_handle_send_interrupt(struct et131x_adapter *etdev )
   return;
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void lockdep_init_map(struct lockdep_map * , char const * , struct lock_class_key * ,
                              int ) ;
 extern void __raw_spin_lock_init(raw_spinlock_t * , char const * , struct lock_class_key * ) ;
@@ -8991,12 +8991,12 @@ void et131x_hwaddr_init(struct et131x_adapter *adapter )
               }
               if (__len > 63UL) {
                 {
-                __ret = memcpy((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
+                __ret = memmove((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
                                  __len);
                 }
               } else {
                 {
-                __ret = memcpy((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
+                __ret = memmove((void *)(& adapter->rom_addr), (void const *)(& adapter->addr),
                                          __len);
                 }
               }
@@ -9020,12 +9020,12 @@ void et131x_hwaddr_init(struct et131x_adapter *adapter )
     __len___0 = 6UL;
     if (__len___0 > 63UL) {
       {
-      __ret___0 = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+      __ret___0 = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                            __len___0);
       }
     } else {
       {
-      __ret___0 = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+      __ret___0 = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                                    __len___0);
       }
     }
@@ -9158,12 +9158,12 @@ static int et131x_pci_init(struct et131x_adapter *adapter , struct pci_dev *pdev
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+    __ret = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
+    __ret = memmove((void *)(& adapter->addr), (void const *)(& adapter->rom_addr),
                              __len);
     }
   }
@@ -9469,11 +9469,11 @@ static struct et131x_adapter *et131x_adapter_init(struct net_device *netdev , st
   __len = 6UL;
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)(& etdev->addr), (void const *)(& default_mac), __len);
+    __ret = memmove((void *)(& etdev->addr), (void const *)(& default_mac), __len);
     }
   } else {
     {
-    __ret = memcpy((void *)(& etdev->addr), (void const *)(& default_mac),
+    __ret = memmove((void *)(& etdev->addr), (void const *)(& default_mac),
                              __len);
     }
   }
@@ -9625,12 +9625,12 @@ static int et131x_pci_setup(struct pci_dev *pdev , struct pci_device_id const *e
   }
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                              __len);
     }
   }
@@ -10549,14 +10549,14 @@ void et131x_multicast(struct net_device *netdev )
     {
     tmp___1 = i;
     i = i + 1;
-    __ret = memcpy((void *)(& adapter->MCList) + (unsigned long )tmp___1, (void const *)(& ha->addr),
+    __ret = memmove((void *)(& adapter->MCList) + (unsigned long )tmp___1, (void const *)(& ha->addr),
                      __len);
     }
   } else {
     {
     tmp___2 = i;
     i = i + 1;
-    __ret = memcpy((void *)(& adapter->MCList) + (unsigned long )tmp___2,
+    __ret = memmove((void *)(& adapter->MCList) + (unsigned long )tmp___2,
                              (void const *)(& ha->addr), __len);
     }
   }
@@ -10702,12 +10702,12 @@ int et131x_change_mtu(struct net_device *netdev , int new_mtu )
   }
   if (__len > 63UL) {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                      __len);
     }
   } else {
     {
-    __ret = memcpy((void *)netdev->dev_addr, (void const *)(& adapter->addr),
+    __ret = memmove((void *)netdev->dev_addr, (void const *)(& adapter->addr),
                              __len);
     }
   }
@@ -10762,7 +10762,7 @@ int et131x_set_mac_addr(struct net_device *netdev , void *new_mac )
   et131x_handle_send_interrupt(adapter);
   et131x_handle_recv_interrupt(adapter);
   __len = (size_t )netdev->addr_len;
-  __ret = memcpy((void *)netdev->dev_addr, (void const *)(& address->sa_data),
+  __ret = memmove((void *)netdev->dev_addr, (void const *)(& address->sa_data),
                            __len);
   printk("<6>%s: Setting MAC address to %pM\n", (char *)(& netdev->name), netdev->dev_addr);
   et131x_adapter_memory_free(adapter);

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
@@ -6061,7 +6061,7 @@ __inline static int test_and_clear_bit(long nr , unsigned long volatile   *addr 
 extern int printk(char const   *  , ...) ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 extern unsigned long __phys_addr(unsigned long  ) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned long arch_local_save_flags(void) 
 { 
@@ -6693,7 +6693,7 @@ __inline static void skb_copy_to_linear_data(struct sk_buff *skb , void const   
 
   {
   __len = (size_t )len;
-  __ret = memcpy((void *)skb->data, from, __len);
+  __ret = memmove((void *)skb->data, from, __len);
   return;
 }
 }
@@ -7468,9 +7468,9 @@ static int dfx_driver_init(struct net_device *dev , char const   *print_name , r
   le32 = data;
   __len = 4UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& bp->factory_mac_addr), (void const   *)(& le32), __len);
+    __ret = memmove((void *)(& bp->factory_mac_addr), (void const   *)(& le32), __len);
   } else {
-    __ret = memcpy((void *)(& bp->factory_mac_addr), (void const   *)(& le32),
+    __ret = memmove((void *)(& bp->factory_mac_addr), (void const   *)(& le32),
                              __len);
   }
   tmp___1 = dfx_hw_port_ctrl_req(bp, 8U, 1U, 0U, & data);
@@ -7483,18 +7483,18 @@ static int dfx_driver_init(struct net_device *dev , char const   *print_name , r
   le32 = data;
   __len___0 = 2UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32),
+    __ret___0 = memmove((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32),
+    __ret___0 = memmove((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32),
                                  __len___0);
   }
   __len___1 = 6UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
+    __ret___1 = memmove((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
+    __ret___1 = memmove((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
                                  __len___1);
   }
   if (dfx_bus_tc != 0) {
@@ -7694,10 +7694,10 @@ static int dfx_open(struct net_device *dev )
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
+    __ret = memmove((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
+    __ret = memmove((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr),
                              __len);
   }
   memset((void *)(& bp->uc_table), 0, 6UL);
@@ -8017,10 +8017,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& bp->stats.smt_station_id), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
+    __ret = memmove((void *)(& bp->stats.smt_station_id), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
                      __len);
   } else {
-    __ret = memcpy((void *)(& bp->stats.smt_station_id), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
+    __ret = memmove((void *)(& bp->stats.smt_station_id), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
                              __len);
   }
   bp->stats.smt_op_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_op_version_id;
@@ -8028,10 +8028,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.smt_lo_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_lo_version_id;
   __len___0 = 32UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->stats.smt_user_data), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
+    __ret___0 = memmove((void *)(& bp->stats.smt_user_data), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->stats.smt_user_data), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
+    __ret___0 = memmove((void *)(& bp->stats.smt_user_data), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
                                  __len___0);
   }
   bp->stats.smt_mib_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_mib_version_id;
@@ -8060,34 +8060,34 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.mac_current_path = (bp->cmd_rsp_virt)->smt_mib_get.mac_current_path;
   __len___1 = 6UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& bp->stats.mac_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
+    __ret___1 = memmove((void *)(& bp->stats.mac_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& bp->stats.mac_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
+    __ret___1 = memmove((void *)(& bp->stats.mac_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
                                  __len___1);
   }
   __len___2 = 6UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& bp->stats.mac_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
+    __ret___2 = memmove((void *)(& bp->stats.mac_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& bp->stats.mac_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
+    __ret___2 = memmove((void *)(& bp->stats.mac_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
                                  __len___2);
   }
   __len___3 = 6UL;
   if (__len___3 > 63UL) {
-    __ret___3 = memcpy((void *)(& bp->stats.mac_old_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
+    __ret___3 = memmove((void *)(& bp->stats.mac_old_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
                          __len___3);
   } else {
-    __ret___3 = memcpy((void *)(& bp->stats.mac_old_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
+    __ret___3 = memmove((void *)(& bp->stats.mac_old_upstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
                                  __len___3);
   }
   __len___4 = 6UL;
   if (__len___4 > 63UL) {
-    __ret___4 = memcpy((void *)(& bp->stats.mac_old_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
+    __ret___4 = memmove((void *)(& bp->stats.mac_old_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
                          __len___4);
   } else {
-    __ret___4 = memcpy((void *)(& bp->stats.mac_old_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
+    __ret___4 = memmove((void *)(& bp->stats.mac_old_downstream_nbr), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
                                  __len___4);
   }
   bp->stats.mac_dup_address_test = (bp->cmd_rsp_virt)->smt_mib_get.mac_dup_address_test;
@@ -8095,10 +8095,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.mac_downstream_port_type = (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_port_type;
   __len___5 = 6UL;
   if (__len___5 > 63UL) {
-    __ret___5 = memcpy((void *)(& bp->stats.mac_smt_address), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
+    __ret___5 = memmove((void *)(& bp->stats.mac_smt_address), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
                          __len___5);
   } else {
-    __ret___5 = memcpy((void *)(& bp->stats.mac_smt_address), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
+    __ret___5 = memmove((void *)(& bp->stats.mac_smt_address), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
                                  __len___5);
   }
   bp->stats.mac_t_req = (bp->cmd_rsp_virt)->smt_mib_get.mac_t_req;
@@ -8119,10 +8119,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.path_max_t_req = (bp->cmd_rsp_virt)->smt_mib_get.path_max_t_req;
   __len___6 = 32UL;
   if (__len___6 > 63UL) {
-    __ret___6 = memcpy((void *)(& bp->stats.path_configuration), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
+    __ret___6 = memmove((void *)(& bp->stats.path_configuration), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
                          __len___6);
   } else {
-    __ret___6 = memcpy((void *)(& bp->stats.path_configuration), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
+    __ret___6 = memmove((void *)(& bp->stats.path_configuration), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
                                  __len___6);
   }
   bp->stats.port_my_type[0] = (bp->cmd_rsp_virt)->smt_mib_get.port_my_type[0];
@@ -8137,18 +8137,18 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.port_current_path[1] = (bp->cmd_rsp_virt)->smt_mib_get.port_current_path[1];
   __len___7 = 3UL;
   if (__len___7 > 63UL) {
-    __ret___7 = memcpy((void *)(& bp->stats.port_requested_paths), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
+    __ret___7 = memmove((void *)(& bp->stats.port_requested_paths), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
                          __len___7);
   } else {
-    __ret___7 = memcpy((void *)(& bp->stats.port_requested_paths), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
+    __ret___7 = memmove((void *)(& bp->stats.port_requested_paths), (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
                                  __len___7);
   }
   __len___8 = 3UL;
   if (__len___8 > 63UL) {
-    __ret___8 = memcpy((void *)(& bp->stats.port_requested_paths) + 3U, (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
+    __ret___8 = memmove((void *)(& bp->stats.port_requested_paths) + 3U, (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
                          __len___8);
   } else {
-    __ret___8 = memcpy((void *)(& bp->stats.port_requested_paths) + 3U,
+    __ret___8 = memmove((void *)(& bp->stats.port_requested_paths) + 3U,
                                  (void const   *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
                                  __len___8);
   }
@@ -8237,12 +8237,12 @@ static void dfx_ctl_set_multicast_list(struct net_device *dev )
     if (__len > 63UL) {
       tmp___0 = i;
       i = i + 1;
-      __ret = memcpy((void *)(& bp->mc_table) + (unsigned long )(tmp___0 * 6), (void const   *)(& ha->addr),
+      __ret = memmove((void *)(& bp->mc_table) + (unsigned long )(tmp___0 * 6), (void const   *)(& ha->addr),
                        __len);
     } else {
       tmp___1 = i;
       i = i + 1;
-      __ret = memcpy((void *)(& bp->mc_table) + (unsigned long )(tmp___1 * 6),
+      __ret = memmove((void *)(& bp->mc_table) + (unsigned long )(tmp___1 * 6),
                                (void const   *)(& ha->addr), __len);
     }
     __mptr___0 = (struct list_head  const  *)ha->list.next;
@@ -8277,18 +8277,18 @@ static int dfx_ctl_set_mac_address(struct net_device *dev , void *addr )
   bp = (DFX_board_t *)tmp;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dev->dev_addr, (void const   *)(& p_sockaddr->sa_data),
+    __ret = memmove((void *)dev->dev_addr, (void const   *)(& p_sockaddr->sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)dev->dev_addr, (void const   *)(& p_sockaddr->sa_data),
+    __ret = memmove((void *)dev->dev_addr, (void const   *)(& p_sockaddr->sa_data),
                              __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->uc_table), (void const   *)(& p_sockaddr->sa_data),
+    __ret___0 = memmove((void *)(& bp->uc_table), (void const   *)(& p_sockaddr->sa_data),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->uc_table), (void const   *)(& p_sockaddr->sa_data),
+    __ret___0 = memmove((void *)(& bp->uc_table), (void const   *)(& p_sockaddr->sa_data),
                                  __len___0);
   }
   bp->uc_count = 1U;
@@ -8323,10 +8323,10 @@ static int dfx_ctl_update_cam(DFX_board_t *bp )
   if (i <= 61) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)p_addr, (void const   *)(& bp->uc_table) + (unsigned long )(i * 6),
+      __ret = memmove((void *)p_addr, (void const   *)(& bp->uc_table) + (unsigned long )(i * 6),
                        __len);
     } else {
-      __ret = memcpy((void *)p_addr, (void const   *)(& bp->uc_table) + (unsigned long )(i * 6),
+      __ret = memmove((void *)p_addr, (void const   *)(& bp->uc_table) + (unsigned long )(i * 6),
                                __len);
     }
     p_addr = p_addr + 1;
@@ -8346,10 +8346,10 @@ static int dfx_ctl_update_cam(DFX_board_t *bp )
   if (bp->uc_count + (u32 )i <= 61U) {
     __len___0 = 6UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)p_addr, (void const   *)(& bp->mc_table) + (unsigned long )(i * 6),
+      __ret___0 = memmove((void *)p_addr, (void const   *)(& bp->mc_table) + (unsigned long )(i * 6),
                            __len___0);
     } else {
-      __ret___0 = memcpy((void *)p_addr, (void const   *)(& bp->mc_table) + (unsigned long )(i * 6),
+      __ret___0 = memmove((void *)p_addr, (void const   *)(& bp->mc_table) + (unsigned long )(i * 6),
                                    __len___0);
     }
     p_addr = p_addr + 1;
@@ -8665,9 +8665,9 @@ static void dfx_rcv_queue_process(DFX_board_t *bp )
   p_buff = (char *)((struct sk_buff *)bp->p_rcv_buff_va[entry])->data;
   __len = 4UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& descr), (void const   *)p_buff, __len);
+    __ret = memmove((void *)(& descr), (void const   *)p_buff, __len);
   } else {
-    __ret = memcpy((void *)(& descr), (void const   *)p_buff, __len);
+    __ret = memmove((void *)(& descr), (void const   *)p_buff, __len);
   }
   if ((descr & 2097152U) != 0U) {
     if ((descr & 1048576U) != 0U) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.i
@@ -6051,7 +6051,7 @@ __inline static int test_and_clear_bit(long nr , unsigned long volatile *addr )
 extern int printk(char const * , ...) ;
 extern void warn_slowpath_null(char const * , int const ) ;
 extern unsigned long __phys_addr(unsigned long ) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned long arch_local_save_flags(void)
 {
@@ -6607,7 +6607,7 @@ __inline static void skb_copy_to_linear_data(struct sk_buff *skb , void const *f
   void *__ret ;
   {
   __len = (size_t )len;
-  __ret = memcpy((void *)skb->data, from, __len);
+  __ret = memmove((void *)skb->data, from, __len);
   return;
 }
 }
@@ -7317,9 +7317,9 @@ static int dfx_driver_init(struct net_device *dev , char const *print_name , res
   le32 = data;
   __len = 4UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& bp->factory_mac_addr), (void const *)(& le32), __len);
+    __ret = memmove((void *)(& bp->factory_mac_addr), (void const *)(& le32), __len);
   } else {
-    __ret = memcpy((void *)(& bp->factory_mac_addr), (void const *)(& le32),
+    __ret = memmove((void *)(& bp->factory_mac_addr), (void const *)(& le32),
                              __len);
   }
   tmp___1 = dfx_hw_port_ctrl_req(bp, 8U, 1U, 0U, & data);
@@ -7331,18 +7331,18 @@ static int dfx_driver_init(struct net_device *dev , char const *print_name , res
   le32 = data;
   __len___0 = 2UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->factory_mac_addr) + 4U, (void const *)(& le32),
+    __ret___0 = memmove((void *)(& bp->factory_mac_addr) + 4U, (void const *)(& le32),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->factory_mac_addr) + 4U, (void const *)(& le32),
+    __ret___0 = memmove((void *)(& bp->factory_mac_addr) + 4U, (void const *)(& le32),
                                  __len___0);
   }
   __len___1 = 6UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
+    __ret___1 = memmove((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
+    __ret___1 = memmove((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
                                  __len___1);
   }
   if (dfx_bus_tc != 0) {
@@ -7522,10 +7522,10 @@ static int dfx_open(struct net_device *dev )
   }
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
+    __ret = memmove((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
                      __len);
   } else {
-    __ret = memcpy((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
+    __ret = memmove((void *)dev->dev_addr, (void const *)(& bp->factory_mac_addr),
                              __len);
   }
   memset((void *)(& bp->uc_table), 0, 6UL);
@@ -7820,10 +7820,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   }
   __len = 8UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& bp->stats.smt_station_id), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
+    __ret = memmove((void *)(& bp->stats.smt_station_id), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
                      __len);
   } else {
-    __ret = memcpy((void *)(& bp->stats.smt_station_id), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
+    __ret = memmove((void *)(& bp->stats.smt_station_id), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_station_id),
                              __len);
   }
   bp->stats.smt_op_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_op_version_id;
@@ -7831,10 +7831,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.smt_lo_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_lo_version_id;
   __len___0 = 32UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->stats.smt_user_data), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
+    __ret___0 = memmove((void *)(& bp->stats.smt_user_data), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->stats.smt_user_data), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
+    __ret___0 = memmove((void *)(& bp->stats.smt_user_data), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.smt_user_data),
                                  __len___0);
   }
   bp->stats.smt_mib_version_id = (bp->cmd_rsp_virt)->smt_mib_get.smt_mib_version_id;
@@ -7863,34 +7863,34 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.mac_current_path = (bp->cmd_rsp_virt)->smt_mib_get.mac_current_path;
   __len___1 = 6UL;
   if (__len___1 > 63UL) {
-    __ret___1 = memcpy((void *)(& bp->stats.mac_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
+    __ret___1 = memmove((void *)(& bp->stats.mac_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
                          __len___1);
   } else {
-    __ret___1 = memcpy((void *)(& bp->stats.mac_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
+    __ret___1 = memmove((void *)(& bp->stats.mac_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_upstream_nbr),
                                  __len___1);
   }
   __len___2 = 6UL;
   if (__len___2 > 63UL) {
-    __ret___2 = memcpy((void *)(& bp->stats.mac_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
+    __ret___2 = memmove((void *)(& bp->stats.mac_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
                          __len___2);
   } else {
-    __ret___2 = memcpy((void *)(& bp->stats.mac_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
+    __ret___2 = memmove((void *)(& bp->stats.mac_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_nbr),
                                  __len___2);
   }
   __len___3 = 6UL;
   if (__len___3 > 63UL) {
-    __ret___3 = memcpy((void *)(& bp->stats.mac_old_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
+    __ret___3 = memmove((void *)(& bp->stats.mac_old_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
                          __len___3);
   } else {
-    __ret___3 = memcpy((void *)(& bp->stats.mac_old_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
+    __ret___3 = memmove((void *)(& bp->stats.mac_old_upstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_upstream_nbr),
                                  __len___3);
   }
   __len___4 = 6UL;
   if (__len___4 > 63UL) {
-    __ret___4 = memcpy((void *)(& bp->stats.mac_old_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
+    __ret___4 = memmove((void *)(& bp->stats.mac_old_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
                          __len___4);
   } else {
-    __ret___4 = memcpy((void *)(& bp->stats.mac_old_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
+    __ret___4 = memmove((void *)(& bp->stats.mac_old_downstream_nbr), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_old_downstream_nbr),
                                  __len___4);
   }
   bp->stats.mac_dup_address_test = (bp->cmd_rsp_virt)->smt_mib_get.mac_dup_address_test;
@@ -7898,10 +7898,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.mac_downstream_port_type = (bp->cmd_rsp_virt)->smt_mib_get.mac_downstream_port_type;
   __len___5 = 6UL;
   if (__len___5 > 63UL) {
-    __ret___5 = memcpy((void *)(& bp->stats.mac_smt_address), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
+    __ret___5 = memmove((void *)(& bp->stats.mac_smt_address), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
                          __len___5);
   } else {
-    __ret___5 = memcpy((void *)(& bp->stats.mac_smt_address), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
+    __ret___5 = memmove((void *)(& bp->stats.mac_smt_address), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.mac_smt_address),
                                  __len___5);
   }
   bp->stats.mac_t_req = (bp->cmd_rsp_virt)->smt_mib_get.mac_t_req;
@@ -7922,10 +7922,10 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.path_max_t_req = (bp->cmd_rsp_virt)->smt_mib_get.path_max_t_req;
   __len___6 = 32UL;
   if (__len___6 > 63UL) {
-    __ret___6 = memcpy((void *)(& bp->stats.path_configuration), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
+    __ret___6 = memmove((void *)(& bp->stats.path_configuration), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
                          __len___6);
   } else {
-    __ret___6 = memcpy((void *)(& bp->stats.path_configuration), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
+    __ret___6 = memmove((void *)(& bp->stats.path_configuration), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.path_configuration),
                                  __len___6);
   }
   bp->stats.port_my_type[0] = (bp->cmd_rsp_virt)->smt_mib_get.port_my_type[0];
@@ -7940,18 +7940,18 @@ static struct net_device_stats *dfx_ctl_get_stats(struct net_device *dev )
   bp->stats.port_current_path[1] = (bp->cmd_rsp_virt)->smt_mib_get.port_current_path[1];
   __len___7 = 3UL;
   if (__len___7 > 63UL) {
-    __ret___7 = memcpy((void *)(& bp->stats.port_requested_paths), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
+    __ret___7 = memmove((void *)(& bp->stats.port_requested_paths), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
                          __len___7);
   } else {
-    __ret___7 = memcpy((void *)(& bp->stats.port_requested_paths), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
+    __ret___7 = memmove((void *)(& bp->stats.port_requested_paths), (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths),
                                  __len___7);
   }
   __len___8 = 3UL;
   if (__len___8 > 63UL) {
-    __ret___8 = memcpy((void *)(& bp->stats.port_requested_paths) + 3U, (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
+    __ret___8 = memmove((void *)(& bp->stats.port_requested_paths) + 3U, (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
                          __len___8);
   } else {
-    __ret___8 = memcpy((void *)(& bp->stats.port_requested_paths) + 3U,
+    __ret___8 = memmove((void *)(& bp->stats.port_requested_paths) + 3U,
                                  (void const *)(& (bp->cmd_rsp_virt)->smt_mib_get.port_requested_paths) + 1U,
                                  __len___8);
   }
@@ -8038,12 +8038,12 @@ static void dfx_ctl_set_multicast_list(struct net_device *dev )
     if (__len > 63UL) {
       tmp___0 = i;
       i = i + 1;
-      __ret = memcpy((void *)(& bp->mc_table) + (unsigned long )(tmp___0 * 6), (void const *)(& ha->addr),
+      __ret = memmove((void *)(& bp->mc_table) + (unsigned long )(tmp___0 * 6), (void const *)(& ha->addr),
                        __len);
     } else {
       tmp___1 = i;
       i = i + 1;
-      __ret = memcpy((void *)(& bp->mc_table) + (unsigned long )(tmp___1 * 6),
+      __ret = memmove((void *)(& bp->mc_table) + (unsigned long )(tmp___1 * 6),
                                (void const *)(& ha->addr), __len);
     }
     __mptr___0 = (struct list_head const *)ha->list.next;
@@ -8076,18 +8076,18 @@ static int dfx_ctl_set_mac_address(struct net_device *dev , void *addr )
   bp = (DFX_board_t *)tmp;
   __len = 6UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)dev->dev_addr, (void const *)(& p_sockaddr->sa_data),
+    __ret = memmove((void *)dev->dev_addr, (void const *)(& p_sockaddr->sa_data),
                      __len);
   } else {
-    __ret = memcpy((void *)dev->dev_addr, (void const *)(& p_sockaddr->sa_data),
+    __ret = memmove((void *)dev->dev_addr, (void const *)(& p_sockaddr->sa_data),
                              __len);
   }
   __len___0 = 6UL;
   if (__len___0 > 63UL) {
-    __ret___0 = memcpy((void *)(& bp->uc_table), (void const *)(& p_sockaddr->sa_data),
+    __ret___0 = memmove((void *)(& bp->uc_table), (void const *)(& p_sockaddr->sa_data),
                          __len___0);
   } else {
-    __ret___0 = memcpy((void *)(& bp->uc_table), (void const *)(& p_sockaddr->sa_data),
+    __ret___0 = memmove((void *)(& bp->uc_table), (void const *)(& p_sockaddr->sa_data),
                                  __len___0);
   }
   bp->uc_count = 1U;
@@ -8120,10 +8120,10 @@ static int dfx_ctl_update_cam(DFX_board_t *bp )
   if (i <= 61) {
     __len = 6UL;
     if (__len > 63UL) {
-      __ret = memcpy((void *)p_addr, (void const *)(& bp->uc_table) + (unsigned long )(i * 6),
+      __ret = memmove((void *)p_addr, (void const *)(& bp->uc_table) + (unsigned long )(i * 6),
                        __len);
     } else {
-      __ret = memcpy((void *)p_addr, (void const *)(& bp->uc_table) + (unsigned long )(i * 6),
+      __ret = memmove((void *)p_addr, (void const *)(& bp->uc_table) + (unsigned long )(i * 6),
                                __len);
     }
     p_addr = p_addr + 1;
@@ -8141,10 +8141,10 @@ static int dfx_ctl_update_cam(DFX_board_t *bp )
   if (bp->uc_count + (u32 )i <= 61U) {
     __len___0 = 6UL;
     if (__len___0 > 63UL) {
-      __ret___0 = memcpy((void *)p_addr, (void const *)(& bp->mc_table) + (unsigned long )(i * 6),
+      __ret___0 = memmove((void *)p_addr, (void const *)(& bp->mc_table) + (unsigned long )(i * 6),
                            __len___0);
     } else {
-      __ret___0 = memcpy((void *)p_addr, (void const *)(& bp->mc_table) + (unsigned long )(i * 6),
+      __ret___0 = memmove((void *)p_addr, (void const *)(& bp->mc_table) + (unsigned long )(i * 6),
                                    __len___0);
     }
     p_addr = p_addr + 1;
@@ -8427,9 +8427,9 @@ static void dfx_rcv_queue_process(DFX_board_t *bp )
   p_buff = (char *)((struct sk_buff *)bp->p_rcv_buff_va[entry])->data;
   __len = 4UL;
   if (__len > 63UL) {
-    __ret = memcpy((void *)(& descr), (void const *)p_buff, __len);
+    __ret = memmove((void *)(& descr), (void const *)p_buff, __len);
   } else {
-    __ret = memcpy((void *)(& descr), (void const *)p_buff, __len);
+    __ret = memmove((void *)(& descr), (void const *)p_buff, __len);
   }
   if ((descr & 2097152U) != 0U) {
     if ((descr & 1048576U) != 0U) {

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -257,7 +257,7 @@ struct page___0 *ldv_some_page() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -989,7 +989,7 @@ long ldv__builtin_expect(long val , long res ) ;
 extern int ( /* format attribute */  __dynamic_dev_dbg)(struct _ddebug *descriptor ,
                                                         struct device  const  *dev ,
                                                         char const   *fmt  , ...) ;
-extern void *memcpy(void *to , void const   *from , size_t len ) ;
+extern void *memmove(void *to , void const   *from , size_t len ) ;
 __inline static bool gpio_is_valid(int number )  __attribute__((__no_instrument_function__)) ;
 __inline static bool gpio_is_valid(int number ) 
 { int tmp ;
@@ -2067,14 +2067,14 @@ static int max8903_probe(struct platform_device *pdev )
     __cil_tmp44 = (struct max8903_pdata *)data;
     __cil_tmp45 = (void *)__cil_tmp44;
     __cil_tmp46 = (void const   *)pdata;
-    __ret = memcpy(__cil_tmp45, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp45, __cil_tmp46, __len);
     }
   } else {
     {
     __cil_tmp47 = (struct max8903_pdata *)data;
     __cil_tmp48 = (void *)__cil_tmp47;
     __cil_tmp49 = (void const   *)pdata;
-    __ret = memcpy(__cil_tmp48, __cil_tmp49, __len);
+    __ret = memmove(__cil_tmp48, __cil_tmp49, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -982,7 +982,7 @@ long ldv__builtin_expect(long val , long res ) ;
 extern int ( __dynamic_dev_dbg)(struct _ddebug *descriptor ,
                                                         struct device const *dev ,
                                                         char const *fmt , ...) ;
-extern void *memcpy(void *to , void const *from , size_t len ) ;
+extern void *memmove(void *to , void const *from , size_t len ) ;
 __inline static bool gpio_is_valid(int number ) __attribute__((__no_instrument_function__)) ;
 __inline static bool gpio_is_valid(int number )
 { int tmp ;
@@ -2031,14 +2031,14 @@ static int max8903_probe(struct platform_device *pdev )
     __cil_tmp44 = (struct max8903_pdata *)data;
     __cil_tmp45 = (void *)__cil_tmp44;
     __cil_tmp46 = (void const *)pdata;
-    __ret = memcpy(__cil_tmp45, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp45, __cil_tmp46, __len);
     }
   } else {
     {
     __cil_tmp47 = (struct max8903_pdata *)data;
     __cil_tmp48 = (void *)__cil_tmp47;
     __cil_tmp49 = (void const *)pdata;
-    __ret = memcpy(__cil_tmp48, __cil_tmp49, __len);
+    __ret = memmove(__cil_tmp48, __cil_tmp49, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5936,7 +5936,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp30 = buf + 1;
       __cil_tmp31 = (void *)__cil_tmp30;
       __cil_tmp32 = (void const   *)out;
-      __ret = memcpy(__cil_tmp31, __cil_tmp32, __len);
+      __ret = memmove(__cil_tmp31, __cil_tmp32, __len);
       }
     } else {
 
@@ -6163,7 +6163,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp90 = (void *)in;
       __cil_tmp91 = buf + 1;
       __cil_tmp92 = (void const   *)__cil_tmp91;
-      __ret___0 = memcpy(__cil_tmp90, __cil_tmp92, __len___0);
+      __ret___0 = memmove(__cil_tmp90, __cil_tmp92, __len___0);
       }
     } else {
 
@@ -7428,7 +7428,7 @@ long ldv__builtin_expect(long val , long res )
   return (val);
 }
 }
-extern void *memcpy(void *to , void const   *from , size_t len ) ;
+extern void *memmove(void *to , void const   *from , size_t len ) ;
 extern void kfree(void const   * ) ;
 extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_assume(int);
@@ -8045,14 +8045,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5922,7 +5922,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp30 = buf + 1;
       __cil_tmp31 = (void *)__cil_tmp30;
       __cil_tmp32 = (void const *)out;
-      __ret = memcpy(__cil_tmp31, __cil_tmp32, __len);
+      __ret = memmove(__cil_tmp31, __cil_tmp32, __len);
       }
     } else {
     }
@@ -6137,7 +6137,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp90 = (void *)in;
       __cil_tmp91 = buf + 1;
       __cil_tmp92 = (void const *)__cil_tmp91;
-      __ret___0 = memcpy(__cil_tmp90, __cil_tmp92, __len___0);
+      __ret___0 = memmove(__cil_tmp90, __cil_tmp92, __len___0);
       }
     } else {
     }
@@ -7355,7 +7355,7 @@ long ldv__builtin_expect(long val , long res )
   return (val);
 }
 }
-extern void *memcpy(void *to , void const *from , size_t len ) ;
+extern void *memmove(void *to , void const *from , size_t len ) ;
 extern void kfree(void const * ) ;
 extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_assume(int);
@@ -7950,14 +7950,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2754,7 +2754,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile   *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count )  __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count ) 
@@ -2766,7 +2766,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile   *src , size
   {
   __len = count;
   __cil_tmp6 = (void const   *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2746,7 +2746,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count ) __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
@@ -2757,7 +2757,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t
   {
   __len = count;
   __cil_tmp6 = (void const *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3137,7 +3137,7 @@ __inline static int __attribute__((__warn_unused_result__))  kstrtoul(char const
 }
 }
 extern unsigned long __phys_addr(unsigned long  ) ;
-extern void *memcpy(void *to , void const   *from , size_t len ) ;
+extern void *memmove(void *to , void const   *from , size_t len ) ;
 extern void *memset(void *s , int c , size_t n ) ;
 extern int strncmp(char const   * , char const   * , __kernel_size_t  ) ;
 __inline static long __attribute__((__warn_unused_result__))  PTR_ERR(void const   *ptr )  __attribute__((__no_instrument_function__)) ;
@@ -4092,7 +4092,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp112 = (efi_guid_t *)__cil_tmp111;
     __cil_tmp113 = (void *)__cil_tmp112;
     __cil_tmp114 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp113, __cil_tmp114, __len);
+    __ret = memmove(__cil_tmp113, __cil_tmp114, __len);
     }
   } else {
     {
@@ -4100,7 +4100,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp116 = (efi_guid_t *)__cil_tmp115;
     __cil_tmp117 = (void *)__cil_tmp116;
     __cil_tmp118 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp117, __cil_tmp118, __len);
+    __ret = memmove(__cil_tmp117, __cil_tmp118, __len);
     }
   }
   {
@@ -4120,7 +4120,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp130 = *((u8 **)__cil_tmp129);
   __cil_tmp131 = (void *)__cil_tmp130;
   __cil_tmp132 = (void const   *)name;
-  __ret___0 = memcpy(__cil_tmp131, __cil_tmp132, __len___0);
+  __ret___0 = memmove(__cil_tmp131, __cil_tmp132, __len___0);
   __cil_tmp133 = (unsigned long )(& gsmi_dev) + 16;
   __cil_tmp134 = *((struct gsmi_buf **)__cil_tmp133);
   __cil_tmp135 = *((u8 **)__cil_tmp134);
@@ -4150,7 +4150,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp153 = *((u8 **)__cil_tmp152);
     __cil_tmp154 = (void *)__cil_tmp153;
     __cil_tmp155 = (void const   *)(& param);
-    __ret___1 = memcpy(__cil_tmp154, __cil_tmp155, __len___1);
+    __ret___1 = memmove(__cil_tmp154, __cil_tmp155, __len___1);
     }
   } else {
     {
@@ -4159,7 +4159,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp158 = *((u8 **)__cil_tmp157);
     __cil_tmp159 = (void *)__cil_tmp158;
     __cil_tmp160 = (void const   *)(& param);
-    __ret___1 = memcpy(__cil_tmp159, __cil_tmp160, __len___1);
+    __ret___1 = memmove(__cil_tmp159, __cil_tmp160, __len___1);
     }
   }
   {
@@ -4186,7 +4186,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
       __cil_tmp167 = *((struct gsmi_buf **)__cil_tmp166);
       __cil_tmp168 = *((u8 **)__cil_tmp167);
       __cil_tmp169 = (void const   *)__cil_tmp168;
-      __ret___2 = memcpy(__cil_tmp165, __cil_tmp169, __len___2);
+      __ret___2 = memmove(__cil_tmp165, __cil_tmp169, __len___2);
       }
     } else {
       {
@@ -4195,7 +4195,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
       __cil_tmp172 = *((struct gsmi_buf **)__cil_tmp171);
       __cil_tmp173 = *((u8 **)__cil_tmp172);
       __cil_tmp174 = (void const   *)__cil_tmp173;
-      __ret___2 = memcpy(__cil_tmp170, __cil_tmp174, __len___2);
+      __ret___2 = memmove(__cil_tmp170, __cil_tmp174, __len___2);
       }
     }
     __min1 = *data_size;
@@ -4226,7 +4226,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp182 = *((struct gsmi_buf **)__cil_tmp181);
     __cil_tmp183 = *((u8 **)__cil_tmp182);
     __cil_tmp184 = (void const   *)__cil_tmp183;
-    __ret___3 = memcpy(data, __cil_tmp184, __len___3);
+    __ret___3 = memmove(data, __cil_tmp184, __len___3);
     *attr = (u32 )7;
     }
   }
@@ -4518,7 +4518,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp90 = (u8 (*)[16])__cil_tmp89;
     __cil_tmp91 = (void *)__cil_tmp90;
     __cil_tmp92 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp91, __cil_tmp92, __len);
+    __ret = memmove(__cil_tmp91, __cil_tmp92, __len);
     }
   } else {
     {
@@ -4526,7 +4526,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp94 = (u8 (*)[16])__cil_tmp93;
     __cil_tmp95 = (void *)__cil_tmp94;
     __cil_tmp96 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp95, __cil_tmp96, __len);
+    __ret = memmove(__cil_tmp95, __cil_tmp96, __len);
     }
   }
   {
@@ -4536,7 +4536,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
   __cil_tmp99 = *((u8 **)__cil_tmp98);
   __cil_tmp100 = (void *)__cil_tmp99;
   __cil_tmp101 = (void const   *)name;
-  __ret___0 = memcpy(__cil_tmp100, __cil_tmp101, __len___0);
+  __ret___0 = memmove(__cil_tmp100, __cil_tmp101, __len___0);
   __cil_tmp102 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp103 = *((struct gsmi_buf **)__cil_tmp102);
   __cil_tmp104 = *((u8 **)__cil_tmp103);
@@ -4556,7 +4556,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp113 = *((u8 **)__cil_tmp112);
     __cil_tmp114 = (void *)__cil_tmp113;
     __cil_tmp115 = (void const   *)(& param);
-    __ret___1 = memcpy(__cil_tmp114, __cil_tmp115, __len___1);
+    __ret___1 = memmove(__cil_tmp114, __cil_tmp115, __len___1);
     }
   } else {
     {
@@ -4565,7 +4565,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp118 = *((u8 **)__cil_tmp117);
     __cil_tmp119 = (void *)__cil_tmp118;
     __cil_tmp120 = (void const   *)(& param);
-    __ret___1 = memcpy(__cil_tmp119, __cil_tmp120, __len___1);
+    __ret___1 = memmove(__cil_tmp119, __cil_tmp120, __len___1);
     }
   }
   {
@@ -4592,7 +4592,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp127 = *((struct gsmi_buf **)__cil_tmp126);
       __cil_tmp128 = *((u8 **)__cil_tmp127);
       __cil_tmp129 = (void const   *)__cil_tmp128;
-      __ret___2 = memcpy(__cil_tmp125, __cil_tmp129, __len___2);
+      __ret___2 = memmove(__cil_tmp125, __cil_tmp129, __len___2);
       }
     } else {
       {
@@ -4601,7 +4601,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp132 = *((struct gsmi_buf **)__cil_tmp131);
       __cil_tmp133 = *((u8 **)__cil_tmp132);
       __cil_tmp134 = (void const   *)__cil_tmp133;
-      __ret___2 = memcpy(__cil_tmp130, __cil_tmp134, __len___2);
+      __ret___2 = memmove(__cil_tmp130, __cil_tmp134, __len___2);
       }
     }
     __len___3 = (size_t )1024;
@@ -4612,7 +4612,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp137 = *((struct gsmi_buf **)__cil_tmp136);
       __cil_tmp138 = *((u8 **)__cil_tmp137);
       __cil_tmp139 = (void const   *)__cil_tmp138;
-      __ret___3 = memcpy(__cil_tmp135, __cil_tmp139, __len___3);
+      __ret___3 = memmove(__cil_tmp135, __cil_tmp139, __len___3);
       }
     } else {
       {
@@ -4621,7 +4621,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp142 = *((struct gsmi_buf **)__cil_tmp141);
       __cil_tmp143 = *((u8 **)__cil_tmp142);
       __cil_tmp144 = (void const   *)__cil_tmp143;
-      __ret___3 = memcpy(__cil_tmp140, __cil_tmp144, __len___3);
+      __ret___3 = memmove(__cil_tmp140, __cil_tmp144, __len___3);
       }
     }
     {
@@ -4635,7 +4635,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp146 = & param;
       __cil_tmp147 = (u8 (*)[16])__cil_tmp146;
       __cil_tmp148 = (void const   *)__cil_tmp147;
-      __ret___4 = memcpy(__cil_tmp145, __cil_tmp148, __len___4);
+      __ret___4 = memmove(__cil_tmp145, __cil_tmp148, __len___4);
       }
     } else {
       {
@@ -4643,7 +4643,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp150 = & param;
       __cil_tmp151 = (u8 (*)[16])__cil_tmp150;
       __cil_tmp152 = (void const   *)__cil_tmp151;
-      __ret___4 = memcpy(__cil_tmp149, __cil_tmp152, __len___4);
+      __ret___4 = memmove(__cil_tmp149, __cil_tmp152, __len___4);
       }
     }
     ret = (efi_status_t )0;
@@ -4950,7 +4950,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp103 = (efi_guid_t *)__cil_tmp102;
     __cil_tmp104 = (void *)__cil_tmp103;
     __cil_tmp105 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp104, __cil_tmp105, __len);
+    __ret = memmove(__cil_tmp104, __cil_tmp105, __len);
     }
   } else {
     {
@@ -4958,7 +4958,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp107 = (efi_guid_t *)__cil_tmp106;
     __cil_tmp108 = (void *)__cil_tmp107;
     __cil_tmp109 = (void const   *)vendor;
-    __ret = memcpy(__cil_tmp108, __cil_tmp109, __len);
+    __ret = memmove(__cil_tmp108, __cil_tmp109, __len);
     }
   }
   {
@@ -4978,7 +4978,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp121 = *((u8 **)__cil_tmp120);
   __cil_tmp122 = (void *)__cil_tmp121;
   __cil_tmp123 = (void const   *)name;
-  __ret___0 = memcpy(__cil_tmp122, __cil_tmp123, __len___0);
+  __ret___0 = memmove(__cil_tmp122, __cil_tmp123, __len___0);
   __cil_tmp124 = (unsigned long )(& gsmi_dev) + 16;
   __cil_tmp125 = *((struct gsmi_buf **)__cil_tmp124);
   __cil_tmp126 = *((u8 **)__cil_tmp125);
@@ -4995,7 +4995,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp135 = *((u8 **)__cil_tmp134);
   __cil_tmp136 = (void *)__cil_tmp135;
   __cil_tmp137 = (void const   *)data;
-  __ret___1 = memcpy(__cil_tmp136, __cil_tmp137, __len___1);
+  __ret___1 = memmove(__cil_tmp136, __cil_tmp137, __len___1);
   __cil_tmp138 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp139 = *((struct gsmi_buf **)__cil_tmp138);
   __cil_tmp140 = *((u8 **)__cil_tmp139);
@@ -5015,7 +5015,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp149 = *((u8 **)__cil_tmp148);
     __cil_tmp150 = (void *)__cil_tmp149;
     __cil_tmp151 = (void const   *)(& param);
-    __ret___2 = memcpy(__cil_tmp150, __cil_tmp151, __len___2);
+    __ret___2 = memmove(__cil_tmp150, __cil_tmp151, __len___2);
     }
   } else {
     {
@@ -5024,7 +5024,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp154 = *((u8 **)__cil_tmp153);
     __cil_tmp155 = (void *)__cil_tmp154;
     __cil_tmp156 = (void const   *)(& param);
-    __ret___2 = memcpy(__cil_tmp155, __cil_tmp156, __len___2);
+    __ret___2 = memmove(__cil_tmp155, __cil_tmp156, __len___2);
     }
   }
   {
@@ -5194,7 +5194,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
   __cil_tmp48 = *((u8 **)__cil_tmp47);
   __cil_tmp49 = (void *)__cil_tmp48;
   __cil_tmp50 = (void const   *)buf;
-  __ret = memcpy(__cil_tmp49, __cil_tmp50, __len);
+  __ret = memmove(__cil_tmp49, __cil_tmp50, __len);
   __cil_tmp51 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp52 = *((struct gsmi_buf **)__cil_tmp51);
   __cil_tmp53 = *((u8 **)__cil_tmp52);
@@ -5214,7 +5214,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
     __cil_tmp62 = *((u8 **)__cil_tmp61);
     __cil_tmp63 = (void *)__cil_tmp62;
     __cil_tmp64 = (void const   *)(& param);
-    __ret___0 = memcpy(__cil_tmp63, __cil_tmp64, __len___0);
+    __ret___0 = memmove(__cil_tmp63, __cil_tmp64, __len___0);
     }
   } else {
     {
@@ -5223,7 +5223,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
     __cil_tmp67 = *((u8 **)__cil_tmp66);
     __cil_tmp68 = (void *)__cil_tmp67;
     __cil_tmp69 = (void const   *)(& param);
-    __ret___0 = memcpy(__cil_tmp68, __cil_tmp69, __len___0);
+    __ret___0 = memmove(__cil_tmp68, __cil_tmp69, __len___0);
     }
   }
   {
@@ -5358,7 +5358,7 @@ static ssize_t gsmi_clear_eventlog_store(struct kobject *kobj , struct kobj_attr
     __cil_tmp33 = *((u8 **)__cil_tmp32);
     __cil_tmp34 = (void *)__cil_tmp33;
     __cil_tmp35 = (void const   *)(& param);
-    __ret = memcpy(__cil_tmp34, __cil_tmp35, __len);
+    __ret = memmove(__cil_tmp34, __cil_tmp35, __len);
     }
   } else {
     {
@@ -5367,7 +5367,7 @@ static ssize_t gsmi_clear_eventlog_store(struct kobject *kobj , struct kobj_attr
     __cil_tmp38 = *((u8 **)__cil_tmp37);
     __cil_tmp39 = (void *)__cil_tmp38;
     __cil_tmp40 = (void const   *)(& param);
-    __ret = memcpy(__cil_tmp39, __cil_tmp40, __len);
+    __ret = memmove(__cil_tmp39, __cil_tmp40, __len);
     }
   }
   {
@@ -5589,7 +5589,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp33 = *((u8 **)__cil_tmp32);
     __cil_tmp34 = (void *)__cil_tmp33;
     __cil_tmp35 = (void const   *)(& entry);
-    __ret = memcpy(__cil_tmp34, __cil_tmp35, __len);
+    __ret = memmove(__cil_tmp34, __cil_tmp35, __len);
     }
   } else {
     {
@@ -5598,7 +5598,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp38 = *((u8 **)__cil_tmp37);
     __cil_tmp39 = (void *)__cil_tmp38;
     __cil_tmp40 = (void const   *)(& entry);
-    __ret = memcpy(__cil_tmp39, __cil_tmp40, __len);
+    __ret = memmove(__cil_tmp39, __cil_tmp40, __len);
     }
   }
   {
@@ -5627,7 +5627,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp57 = *((u8 **)__cil_tmp56);
     __cil_tmp58 = (void *)__cil_tmp57;
     __cil_tmp59 = (void const   *)(& param);
-    __ret___0 = memcpy(__cil_tmp58, __cil_tmp59, __len___0);
+    __ret___0 = memmove(__cil_tmp58, __cil_tmp59, __len___0);
     }
   } else {
     {
@@ -5636,7 +5636,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp62 = *((u8 **)__cil_tmp61);
     __cil_tmp63 = (void *)__cil_tmp62;
     __cil_tmp64 = (void const   *)(& param);
-    __ret___0 = memcpy(__cil_tmp63, __cil_tmp64, __len___0);
+    __ret___0 = memmove(__cil_tmp63, __cil_tmp64, __len___0);
     }
   }
   {
@@ -5746,13 +5746,13 @@ static u32 hash_oem_table_id(char *s )
     {
     __cil_tmp6 = (void *)(& input);
     __cil_tmp7 = (void const   *)s;
-    __ret = memcpy(__cil_tmp6, __cil_tmp7, __len);
+    __ret = memmove(__cil_tmp6, __cil_tmp7, __len);
     }
   } else {
     {
     __cil_tmp8 = (void *)(& input);
     __cil_tmp9 = (void const   *)s;
-    __ret = memcpy(__cil_tmp8, __cil_tmp9, __len);
+    __ret = memmove(__cil_tmp8, __cil_tmp9, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3128,7 +3128,7 @@ __inline static int __attribute__((__warn_unused_result__)) kstrtoul(char const 
 }
 }
 extern unsigned long __phys_addr(unsigned long ) ;
-extern void *memcpy(void *to , void const *from , size_t len ) ;
+extern void *memmove(void *to , void const *from , size_t len ) ;
 extern void *memset(void *s , int c , size_t n ) ;
 extern int strncmp(char const * , char const * , __kernel_size_t ) ;
 __inline static long __attribute__((__warn_unused_result__)) PTR_ERR(void const *ptr ) __attribute__((__no_instrument_function__)) ;
@@ -4060,7 +4060,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp112 = (efi_guid_t *)__cil_tmp111;
     __cil_tmp113 = (void *)__cil_tmp112;
     __cil_tmp114 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp113, __cil_tmp114, __len);
+    __ret = memmove(__cil_tmp113, __cil_tmp114, __len);
     }
   } else {
     {
@@ -4068,7 +4068,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp116 = (efi_guid_t *)__cil_tmp115;
     __cil_tmp117 = (void *)__cil_tmp116;
     __cil_tmp118 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp117, __cil_tmp118, __len);
+    __ret = memmove(__cil_tmp117, __cil_tmp118, __len);
     }
   }
   {
@@ -4088,7 +4088,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp130 = *((u8 **)__cil_tmp129);
   __cil_tmp131 = (void *)__cil_tmp130;
   __cil_tmp132 = (void const *)name;
-  __ret___0 = memcpy(__cil_tmp131, __cil_tmp132, __len___0);
+  __ret___0 = memmove(__cil_tmp131, __cil_tmp132, __len___0);
   __cil_tmp133 = (unsigned long )(& gsmi_dev) + 16;
   __cil_tmp134 = *((struct gsmi_buf **)__cil_tmp133);
   __cil_tmp135 = *((u8 **)__cil_tmp134);
@@ -4118,7 +4118,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp153 = *((u8 **)__cil_tmp152);
     __cil_tmp154 = (void *)__cil_tmp153;
     __cil_tmp155 = (void const *)(& param);
-    __ret___1 = memcpy(__cil_tmp154, __cil_tmp155, __len___1);
+    __ret___1 = memmove(__cil_tmp154, __cil_tmp155, __len___1);
     }
   } else {
     {
@@ -4127,7 +4127,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp158 = *((u8 **)__cil_tmp157);
     __cil_tmp159 = (void *)__cil_tmp158;
     __cil_tmp160 = (void const *)(& param);
-    __ret___1 = memcpy(__cil_tmp159, __cil_tmp160, __len___1);
+    __ret___1 = memmove(__cil_tmp159, __cil_tmp160, __len___1);
     }
   }
   {
@@ -4154,7 +4154,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
       __cil_tmp167 = *((struct gsmi_buf **)__cil_tmp166);
       __cil_tmp168 = *((u8 **)__cil_tmp167);
       __cil_tmp169 = (void const *)__cil_tmp168;
-      __ret___2 = memcpy(__cil_tmp165, __cil_tmp169, __len___2);
+      __ret___2 = memmove(__cil_tmp165, __cil_tmp169, __len___2);
       }
     } else {
       {
@@ -4163,7 +4163,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
       __cil_tmp172 = *((struct gsmi_buf **)__cil_tmp171);
       __cil_tmp173 = *((u8 **)__cil_tmp172);
       __cil_tmp174 = (void const *)__cil_tmp173;
-      __ret___2 = memcpy(__cil_tmp170, __cil_tmp174, __len___2);
+      __ret___2 = memmove(__cil_tmp170, __cil_tmp174, __len___2);
       }
     }
     __min1 = *data_size;
@@ -4194,7 +4194,7 @@ static efi_status_t gsmi_get_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp182 = *((struct gsmi_buf **)__cil_tmp181);
     __cil_tmp183 = *((u8 **)__cil_tmp182);
     __cil_tmp184 = (void const *)__cil_tmp183;
-    __ret___3 = memcpy(data, __cil_tmp184, __len___3);
+    __ret___3 = memmove(data, __cil_tmp184, __len___3);
     *attr = (u32 )7;
     }
   }
@@ -4483,7 +4483,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp90 = (u8 (*)[16])__cil_tmp89;
     __cil_tmp91 = (void *)__cil_tmp90;
     __cil_tmp92 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp91, __cil_tmp92, __len);
+    __ret = memmove(__cil_tmp91, __cil_tmp92, __len);
     }
   } else {
     {
@@ -4491,7 +4491,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp94 = (u8 (*)[16])__cil_tmp93;
     __cil_tmp95 = (void *)__cil_tmp94;
     __cil_tmp96 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp95, __cil_tmp96, __len);
+    __ret = memmove(__cil_tmp95, __cil_tmp96, __len);
     }
   }
   {
@@ -4501,7 +4501,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
   __cil_tmp99 = *((u8 **)__cil_tmp98);
   __cil_tmp100 = (void *)__cil_tmp99;
   __cil_tmp101 = (void const *)name;
-  __ret___0 = memcpy(__cil_tmp100, __cil_tmp101, __len___0);
+  __ret___0 = memmove(__cil_tmp100, __cil_tmp101, __len___0);
   __cil_tmp102 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp103 = *((struct gsmi_buf **)__cil_tmp102);
   __cil_tmp104 = *((u8 **)__cil_tmp103);
@@ -4521,7 +4521,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp113 = *((u8 **)__cil_tmp112);
     __cil_tmp114 = (void *)__cil_tmp113;
     __cil_tmp115 = (void const *)(& param);
-    __ret___1 = memcpy(__cil_tmp114, __cil_tmp115, __len___1);
+    __ret___1 = memmove(__cil_tmp114, __cil_tmp115, __len___1);
     }
   } else {
     {
@@ -4530,7 +4530,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
     __cil_tmp118 = *((u8 **)__cil_tmp117);
     __cil_tmp119 = (void *)__cil_tmp118;
     __cil_tmp120 = (void const *)(& param);
-    __ret___1 = memcpy(__cil_tmp119, __cil_tmp120, __len___1);
+    __ret___1 = memmove(__cil_tmp119, __cil_tmp120, __len___1);
     }
   }
   {
@@ -4557,7 +4557,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp127 = *((struct gsmi_buf **)__cil_tmp126);
       __cil_tmp128 = *((u8 **)__cil_tmp127);
       __cil_tmp129 = (void const *)__cil_tmp128;
-      __ret___2 = memcpy(__cil_tmp125, __cil_tmp129, __len___2);
+      __ret___2 = memmove(__cil_tmp125, __cil_tmp129, __len___2);
       }
     } else {
       {
@@ -4566,7 +4566,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp132 = *((struct gsmi_buf **)__cil_tmp131);
       __cil_tmp133 = *((u8 **)__cil_tmp132);
       __cil_tmp134 = (void const *)__cil_tmp133;
-      __ret___2 = memcpy(__cil_tmp130, __cil_tmp134, __len___2);
+      __ret___2 = memmove(__cil_tmp130, __cil_tmp134, __len___2);
       }
     }
     __len___3 = (size_t )1024;
@@ -4577,7 +4577,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp137 = *((struct gsmi_buf **)__cil_tmp136);
       __cil_tmp138 = *((u8 **)__cil_tmp137);
       __cil_tmp139 = (void const *)__cil_tmp138;
-      __ret___3 = memcpy(__cil_tmp135, __cil_tmp139, __len___3);
+      __ret___3 = memmove(__cil_tmp135, __cil_tmp139, __len___3);
       }
     } else {
       {
@@ -4586,7 +4586,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp142 = *((struct gsmi_buf **)__cil_tmp141);
       __cil_tmp143 = *((u8 **)__cil_tmp142);
       __cil_tmp144 = (void const *)__cil_tmp143;
-      __ret___3 = memcpy(__cil_tmp140, __cil_tmp144, __len___3);
+      __ret___3 = memmove(__cil_tmp140, __cil_tmp144, __len___3);
       }
     }
     {
@@ -4600,7 +4600,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp146 = & param;
       __cil_tmp147 = (u8 (*)[16])__cil_tmp146;
       __cil_tmp148 = (void const *)__cil_tmp147;
-      __ret___4 = memcpy(__cil_tmp145, __cil_tmp148, __len___4);
+      __ret___4 = memmove(__cil_tmp145, __cil_tmp148, __len___4);
       }
     } else {
       {
@@ -4608,7 +4608,7 @@ static efi_status_t gsmi_get_next_variable(unsigned long *name_size , efi_char16
       __cil_tmp150 = & param;
       __cil_tmp151 = (u8 (*)[16])__cil_tmp150;
       __cil_tmp152 = (void const *)__cil_tmp151;
-      __ret___4 = memcpy(__cil_tmp149, __cil_tmp152, __len___4);
+      __ret___4 = memmove(__cil_tmp149, __cil_tmp152, __len___4);
       }
     }
     ret = (efi_status_t )0;
@@ -4913,7 +4913,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp103 = (efi_guid_t *)__cil_tmp102;
     __cil_tmp104 = (void *)__cil_tmp103;
     __cil_tmp105 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp104, __cil_tmp105, __len);
+    __ret = memmove(__cil_tmp104, __cil_tmp105, __len);
     }
   } else {
     {
@@ -4921,7 +4921,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp107 = (efi_guid_t *)__cil_tmp106;
     __cil_tmp108 = (void *)__cil_tmp107;
     __cil_tmp109 = (void const *)vendor;
-    __ret = memcpy(__cil_tmp108, __cil_tmp109, __len);
+    __ret = memmove(__cil_tmp108, __cil_tmp109, __len);
     }
   }
   {
@@ -4941,7 +4941,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp121 = *((u8 **)__cil_tmp120);
   __cil_tmp122 = (void *)__cil_tmp121;
   __cil_tmp123 = (void const *)name;
-  __ret___0 = memcpy(__cil_tmp122, __cil_tmp123, __len___0);
+  __ret___0 = memmove(__cil_tmp122, __cil_tmp123, __len___0);
   __cil_tmp124 = (unsigned long )(& gsmi_dev) + 16;
   __cil_tmp125 = *((struct gsmi_buf **)__cil_tmp124);
   __cil_tmp126 = *((u8 **)__cil_tmp125);
@@ -4958,7 +4958,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
   __cil_tmp135 = *((u8 **)__cil_tmp134);
   __cil_tmp136 = (void *)__cil_tmp135;
   __cil_tmp137 = (void const *)data;
-  __ret___1 = memcpy(__cil_tmp136, __cil_tmp137, __len___1);
+  __ret___1 = memmove(__cil_tmp136, __cil_tmp137, __len___1);
   __cil_tmp138 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp139 = *((struct gsmi_buf **)__cil_tmp138);
   __cil_tmp140 = *((u8 **)__cil_tmp139);
@@ -4978,7 +4978,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp149 = *((u8 **)__cil_tmp148);
     __cil_tmp150 = (void *)__cil_tmp149;
     __cil_tmp151 = (void const *)(& param);
-    __ret___2 = memcpy(__cil_tmp150, __cil_tmp151, __len___2);
+    __ret___2 = memmove(__cil_tmp150, __cil_tmp151, __len___2);
     }
   } else {
     {
@@ -4987,7 +4987,7 @@ static efi_status_t gsmi_set_variable(efi_char16_t *name , efi_guid_t *vendor , 
     __cil_tmp154 = *((u8 **)__cil_tmp153);
     __cil_tmp155 = (void *)__cil_tmp154;
     __cil_tmp156 = (void const *)(& param);
-    __ret___2 = memcpy(__cil_tmp155, __cil_tmp156, __len___2);
+    __ret___2 = memmove(__cil_tmp155, __cil_tmp156, __len___2);
     }
   }
   {
@@ -5153,7 +5153,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
   __cil_tmp48 = *((u8 **)__cil_tmp47);
   __cil_tmp49 = (void *)__cil_tmp48;
   __cil_tmp50 = (void const *)buf;
-  __ret = memcpy(__cil_tmp49, __cil_tmp50, __len);
+  __ret = memmove(__cil_tmp49, __cil_tmp50, __len);
   __cil_tmp51 = (unsigned long )(& gsmi_dev) + 24;
   __cil_tmp52 = *((struct gsmi_buf **)__cil_tmp51);
   __cil_tmp53 = *((u8 **)__cil_tmp52);
@@ -5173,7 +5173,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
     __cil_tmp62 = *((u8 **)__cil_tmp61);
     __cil_tmp63 = (void *)__cil_tmp62;
     __cil_tmp64 = (void const *)(& param);
-    __ret___0 = memcpy(__cil_tmp63, __cil_tmp64, __len___0);
+    __ret___0 = memmove(__cil_tmp63, __cil_tmp64, __len___0);
     }
   } else {
     {
@@ -5182,7 +5182,7 @@ static ssize_t eventlog_write(struct file *filp , struct kobject *kobj , struct 
     __cil_tmp67 = *((u8 **)__cil_tmp66);
     __cil_tmp68 = (void *)__cil_tmp67;
     __cil_tmp69 = (void const *)(& param);
-    __ret___0 = memcpy(__cil_tmp68, __cil_tmp69, __len___0);
+    __ret___0 = memmove(__cil_tmp68, __cil_tmp69, __len___0);
     }
   }
   {
@@ -5313,7 +5313,7 @@ static ssize_t gsmi_clear_eventlog_store(struct kobject *kobj , struct kobj_attr
     __cil_tmp33 = *((u8 **)__cil_tmp32);
     __cil_tmp34 = (void *)__cil_tmp33;
     __cil_tmp35 = (void const *)(& param);
-    __ret = memcpy(__cil_tmp34, __cil_tmp35, __len);
+    __ret = memmove(__cil_tmp34, __cil_tmp35, __len);
     }
   } else {
     {
@@ -5322,7 +5322,7 @@ static ssize_t gsmi_clear_eventlog_store(struct kobject *kobj , struct kobj_attr
     __cil_tmp38 = *((u8 **)__cil_tmp37);
     __cil_tmp39 = (void *)__cil_tmp38;
     __cil_tmp40 = (void const *)(& param);
-    __ret = memcpy(__cil_tmp39, __cil_tmp40, __len);
+    __ret = memmove(__cil_tmp39, __cil_tmp40, __len);
     }
   }
   {
@@ -5539,7 +5539,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp33 = *((u8 **)__cil_tmp32);
     __cil_tmp34 = (void *)__cil_tmp33;
     __cil_tmp35 = (void const *)(& entry);
-    __ret = memcpy(__cil_tmp34, __cil_tmp35, __len);
+    __ret = memmove(__cil_tmp34, __cil_tmp35, __len);
     }
   } else {
     {
@@ -5548,7 +5548,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp38 = *((u8 **)__cil_tmp37);
     __cil_tmp39 = (void *)__cil_tmp38;
     __cil_tmp40 = (void const *)(& entry);
-    __ret = memcpy(__cil_tmp39, __cil_tmp40, __len);
+    __ret = memmove(__cil_tmp39, __cil_tmp40, __len);
     }
   }
   {
@@ -5577,7 +5577,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp57 = *((u8 **)__cil_tmp56);
     __cil_tmp58 = (void *)__cil_tmp57;
     __cil_tmp59 = (void const *)(& param);
-    __ret___0 = memcpy(__cil_tmp58, __cil_tmp59, __len___0);
+    __ret___0 = memmove(__cil_tmp58, __cil_tmp59, __len___0);
     }
   } else {
     {
@@ -5586,7 +5586,7 @@ static int gsmi_shutdown_reason(int reason )
     __cil_tmp62 = *((u8 **)__cil_tmp61);
     __cil_tmp63 = (void *)__cil_tmp62;
     __cil_tmp64 = (void const *)(& param);
-    __ret___0 = memcpy(__cil_tmp63, __cil_tmp64, __len___0);
+    __ret___0 = memmove(__cil_tmp63, __cil_tmp64, __len___0);
     }
   }
   {
@@ -5690,13 +5690,13 @@ static u32 hash_oem_table_id(char *s )
     {
     __cil_tmp6 = (void *)(& input);
     __cil_tmp7 = (void const *)s;
-    __ret = memcpy(__cil_tmp6, __cil_tmp7, __len);
+    __ret = memmove(__cil_tmp6, __cil_tmp7, __len);
     }
   } else {
     {
     __cil_tmp8 = (void *)(& input);
     __cil_tmp9 = (void const *)s;
-    __ret = memcpy(__cil_tmp8, __cil_tmp9, __len);
+    __ret = memmove(__cil_tmp8, __cil_tmp9, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -938,7 +938,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile   *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count )  __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count ) 
@@ -950,7 +950,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile   *src , size
   {
   __len = count;
   __cil_tmp6 = (void const   *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }
@@ -965,7 +965,7 @@ __inline static void memcpy_toio(void volatile   *dst , void const   *src , size
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -927,7 +927,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count ) __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
@@ -938,7 +938,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t
   {
   __len = count;
   __cil_tmp6 = (void const *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }
@@ -952,7 +952,7 @@ __inline static void memcpy_toio(void volatile *dst , void const *src , size_t c
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2727,7 +2727,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile   * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count ) 
 { size_t __len ;
@@ -2738,7 +2738,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile   *src , size
   {
   __len = count;
   __cil_tmp6 = (void const   *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2720,7 +2720,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;
@@ -2730,7 +2730,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t
   {
   __len = count;
   __cil_tmp6 = (void const *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -6823,7 +6823,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
 }
 }
 
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7782,14 +7782,14 @@ struct dvb_frontend *cinergyt2_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const   *)(& cinergyt2_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const   *)(& cinergyt2_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6780,7 +6780,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void kfree(void const * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7712,14 +7712,14 @@ struct dvb_frontend *cinergyt2_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const *)(& cinergyt2_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const *)(& cinergyt2_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5916,7 +5916,7 @@ __inline static int mt352_write(struct dvb_frontend *fe , u8 const   *buf , int 
   return (r);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 static int dvb_usb_digitv_debug  ;
 static short adapter_nr[8U]  = 
   {      (short)-1,      (short)-1,      (short)-1,      (short)-1, 
@@ -5999,7 +5999,7 @@ static int digitv_ctrl_msg(struct dvb_usb_device *d , u8 cmd , u8 vv , u8 *wbuf 
     __cil_tmp29 = (void *)(& sndbuf);
     __cil_tmp30 = __cil_tmp29 + 3U;
     __cil_tmp31 = (void const   *)wbuf;
-    __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+    __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
     __cil_tmp32 = (u8 *)(& sndbuf);
     __cil_tmp33 = (u16 )7;
     dvb_usb_generic_write(d, __cil_tmp32, __cil_tmp33);
@@ -6015,7 +6015,7 @@ static int digitv_ctrl_msg(struct dvb_usb_device *d , u8 cmd , u8 vv , u8 *wbuf 
     __cil_tmp38 = (void *)rbuf;
     __cil_tmp39 = (void const   *)(& rcvbuf);
     __cil_tmp40 = __cil_tmp39 + 3U;
-    __ret___0 = memcpy(__cil_tmp38, __cil_tmp40, __len___0);
+    __ret___0 = memmove(__cil_tmp38, __cil_tmp40, __len___0);
     }
   }
   return (0);

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5904,7 +5904,7 @@ __inline static int mt352_write(struct dvb_frontend *fe , u8 const *buf , int le
   return (r);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 static int dvb_usb_digitv_debug ;
 static short adapter_nr[8U] =
   { (short)-1, (short)-1, (short)-1, (short)-1,
@@ -5986,7 +5986,7 @@ static int digitv_ctrl_msg(struct dvb_usb_device *d , u8 cmd , u8 vv , u8 *wbuf 
     __cil_tmp29 = (void *)(& sndbuf);
     __cil_tmp30 = __cil_tmp29 + 3U;
     __cil_tmp31 = (void const *)wbuf;
-    __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+    __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
     __cil_tmp32 = (u8 *)(& sndbuf);
     __cil_tmp33 = (u16 )7;
     dvb_usb_generic_write(d, __cil_tmp32, __cil_tmp33);
@@ -6002,7 +6002,7 @@ static int digitv_ctrl_msg(struct dvb_usb_device *d , u8 cmd , u8 vv , u8 *wbuf 
     __cil_tmp38 = (void *)rbuf;
     __cil_tmp39 = (void const *)(& rcvbuf);
     __cil_tmp40 = __cil_tmp39 + 3U;
-    __ret___0 = memcpy(__cil_tmp38, __cil_tmp40, __len___0);
+    __ret___0 = memmove(__cil_tmp38, __cil_tmp40, __len___0);
     }
   }
   return (0);

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
@@ -8266,7 +8266,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
 }
 }
 
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -8818,7 +8818,7 @@ static int dtt200u_fe_get_frontend(struct dvb_frontend *fe )
     __cil_tmp13 = __cil_tmp12 + 12;
     __cil_tmp14 = (struct dtv_frontend_properties *)__cil_tmp13;
     __cil_tmp15 = (void const   *)__cil_tmp14;
-    __ret = memcpy(__cil_tmp11, __cil_tmp15, __len);
+    __ret = memmove(__cil_tmp11, __cil_tmp15, __len);
     }
   } else {
     {
@@ -8827,7 +8827,7 @@ static int dtt200u_fe_get_frontend(struct dvb_frontend *fe )
     __cil_tmp18 = __cil_tmp17 + 12;
     __cil_tmp19 = (struct dtv_frontend_properties *)__cil_tmp18;
     __cil_tmp20 = (void const   *)__cil_tmp19;
-    __ret = memcpy(__cil_tmp16, __cil_tmp20, __len);
+    __ret = memmove(__cil_tmp16, __cil_tmp20, __len);
     }
   }
   return (0);
@@ -8915,7 +8915,7 @@ struct dvb_frontend *dtt200u_fe_attach(struct dvb_usb_device *d )
     __cil_tmp13 = (struct dvb_frontend_ops *)__cil_tmp12;
     __cil_tmp14 = (void *)__cil_tmp13;
     __cil_tmp15 = (void const   *)(& dtt200u_fe_ops);
-    __ret = memcpy(__cil_tmp14, __cil_tmp15, __len);
+    __ret = memmove(__cil_tmp14, __cil_tmp15, __len);
     }
   } else {
     {
@@ -8924,7 +8924,7 @@ struct dvb_frontend *dtt200u_fe_attach(struct dvb_usb_device *d )
     __cil_tmp18 = (struct dvb_frontend_ops *)__cil_tmp17;
     __cil_tmp19 = (void *)__cil_tmp18;
     __cil_tmp20 = (void const   *)(& dtt200u_fe_ops);
-    __ret = memcpy(__cil_tmp19, __cil_tmp20, __len);
+    __ret = memmove(__cil_tmp19, __cil_tmp20, __len);
     }
   }
   __cil_tmp21 = 152 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -8227,7 +8227,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void kfree(void const * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -8768,7 +8768,7 @@ static int dtt200u_fe_get_frontend(struct dvb_frontend *fe )
     __cil_tmp13 = __cil_tmp12 + 12;
     __cil_tmp14 = (struct dtv_frontend_properties *)__cil_tmp13;
     __cil_tmp15 = (void const *)__cil_tmp14;
-    __ret = memcpy(__cil_tmp11, __cil_tmp15, __len);
+    __ret = memmove(__cil_tmp11, __cil_tmp15, __len);
     }
   } else {
     {
@@ -8777,7 +8777,7 @@ static int dtt200u_fe_get_frontend(struct dvb_frontend *fe )
     __cil_tmp18 = __cil_tmp17 + 12;
     __cil_tmp19 = (struct dtv_frontend_properties *)__cil_tmp18;
     __cil_tmp20 = (void const *)__cil_tmp19;
-    __ret = memcpy(__cil_tmp16, __cil_tmp20, __len);
+    __ret = memmove(__cil_tmp16, __cil_tmp20, __len);
     }
   }
   return (0);
@@ -8861,7 +8861,7 @@ struct dvb_frontend *dtt200u_fe_attach(struct dvb_usb_device *d )
     __cil_tmp13 = (struct dvb_frontend_ops *)__cil_tmp12;
     __cil_tmp14 = (void *)__cil_tmp13;
     __cil_tmp15 = (void const *)(& dtt200u_fe_ops);
-    __ret = memcpy(__cil_tmp14, __cil_tmp15, __len);
+    __ret = memmove(__cil_tmp14, __cil_tmp15, __len);
     }
   } else {
     {
@@ -8870,7 +8870,7 @@ struct dvb_frontend *dtt200u_fe_attach(struct dvb_usb_device *d )
     __cil_tmp18 = (struct dvb_frontend_ops *)__cil_tmp17;
     __cil_tmp19 = (void *)__cil_tmp18;
     __cil_tmp20 = (void const *)(& dtt200u_fe_ops);
-    __ret = memcpy(__cil_tmp19, __cil_tmp20, __len);
+    __ret = memmove(__cil_tmp19, __cil_tmp20, __len);
     }
   }
   __cil_tmp21 = 152 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5701,7 +5701,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const   *  , ...) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void __mutex_init(struct mutex * , char const   * , struct lock_class_key * ) ;
 extern void mutex_lock_nested(struct mutex * , unsigned int  ) ;
@@ -6325,7 +6325,7 @@ static int vp702x_usb_inout_cmd(struct dvb_usb_device *d , u8 cmd , u8 *o , int 
   __cil_tmp43 = (void *)buf;
   __cil_tmp44 = __cil_tmp43 + 2U;
   __cil_tmp45 = (void const   *)o;
-  __ret = memcpy(__cil_tmp44, __cil_tmp45, __len);
+  __ret = memmove(__cil_tmp44, __cil_tmp45, __len);
   __cil_tmp46 = olen + 2;
   __cil_tmp47 = ilen + 1;
   ret = vp702x_usb_inout_op(d, buf, __cil_tmp46, buf, __cil_tmp47, msec);
@@ -6336,7 +6336,7 @@ static int vp702x_usb_inout_cmd(struct dvb_usb_device *d , u8 cmd , u8 *o , int 
     __cil_tmp48 = (void *)i;
     __cil_tmp49 = (void const   *)buf;
     __cil_tmp50 = __cil_tmp49 + 1U;
-    __ret___0 = memcpy(__cil_tmp48, __cil_tmp50, __len___0);
+    __ret___0 = memmove(__cil_tmp48, __cil_tmp50, __len___0);
     }
   } else {
 
@@ -6971,13 +6971,13 @@ static int vp702x_read_mac_addr(struct dvb_usb_device *d , u8 *mac )
     {
     __cil_tmp24 = (void *)mac;
     __cil_tmp25 = (void const   *)buf;
-    __ret = memcpy(__cil_tmp24, __cil_tmp25, __len);
+    __ret = memmove(__cil_tmp24, __cil_tmp25, __len);
     }
   } else {
     {
     __cil_tmp26 = (void *)mac;
     __cil_tmp27 = (void const   *)buf;
-    __ret = memcpy(__cil_tmp26, __cil_tmp27, __len);
+    __ret = memmove(__cil_tmp26, __cil_tmp27, __len);
     }
   }
   {
@@ -8748,7 +8748,7 @@ static int vp702x_fe_send_diseqc_msg(struct dvb_frontend *fe , struct dvb_diseqc
   __cil_tmp35 = __cil_tmp34 + 3U;
   __cil_tmp36 = (__u8 (*)[6U])m;
   __cil_tmp37 = (void const   *)__cil_tmp36;
-  __ret = memcpy(__cil_tmp35, __cil_tmp37, __len);
+  __ret = memmove(__cil_tmp35, __cil_tmp37, __len);
   __cil_tmp38 = cmd + 7UL;
   *__cil_tmp38 = vp702x_chksum(cmd, 0, 7);
   __cil_tmp39 = (unsigned long )st;
@@ -8959,7 +8959,7 @@ static int vp702x_fe_set_tone(struct dvb_frontend *fe , fe_sec_tone_mode_t tone 
     __cil_tmp44 = __cil_tmp43 + 1728;
     __cil_tmp45 = (u8 (*)[8U])__cil_tmp44;
     __cil_tmp46 = (void const   *)__cil_tmp45;
-    __ret = memcpy(__cil_tmp42, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp42, __cil_tmp46, __len);
     }
   } else {
     {
@@ -8968,7 +8968,7 @@ static int vp702x_fe_set_tone(struct dvb_frontend *fe , fe_sec_tone_mode_t tone 
     __cil_tmp49 = __cil_tmp48 + 1728;
     __cil_tmp50 = (u8 (*)[8U])__cil_tmp49;
     __cil_tmp51 = (void const   *)__cil_tmp50;
-    __ret = memcpy(__cil_tmp47, __cil_tmp51, __len);
+    __ret = memmove(__cil_tmp47, __cil_tmp51, __len);
     }
   }
   {
@@ -9159,7 +9159,7 @@ static int vp702x_fe_set_voltage(struct dvb_frontend *fe , fe_sec_voltage_t volt
     __cil_tmp44 = __cil_tmp43 + 1728;
     __cil_tmp45 = (u8 (*)[8U])__cil_tmp44;
     __cil_tmp46 = (void const   *)__cil_tmp45;
-    __ret = memcpy(__cil_tmp42, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp42, __cil_tmp46, __len);
     }
   } else {
     {
@@ -9168,7 +9168,7 @@ static int vp702x_fe_set_voltage(struct dvb_frontend *fe , fe_sec_voltage_t volt
     __cil_tmp49 = __cil_tmp48 + 1728;
     __cil_tmp50 = (u8 (*)[8U])__cil_tmp49;
     __cil_tmp51 = (void const   *)__cil_tmp50;
-    __ret = memcpy(__cil_tmp47, __cil_tmp51, __len);
+    __ret = memmove(__cil_tmp47, __cil_tmp51, __len);
     }
   }
   {
@@ -9297,14 +9297,14 @@ struct dvb_frontend *vp702x_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const   *)(& vp702x_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const   *)(& vp702x_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5694,7 +5694,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const * , ...) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 extern void __mutex_init(struct mutex * , char const * , struct lock_class_key * ) ;
 extern void mutex_lock_nested(struct mutex * , unsigned int ) ;
@@ -6297,7 +6297,7 @@ static int vp702x_usb_inout_cmd(struct dvb_usb_device *d , u8 cmd , u8 *o , int 
   __cil_tmp43 = (void *)buf;
   __cil_tmp44 = __cil_tmp43 + 2U;
   __cil_tmp45 = (void const *)o;
-  __ret = memcpy(__cil_tmp44, __cil_tmp45, __len);
+  __ret = memmove(__cil_tmp44, __cil_tmp45, __len);
   __cil_tmp46 = olen + 2;
   __cil_tmp47 = ilen + 1;
   ret = vp702x_usb_inout_op(d, buf, __cil_tmp46, buf, __cil_tmp47, msec);
@@ -6308,7 +6308,7 @@ static int vp702x_usb_inout_cmd(struct dvb_usb_device *d , u8 cmd , u8 *o , int 
     __cil_tmp48 = (void *)i;
     __cil_tmp49 = (void const *)buf;
     __cil_tmp50 = __cil_tmp49 + 1U;
-    __ret___0 = memcpy(__cil_tmp48, __cil_tmp50, __len___0);
+    __ret___0 = memmove(__cil_tmp48, __cil_tmp50, __len___0);
     }
   } else {
   }
@@ -6931,13 +6931,13 @@ static int vp702x_read_mac_addr(struct dvb_usb_device *d , u8 *mac )
     {
     __cil_tmp24 = (void *)mac;
     __cil_tmp25 = (void const *)buf;
-    __ret = memcpy(__cil_tmp24, __cil_tmp25, __len);
+    __ret = memmove(__cil_tmp24, __cil_tmp25, __len);
     }
   } else {
     {
     __cil_tmp26 = (void *)mac;
     __cil_tmp27 = (void const *)buf;
-    __ret = memcpy(__cil_tmp26, __cil_tmp27, __len);
+    __ret = memmove(__cil_tmp26, __cil_tmp27, __len);
     }
   }
   {
@@ -8655,7 +8655,7 @@ static int vp702x_fe_send_diseqc_msg(struct dvb_frontend *fe , struct dvb_diseqc
   __cil_tmp35 = __cil_tmp34 + 3U;
   __cil_tmp36 = (__u8 (*)[6U])m;
   __cil_tmp37 = (void const *)__cil_tmp36;
-  __ret = memcpy(__cil_tmp35, __cil_tmp37, __len);
+  __ret = memmove(__cil_tmp35, __cil_tmp37, __len);
   __cil_tmp38 = cmd + 7UL;
   *__cil_tmp38 = vp702x_chksum(cmd, 0, 7);
   __cil_tmp39 = (unsigned long )st;
@@ -8859,7 +8859,7 @@ static int vp702x_fe_set_tone(struct dvb_frontend *fe , fe_sec_tone_mode_t tone 
     __cil_tmp44 = __cil_tmp43 + 1728;
     __cil_tmp45 = (u8 (*)[8U])__cil_tmp44;
     __cil_tmp46 = (void const *)__cil_tmp45;
-    __ret = memcpy(__cil_tmp42, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp42, __cil_tmp46, __len);
     }
   } else {
     {
@@ -8868,7 +8868,7 @@ static int vp702x_fe_set_tone(struct dvb_frontend *fe , fe_sec_tone_mode_t tone 
     __cil_tmp49 = __cil_tmp48 + 1728;
     __cil_tmp50 = (u8 (*)[8U])__cil_tmp49;
     __cil_tmp51 = (void const *)__cil_tmp50;
-    __ret = memcpy(__cil_tmp47, __cil_tmp51, __len);
+    __ret = memmove(__cil_tmp47, __cil_tmp51, __len);
     }
   }
   {
@@ -9054,7 +9054,7 @@ static int vp702x_fe_set_voltage(struct dvb_frontend *fe , fe_sec_voltage_t volt
     __cil_tmp44 = __cil_tmp43 + 1728;
     __cil_tmp45 = (u8 (*)[8U])__cil_tmp44;
     __cil_tmp46 = (void const *)__cil_tmp45;
-    __ret = memcpy(__cil_tmp42, __cil_tmp46, __len);
+    __ret = memmove(__cil_tmp42, __cil_tmp46, __len);
     }
   } else {
     {
@@ -9063,7 +9063,7 @@ static int vp702x_fe_set_voltage(struct dvb_frontend *fe , fe_sec_voltage_t volt
     __cil_tmp49 = __cil_tmp48 + 1728;
     __cil_tmp50 = (u8 (*)[8U])__cil_tmp49;
     __cil_tmp51 = (void const *)__cil_tmp50;
-    __ret = memcpy(__cil_tmp47, __cil_tmp51, __len);
+    __ret = memmove(__cil_tmp47, __cil_tmp51, __len);
     }
   }
   {
@@ -9186,14 +9186,14 @@ struct dvb_frontend *vp702x_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const *)(& vp702x_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const *)(& vp702x_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5870,7 +5870,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp29 = (void *)buf;
       __cil_tmp30 = __cil_tmp29 + 1U;
       __cil_tmp31 = (void const   *)out;
-      __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+      __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
       }
     } else {
 
@@ -6051,7 +6051,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp89 = (void *)in;
       __cil_tmp90 = (void const   *)buf;
       __cil_tmp91 = __cil_tmp90 + 1U;
-      __ret___0 = memcpy(__cil_tmp89, __cil_tmp91, __len___0);
+      __ret___0 = memmove(__cil_tmp89, __cil_tmp91, __len___0);
       }
     } else {
 
@@ -7217,7 +7217,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7787,14 +7787,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5857,7 +5857,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp29 = (void *)buf;
       __cil_tmp30 = __cil_tmp29 + 1U;
       __cil_tmp31 = (void const *)out;
-      __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+      __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
       }
     } else {
     }
@@ -6028,7 +6028,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp89 = (void *)in;
       __cil_tmp90 = (void const *)buf;
       __cil_tmp91 = __cil_tmp90 + 1U;
-      __ret___0 = memcpy(__cil_tmp89, __cil_tmp91, __len___0);
+      __ret___0 = memmove(__cil_tmp89, __cil_tmp91, __len___0);
       }
     } else {
     }
@@ -7155,7 +7155,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void kfree(void const * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7707,14 +7707,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5870,7 +5870,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp29 = (void *)buf;
       __cil_tmp30 = __cil_tmp29 + 1U;
       __cil_tmp31 = (void const   *)out;
-      __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+      __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
       }
     } else {
 
@@ -6051,7 +6051,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp89 = (void *)in;
       __cil_tmp90 = (void const   *)buf;
       __cil_tmp91 = __cil_tmp90 + 1U;
-      __ret___0 = memcpy(__cil_tmp89, __cil_tmp91, __len___0);
+      __ret___0 = memmove(__cil_tmp89, __cil_tmp91, __len___0);
       }
     } else {
 
@@ -7217,7 +7217,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7787,14 +7787,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const   *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5857,7 +5857,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp29 = (void *)buf;
       __cil_tmp30 = __cil_tmp29 + 1U;
       __cil_tmp31 = (void const *)out;
-      __ret = memcpy(__cil_tmp30, __cil_tmp31, __len);
+      __ret = memmove(__cil_tmp30, __cil_tmp31, __len);
       }
     } else {
     }
@@ -6028,7 +6028,7 @@ int vp7045_usb_op(struct dvb_usb_device *d , u8 cmd , u8 *out , int outlen , u8 
       __cil_tmp89 = (void *)in;
       __cil_tmp90 = (void const *)buf;
       __cil_tmp91 = __cil_tmp90 + 1U;
-      __ret___0 = memcpy(__cil_tmp89, __cil_tmp91, __len___0);
+      __ret___0 = memmove(__cil_tmp89, __cil_tmp91, __len___0);
       }
     } else {
     }
@@ -7155,7 +7155,7 @@ int ldv_pskb_expand_head_27(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 , 
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void kfree(void const * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
@@ -7707,14 +7707,14 @@ struct dvb_frontend *vp7045_fe_attach(struct dvb_usb_device *d )
     __cil_tmp11 = (struct dvb_frontend_ops *)s;
     __cil_tmp12 = (void *)__cil_tmp11;
     __cil_tmp13 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp12, __cil_tmp13, __len);
+    __ret = memmove(__cil_tmp12, __cil_tmp13, __len);
     }
   } else {
     {
     __cil_tmp14 = (struct dvb_frontend_ops *)s;
     __cil_tmp15 = (void *)__cil_tmp14;
     __cil_tmp16 = (void const *)(& vp7045_fe_ops);
-    __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+    __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
     }
   }
   __cil_tmp17 = 0 + 760;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3713,7 +3713,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int gspca_dev_probe(struct usb_interface * , struct usb_device_id  const  * ,
                            struct sd_desc  const  * , int  , struct module * ) ;
 extern void gspca_frame_add(struct gspca_dev * , enum gspca_packet_type  , u8 const   * ,
@@ -3794,7 +3794,7 @@ static int pac207_write_regs(struct gspca_dev *gspca_dev , u16 index , u8 const 
   __cil_tmp14 = *((__u8 **)__cil_tmp13);
   __cil_tmp15 = (void *)__cil_tmp14;
   __cil_tmp16 = (void const   *)buffer;
-  __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+  __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
   tmp = __create_pipe(udev, 0U);
   __cil_tmp17 = tmp | 2147483648U;
   __cil_tmp18 = (__u8 )1;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3701,7 +3701,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int gspca_dev_probe(struct usb_interface * , struct usb_device_id const * ,
                            struct sd_desc const * , int , struct module * ) ;
 extern void gspca_frame_add(struct gspca_dev * , enum gspca_packet_type , u8 const * ,
@@ -3781,7 +3781,7 @@ static int pac207_write_regs(struct gspca_dev *gspca_dev , u16 index , u8 const 
   __cil_tmp14 = *((__u8 **)__cil_tmp13);
   __cil_tmp15 = (void *)__cil_tmp14;
   __cil_tmp16 = (void const *)buffer;
-  __ret = memcpy(__cil_tmp15, __cil_tmp16, __len);
+  __ret = memmove(__cil_tmp15, __cil_tmp16, __len);
   tmp = __create_pipe(udev, 0U);
   __cil_tmp17 = tmp | 2147483648U;
   __cil_tmp18 = (__u8 )1;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -4000,7 +4000,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const   *  , ...) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 __inline static void *ERR_PTR(long error ) 
 { 
 
@@ -4072,7 +4072,7 @@ __inline static void memcpy_toio(void volatile   *dst , void const   *src , size
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }
@@ -5491,7 +5491,7 @@ static int i2o_scsi_reply(struct i2o_controller *c , u32 m , struct i2o_message 
     __cil_tmp41 = (u32 (*)[0U])__cil_tmp40;
     __cil_tmp42 = (void const   *)__cil_tmp41;
     __cil_tmp43 = __cil_tmp42 + 3U;
-    __ret = memcpy(__cil_tmp38, __cil_tmp43, __len);
+    __ret = memmove(__cil_tmp38, __cil_tmp43, __len);
     }
   } else {
 
@@ -6007,7 +6007,7 @@ static int i2o_scsi_queuecommand_lck(struct scsi_cmnd *SCpnt , void (*done)(stru
     __cil_tmp83 = __cil_tmp82 + 80;
     __cil_tmp84 = *((unsigned char **)__cil_tmp83);
     __cil_tmp85 = (void const   *)__cil_tmp84;
-    __ret = memcpy(__cil_tmp81, __cil_tmp85, __len);
+    __ret = memmove(__cil_tmp81, __cil_tmp85, __len);
     }
   } else {
     {
@@ -6018,7 +6018,7 @@ static int i2o_scsi_queuecommand_lck(struct scsi_cmnd *SCpnt , void (*done)(stru
     __cil_tmp90 = __cil_tmp89 + 80;
     __cil_tmp91 = *((unsigned char **)__cil_tmp90);
     __cil_tmp92 = (void const   *)__cil_tmp91;
-    __ret = memcpy(__cil_tmp88, __cil_tmp92, __len);
+    __ret = memmove(__cil_tmp88, __cil_tmp92, __len);
     }
   }
   __cil_tmp93 = & mptr;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3994,7 +3994,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const * , ...) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 __inline static void *ERR_PTR(long error )
 {
   {
@@ -4059,7 +4059,7 @@ __inline static void memcpy_toio(void volatile *dst , void const *src , size_t c
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }
@@ -5433,7 +5433,7 @@ static int i2o_scsi_reply(struct i2o_controller *c , u32 m , struct i2o_message 
     __cil_tmp41 = (u32 (*)[0U])__cil_tmp40;
     __cil_tmp42 = (void const *)__cil_tmp41;
     __cil_tmp43 = __cil_tmp42 + 3U;
-    __ret = memcpy(__cil_tmp38, __cil_tmp43, __len);
+    __ret = memmove(__cil_tmp38, __cil_tmp43, __len);
     }
   } else {
   }
@@ -5937,7 +5937,7 @@ static int i2o_scsi_queuecommand_lck(struct scsi_cmnd *SCpnt , void (*done)(stru
     __cil_tmp83 = __cil_tmp82 + 80;
     __cil_tmp84 = *((unsigned char **)__cil_tmp83);
     __cil_tmp85 = (void const *)__cil_tmp84;
-    __ret = memcpy(__cil_tmp81, __cil_tmp85, __len);
+    __ret = memmove(__cil_tmp81, __cil_tmp85, __len);
     }
   } else {
     {
@@ -5948,7 +5948,7 @@ static int i2o_scsi_queuecommand_lck(struct scsi_cmnd *SCpnt , void (*done)(stru
     __cil_tmp90 = __cil_tmp89 + 80;
     __cil_tmp91 = *((unsigned char **)__cil_tmp90);
     __cil_tmp92 = (void const *)__cil_tmp91;
-    __ret = memcpy(__cil_tmp88, __cil_tmp92, __len);
+    __ret = memmove(__cil_tmp88, __cil_tmp92, __len);
     }
   }
   __cil_tmp93 = & mptr;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -984,7 +984,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile   * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile   *src , size_t count ) 
 { size_t __len ;
@@ -995,7 +995,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile   *src , size
   {
   __len = count;
   __cil_tmp6 = (void const   *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }
@@ -1009,7 +1009,7 @@ __inline static void memcpy_toio(void volatile   *dst , void const   *src , size
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -973,7 +973,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;
@@ -983,7 +983,7 @@ __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t
   {
   __len = count;
   __cil_tmp6 = (void const *)src;
-  __ret = memcpy(dst, __cil_tmp6, __len);
+  __ret = memmove(dst, __cil_tmp6, __len);
   }
   return;
 }
@@ -996,7 +996,7 @@ __inline static void memcpy_toio(void volatile *dst , void const *src , size_t c
   {
   __len = count;
   __cil_tmp6 = (void *)dst;
-  __ret = memcpy(__cil_tmp6, src, __len);
+  __ret = memmove(__cil_tmp6, src, __len);
   }
   return;
 }

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -4469,7 +4469,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const   *  , ...) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *kmem_cache_alloc(struct kmem_cache * , gfp_t  ) ;
 void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
@@ -4865,13 +4865,13 @@ static void rx(struct net_device *dev , int bufnum , struct archdr *pkthdr , int
     {
     __cil_tmp35 = (void *)pkt;
     __cil_tmp36 = (void const   *)pkthdr;
-    __ret = memcpy(__cil_tmp35, __cil_tmp36, __len);
+    __ret = memmove(__cil_tmp35, __cil_tmp36, __len);
     }
   } else {
     {
     __cil_tmp37 = (void *)pkt;
     __cil_tmp38 = (void const   *)pkthdr;
-    __ret = memcpy(__cil_tmp37, __cil_tmp38, __len);
+    __ret = memmove(__cil_tmp37, __cil_tmp38, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4462,7 +4462,7 @@ void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;
 extern int printk(char const * , ...) ;
-extern void *memcpy(void * , void const * , size_t ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void *kmem_cache_alloc(struct kmem_cache * , gfp_t ) ;
 void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
@@ -4846,13 +4846,13 @@ static void rx(struct net_device *dev , int bufnum , struct archdr *pkthdr , int
     {
     __cil_tmp35 = (void *)pkt;
     __cil_tmp36 = (void const *)pkthdr;
-    __ret = memcpy(__cil_tmp35, __cil_tmp36, __len);
+    __ret = memmove(__cil_tmp35, __cil_tmp36, __len);
     }
   } else {
     {
     __cil_tmp37 = (void *)pkt;
     __cil_tmp38 = (void const *)pkthdr;
-    __ret = memcpy(__cil_tmp37, __cil_tmp38, __len);
+    __ret = memmove(__cil_tmp37, __cil_tmp38, __len);
     }
   }
   {

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--power--max8903_charger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -92,7 +92,7 @@ void ldv_initialize() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: platform_driver_register
 // with type: int platform_driver_register(struct platform_driver *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -31,7 +31,7 @@ void ldv_initialize() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: msleep
 // with type: void msleep(unsigned int msecs)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--firmware--google--gsmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -144,7 +144,7 @@ void ldv_initialize() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -84,7 +84,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: printk
 // with type: int printk(const char *, ...)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -93,7 +93,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: msleep
 // with type: void msleep(unsigned int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp702x.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -93,7 +93,7 @@ struct page *ldv_some_page() {
 
 // Skip function: malloc
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Skip function: memset
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -66,7 +66,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: msleep
 // with type: void msleep(unsigned int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -66,7 +66,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: msleep
 // with type: void msleep(unsigned int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -174,7 +174,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: mempool_alloc
 // with type: void *mempool_alloc(mempool_t *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,7 +62,7 @@ struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
 
-// Skip function: memcpy
+// Skip function: memmove
 
 // Function: netif_rx
 // with type: int netif_rx(struct sk_buff *)


### PR DESCRIPTION
memcpy does not permit source/destination address overlap. Use memmove instead,
which has no such restriction. See also 32cb6344 and others. The replacement has
been performed for any use of memcpy in benchmarks where CBMC reported a violation in https://sv-comp.sosy-lab.org/2019/results/results-verified/cbmc.2018-12-04_2248.results.sv-comp19_prop-reachsafety.Systems_DeviceDriversLinux64_ReachSafety.xml.bz2.merged.xml.bz2.table.html
