### PR TITLE
Fix source files to ensure re-preprocessing works

### DIFF
--- a/c/array-memsafety/diff-alloca_true-valid-memsafety_true-termination.c
+++ b/c/array-memsafety/diff-alloca_true-valid-memsafety_true-termination.c
@@ -32,10 +32,10 @@ int main() {
   int Alen = __VERIFIER_nondet_int();
   int Blen = __VERIFIER_nondet_int();
   if (Alen < 1 || Alen >= 2147483647 / sizeof(int)) {
-     Alen = 1;
+    Alen = 1;
   }
   if (Blen < 1 || Blen >= 2147483647 / sizeof(int)) {
-     Blen = 1;
+    Blen = 1;
   }
   int* A = (int*) alloca(Alen * sizeof(int));
   int* B = (int*) alloca(Blen * sizeof(int));

--- a/c/list-properties/list_search_true-unreach-call_false-valid-memcleanup.c
+++ b/c/list-properties/list_search_true-unreach-call_false-valid-memcleanup.c
@@ -59,7 +59,7 @@ int main(void){
 
 	int i;
 	mlist *mylist = 0;
-  mlist *temp;
+	mlist *temp;
 
 	insert_list(mylist,2);
 	insert_list(mylist,5);

--- a/c/memsafety/test-0019_false-valid-memtrack_true-termination.c
+++ b/c/memsafety/test-0019_false-valid-memtrack_true-termination.c
@@ -23,8 +23,8 @@ static void free_data(TData *data)
         free(hi);
     }
 
-    data->lo = NULL;
-    data->hi = NULL;
+    data->lo = (void *) 0;
+    data->hi = (void *) 0;
 }
 
 int main() {

--- a/c/pthread-atomic/dekker_true-unreach-call.c
+++ b/c/pthread-atomic/dekker_true-unreach-call.c
@@ -6,7 +6,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int flag1 = 0, flag2 = 0; // boolean flags
 int turn; // integer variable to hold the ID of the thread whose turn is it

--- a/c/pthread-atomic/lamport_true-unreach-call.c
+++ b/c/pthread-atomic/lamport_true-unreach-call.c
@@ -5,7 +5,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int x, y;
 int b1, b2; // boolean flags

--- a/c/pthread-atomic/peterson_true-unreach-call.c
+++ b/c/pthread-atomic/peterson_true-unreach-call.c
@@ -5,7 +5,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int flag1 = 0, flag2 = 0; // boolean flags
 int turn; // integer variable to hold the ID of the thread whose turn is it

--- a/c/pthread-atomic/qrcu_false-unreach-call.c
+++ b/c/pthread-atomic/qrcu_false-unreach-call.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int idx=0; // boolean to control which of the two elements will be used by readers
   // (idx <= 0) then ctr1 is used

--- a/c/pthread-atomic/qrcu_true-unreach-call.c
+++ b/c/pthread-atomic/qrcu_true-unreach-call.c
@@ -11,7 +11,7 @@ extern int __VERIFIER_nondet_int();
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int idx=0; // boolean to control which of the two elements will be used by readers
   // (idx <= 0) then ctr1 is used

--- a/c/pthread-atomic/read_write_lock_false-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_false-unreach-call.c
@@ -10,7 +10,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int w=0, r=0, x, y;
 

--- a/c/pthread-atomic/read_write_lock_true-unreach-call.c
+++ b/c/pthread-atomic/read_write_lock_true-unreach-call.c
@@ -10,7 +10,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int w=0, r=0, x, y;
 

--- a/c/pthread-atomic/scull_true-unreach-call.c
+++ b/c/pthread-atomic/scull_true-unreach-call.c
@@ -81,7 +81,7 @@ extern int __VERIFIER_nondet_int();
 
 
 
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 inode i;
 pthread_mutex_t lock;

--- a/c/pthread-atomic/szymanski_true-unreach-call.c
+++ b/c/pthread-atomic/szymanski_true-unreach-call.c
@@ -5,7 +5,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int flag1 = 0, flag2 = 0; // integer flags 
 int x; // boolean variable to test mutual exclusion

--- a/c/pthread-atomic/time_var_mutex_true-unreach-call.c
+++ b/c/pthread-atomic/time_var_mutex_true-unreach-call.c
@@ -10,7 +10,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 */
 
 #include <pthread.h>
-#define assert(e) if (!(e)) ERROR: __VERIFIER_error();
+#define assert(e) if (!(e)) ERROR: __VERIFIER_error()
 
 int block;
 int busy; // boolean flag indicating whether the block has been allocated to an inode

--- a/c/pthread-ext/06_ticket_true-unreach-call.c
+++ b/c/pthread-ext/06_ticket_true-unreach-call.c
@@ -22,7 +22,7 @@ volatile unsigned now_serving = 0;
 // #define NEXT(e) ((e+1 == FAILED)?0:e+1)
 
 unsigned fetch_and_increment__next_ticket(){
-        __VERIFIER_atomic_begin();
+	__VERIFIER_atomic_begin();
 	unsigned value;
 
 		if(NEXT(next_ticket) == now_serving){ 

--- a/c/pthread-ext/08_rand_cas_true-unreach-call.c
+++ b/c/pthread-ext/08_rand_cas_true-unreach-call.c
@@ -1,5 +1,5 @@
-extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 //http://www.ibm.com/developerworks/java/library/j-jtp11234/

--- a/c/pthread-ext/09_fmaxsym_true-unreach-call.c
+++ b/c/pthread-ext/09_fmaxsym_true-unreach-call.c
@@ -45,7 +45,7 @@ inline void findMax(int offset)
 }
 
 void* thr1(void* arg) {
-	int offset=__VERIFIER_nondet_int();
+  int offset=__VERIFIER_nondet_int();
 
 	assume(offset % WORKPERTHREAD == 0 && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);
 	//assume(offset < WORKPERTHREAD && offset >= 0 && offset < WORKPERTHREAD*THREADSMAX);

--- a/c/pthread-ext/25_stack_longer_false-unreach-call.c
+++ b/c/pthread-ext/25_stack_longer_false-unreach-call.c
@@ -1,5 +1,5 @@
-extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/25_stack_longer_true-unreach-call.c
+++ b/c/pthread-ext/25_stack_longer_true-unreach-call.c
@@ -1,5 +1,5 @@
-extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 //original file: EBStack.java
 //amino-cbbs\trunk\amino\java\src\main\java\org\amino\ds\lockfree

--- a/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
+++ b/c/pthread-ext/42_FreeBSD__rdma_addr__sliced_true-unreach-call.c
@@ -1,5 +1,5 @@
-extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.c
+++ b/c/pthread-ext/44_Solaris__space_map__sliced_true-unreach-call.c
@@ -1,5 +1,5 @@
-extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <pthread.h>

--- a/c/pthread-lit/qw2004_true-unreach-call.c
+++ b/c/pthread-lit/qw2004_true-unreach-call.c
@@ -11,15 +11,15 @@ volatile int stoppingEvent;
 volatile int stopped;
 
 int BCSP_IoIncrement() {
-    int ret = 0;
     __VERIFIER_atomic_begin();
     if (stoppingFlag) {
-      ret = -1;
+        __VERIFIER_atomic_end();
+	return -1;
     } else {
 	pendingIo = pendingIo + 1;
     }
     __VERIFIER_atomic_end();
-    return ret;
+    return 0;
 }
 
 int dec() {

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.c
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.c
@@ -14,15 +14,15 @@ volatile int stoppingEvent;
 volatile int stopped;
 
 int BCSP_IoIncrement() {
-    int ret = 0;
     __VERIFIER_atomic_begin();
     if (stoppingFlag) {
-      ret = -1;
+        __VERIFIER_atomic_end();
+	return -1;
     } else {
 	pendingIo = pendingIo + 1;
     }
     __VERIFIER_atomic_end();
-    return ret;
+    return 0;
 }
 
 void BCSP_IoDecrement() {

--- a/c/pthread/queue_false-unreach-call.c
+++ b/c/pthread/queue_false-unreach-call.c
@@ -153,6 +153,7 @@ int main(void)
 
   if (!empty(&queue)==EMPTY) {
     ERROR: __VERIFIER_error();
+    goto ERROR;
   }
 
 

--- a/c/pthread/reorder_2_false-unreach-call.c
+++ b/c/pthread/reorder_2_false-unreach-call.c
@@ -78,7 +78,6 @@ void *checkThread(void *param) {
     if (! ((a == 0 && b == 0) || (a == 1 && b == -1))) {
         fprintf(stderr, "Bug found!\n");
     	ERROR: __VERIFIER_error();
-    	goto ERROR;
     }
 
     return NULL;

--- a/c/pthread/sigma_false-unreach-call.c
+++ b/c/pthread/sigma_false-unreach-call.c
@@ -32,7 +32,7 @@ int main()
 	__VERIFIER_assume(array);
 
 	for (tid=0; tid<SIGMA; tid++) {
-	        array_index++;
+		array_index++;
 		pthread_create(&t[tid], 0, thread, 0);
 	}
 

--- a/c/seq-pthread/cs_dekker_true-unreach-call.c
+++ b/c/seq-pthread/cs_dekker_true-unreach-call.c
@@ -431,18 +431,18 @@ int main()
 	int __CS_cp_flag2[__CS_ROUNDS];
 	int __CS_cp_turn[__CS_ROUNDS];
 	int __CS_cp_x[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for (i = 0; i < 3; i++) {
-    __CS_cp_flag1[i] = __VERIFIER_nondet_int();
-    __CS_cp_flag2[i] = __VERIFIER_nondet_int();
-    __CS_cp_turn[i] = __VERIFIER_nondet_int();
-    __CS_cp_x[i] = __VERIFIER_nondet_int();
-    for (j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)__VERIFIER_nondet_pointer();
-    }
-  }
+	for (i = 0; i < 3; i++) {
+		__CS_cp_flag1[i] = __VERIFIER_nondet_int();
+		__CS_cp_flag2[i] = __VERIFIER_nondet_int();
+		__CS_cp_turn[i] = __VERIFIER_nondet_int();
+		__CS_cp_x[i] = __VERIFIER_nondet_int();
+		for (j = 0; j < 3; j++) {
+			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+			__CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)__VERIFIER_nondet_pointer();
+		}
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_fib_longer_true-unreach-call.c
+++ b/c/seq-pthread/cs_fib_longer_true-unreach-call.c
@@ -379,16 +379,16 @@ int main(int argc, char **argv)
 	__CS_type *__CS_cp___CS_thread_lockedon[__CS_ROUNDS][__CS_THREADS+1];
 	int __CS_cp_i[__CS_ROUNDS];
 	int __CS_cp_j[__CS_ROUNDS];
-  int k, l;
+	int k, l;
 
-  for(k = 0; k < 7; k++) {
-    __CS_cp_i[k] = __VERIFIER_nondet_int();
-    __CS_cp_j[k] = __VERIFIER_nondet_int();
-    for(l = 0; l < 3; l++) {
-      __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(k = 0; k < 7; k++) {
+		__CS_cp_i[k] = __VERIFIER_nondet_int();
+		__CS_cp_j[k] = __VERIFIER_nondet_int();
+		for(l = 0; l < 3; l++) {
+		  __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
+		  __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+		}
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_fib_true-unreach-call.c
+++ b/c/seq-pthread/cs_fib_true-unreach-call.c
@@ -379,16 +379,16 @@ int main(int argc, char **argv)
 	__CS_type *__CS_cp___CS_thread_lockedon[__CS_ROUNDS][__CS_THREADS+1];
 	int __CS_cp_i[__CS_ROUNDS];
 	int __CS_cp_j[__CS_ROUNDS];
-  int k, l;
+	int k, l;
 
-  for(k = 0; k < 6; k++) {
-    __CS_cp_i[k] = __VERIFIER_nondet_int();
-    __CS_cp_j[k] = __VERIFIER_nondet_int();
-    for(l = 0; l < 3; l++) {
-      __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(k = 0; k < 6; k++) {
+	  __CS_cp_i[k] = __VERIFIER_nondet_int();
+	  __CS_cp_j[k] = __VERIFIER_nondet_int();
+	  for(l = 0; l < 3; l++) {
+	    __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_lamport_true-unreach-call.c
+++ b/c/seq-pthread/cs_lamport_true-unreach-call.c
@@ -502,19 +502,19 @@ int main()
 	int __CS_cp_b1[__CS_ROUNDS];
 	int __CS_cp_b2[__CS_ROUNDS];
 	int __CS_cp_X[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 3; i++) {
-    __CS_cp_x[i] = __VERIFIER_nondet_int();
-    __CS_cp_y[i] = __VERIFIER_nondet_int();
-    __CS_cp_b1[i] = __VERIFIER_nondet_int();
-    __CS_cp_b2[i] = __VERIFIER_nondet_int();
-    __CS_cp_X[i] = __VERIFIER_nondet_int();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 3; i++) {
+	  __CS_cp_x[i] = __VERIFIER_nondet_int();
+	  __CS_cp_y[i] = __VERIFIER_nondet_int();
+	  __CS_cp_b1[i] = __VERIFIER_nondet_int();
+	  __CS_cp_b2[i] = __VERIFIER_nondet_int();
+	  __CS_cp_X[i] = __VERIFIER_nondet_int();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_peterson_true-unreach-call.c
+++ b/c/seq-pthread/cs_peterson_true-unreach-call.c
@@ -403,18 +403,18 @@ int main()
 	int __CS_cp_flag2[__CS_ROUNDS];
 	int __CS_cp_turn[__CS_ROUNDS];
 	int __CS_cp_x[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 3; i++) {
-    __CS_cp_flag1[i] = __VERIFIER_nondet_int();
-    __CS_cp_flag2[i] = __VERIFIER_nondet_int();
-    __CS_cp_turn[i] = __VERIFIER_nondet_int();
-    __CS_cp_x[i] = __VERIFIER_nondet_int();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 3; i++) {
+	  __CS_cp_flag1[i] = __VERIFIER_nondet_int();
+	  __CS_cp_flag2[i] = __VERIFIER_nondet_int();
+	  __CS_cp_turn[i] = __VERIFIER_nondet_int();
+	  __CS_cp_x[i] = __VERIFIER_nondet_int();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_queue_true-unreach-call.c
+++ b/c/seq-pthread/cs_queue_true-unreach-call.c
@@ -541,27 +541,27 @@ int main(void)
 	_Bool __CS_cp_enqueue_flag[__CS_ROUNDS];
 	_Bool __CS_cp_dequeue_flag[__CS_ROUNDS];
 	QType __CS_cp_queue[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 2; i++) {
-    __CS_cp_m[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_enqueue_flag[i] = __VERIFIER_nondet_bool();
-    __CS_cp_dequeue_flag[i] = __VERIFIER_nondet_bool();
-    __CS_cp_queue[i].head = __VERIFIER_nondet_int();
-    __CS_cp_queue[i].tail = __VERIFIER_nondet_int();
-    __CS_cp_queue[i].amount = __VERIFIER_nondet_int();
-    for(j = 0; j < 20; j++) {
-      __CS_cp_queue[i].element[j] = __VERIFIER_nondet_int();
-    }
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
+	for(i = 0; i < 2; i++) {
+	  __CS_cp_m[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_enqueue_flag[i] = __VERIFIER_nondet_bool();
+	  __CS_cp_dequeue_flag[i] = __VERIFIER_nondet_bool();
+	  __CS_cp_queue[i].head = __VERIFIER_nondet_int();
+	  __CS_cp_queue[i].tail = __VERIFIER_nondet_int();
+	  __CS_cp_queue[i].amount = __VERIFIER_nondet_int();
+	  for(j = 0; j < 20; j++) {
+	    __CS_cp_queue[i].element[j] = __VERIFIER_nondet_int();
+	  }
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
 
-    for (j = 0; j < 20; j++) {
-      __CS_cp_stored_elements[i][j] = __VERIFIER_nondet_int();
-    }
-  }
+	  for (j = 0; j < 20; j++) {
+	    __CS_cp_stored_elements[i][j] = __VERIFIER_nondet_int();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_read_write_lock_true-unreach-call.c
+++ b/c/seq-pthread/cs_read_write_lock_true-unreach-call.c
@@ -412,18 +412,18 @@ int main()
 	int __CS_cp_r[__CS_ROUNDS];
 	int __CS_cp_x[__CS_ROUNDS];
 	int __CS_cp_y[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 2; i++) {
-    __CS_cp_w[i] = __VERIFIER_nondet_int();
-    __CS_cp_r[i] = __VERIFIER_nondet_int();
-    __CS_cp_x[i] = __VERIFIER_nondet_int();
-    __CS_cp_y[i] = __VERIFIER_nondet_int();
-    for(j = 0; j < 5; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 2; i++) {
+	  __CS_cp_w[i] = __VERIFIER_nondet_int();
+	  __CS_cp_r[i] = __VERIFIER_nondet_int();
+	  __CS_cp_x[i] = __VERIFIER_nondet_int();
+	  __CS_cp_y[i] = __VERIFIER_nondet_int();
+ 	 for(j = 0; j < 5; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_stack_true-unreach-call.c
+++ b/c/seq-pthread/cs_stack_true-unreach-call.c
@@ -487,22 +487,22 @@ int main(void)
 	static unsigned int __CS_cp_arr[__CS_ROUNDS][5];
 	__CS_pthread_mutex_t __CS_cp_m[__CS_ROUNDS];
 	_Bool __CS_cp_flag[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 2; i++) {
-    __CS_cp_top[i] = __VERIFIER_nondet_int();
-    __CS_cp_m[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_flag[i] = __VERIFIER_nondet_bool();
+	for(i = 0; i < 2; i++) {
+	  __CS_cp_top[i] = __VERIFIER_nondet_int();
+	  __CS_cp_m[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_flag[i] = __VERIFIER_nondet_bool();
 
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
 
-    for(j = 0; j < 5; j++) {
-      __CS_cp_arr[i][j] = __VERIFIER_nondet_uint();
-    }
-  }
+	  for(j = 0; j < 5; j++) {
+	    __CS_cp_arr[i][j] = __VERIFIER_nondet_uint();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_stateful_true-unreach-call.c
+++ b/c/seq-pthread/cs_stateful_true-unreach-call.c
@@ -393,18 +393,18 @@ int main()
 	__CS_pthread_mutex_t __CS_cp_mb[__CS_ROUNDS];
 	int __CS_cp_data1[__CS_ROUNDS];
 	int __CS_cp_data2[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 2; i++) {
-    __CS_cp_ma[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_mb[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_data1[i] = __VERIFIER_nondet_int();
-    __CS_cp_data2[i] = __VERIFIER_nondet_int();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 2; i++) {
+	  __CS_cp_ma[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_mb[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_data1[i] = __VERIFIER_nondet_int();
+	  __CS_cp_data2[i] = __VERIFIER_nondet_int();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_sync_true-unreach-call.c
+++ b/c/seq-pthread/cs_sync_true-unreach-call.c
@@ -400,18 +400,18 @@ int main()
 	__CS_pthread_mutex_t __CS_cp_m[__CS_ROUNDS];
 	__CS_pthread_cond_t __CS_cp_empty[__CS_ROUNDS];
 	__CS_pthread_cond_t __CS_cp_full[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 2; i++) {
-    __CS_cp_num[i] = __VERIFIER_nondet_int();
-    __CS_cp_m[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_empty[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_full[i] = __VERIFIER_nondet_uchar();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 2; i++) {
+	  __CS_cp_num[i] = __VERIFIER_nondet_int();
+	  __CS_cp_m[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_empty[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_full[i] = __VERIFIER_nondet_uchar();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_szymanski_true-unreach-call.c
+++ b/c/seq-pthread/cs_szymanski_true-unreach-call.c
@@ -460,17 +460,17 @@ int main()
 	int __CS_cp_flag1[__CS_ROUNDS];
 	int __CS_cp_flag2[__CS_ROUNDS];
 	int __CS_cp_x[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 3; i++) {
-    __CS_cp_flag1[i] = __VERIFIER_nondet_int();
-    __CS_cp_flag2[i] = __VERIFIER_nondet_int();
-    __CS_cp_x[i] = __VERIFIER_nondet_int();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 3; i++) {
+	  __CS_cp_flag1[i] = __VERIFIER_nondet_int();
+	  __CS_cp_flag2[i] = __VERIFIER_nondet_int();
+	  __CS_cp_x[i] = __VERIFIER_nondet_int();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].

--- a/c/seq-pthread/cs_time_var_mutex_true-unreach-call.c
+++ b/c/seq-pthread/cs_time_var_mutex_true-unreach-call.c
@@ -420,19 +420,19 @@ int main()
 	int __CS_cp_inode[__CS_ROUNDS];
 	__CS_pthread_mutex_t __CS_cp_m_inode[__CS_ROUNDS];
 	__CS_pthread_mutex_t __CS_cp_m_busy[__CS_ROUNDS];
-  int i, j;
+	int i, j;
 
-  for(i = 0; i < 3; i++) {
-    __CS_cp_block[i] = __VERIFIER_nondet_int();
-    __CS_cp_busy[i] = __VERIFIER_nondet_int();
-    __CS_cp_inode[i] = __VERIFIER_nondet_int();
-    __CS_cp_m_inode[i] = __VERIFIER_nondet_uchar();
-    __CS_cp_m_busy[i] = __VERIFIER_nondet_uchar();
-    for(j = 0; j < 3; j++) {
-      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-      __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
-    }
-  }
+	for(i = 0; i < 3; i++) {
+	  __CS_cp_block[i] = __VERIFIER_nondet_int();
+	  __CS_cp_busy[i] = __VERIFIER_nondet_int();
+	  __CS_cp_inode[i] = __VERIFIER_nondet_int();
+	  __CS_cp_m_inode[i] = __VERIFIER_nondet_uchar();
+	  __CS_cp_m_busy[i] = __VERIFIER_nondet_uchar();
+	  for(j = 0; j < 3; j++) {
+	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	  }
+	}
 	//cseq: Copy statements for global variables:
 	//cseq: for each global variable x,
 	//cseq: copy into x[1...___CS_ROUNDS] <--- __CS_cp_x[1..___CS_ROUNDS].


### PR DESCRIPTION
Changes original source files to match whatever is now in the
preprocessed files, which sometimes have been updated without making
matching changes to the original source. Most of these changes are
whitespace-only or an order of declarations. Some changes do affect
behaviour, but the competition always uses preprocessed files and thus
this these changes do not affect the intended verdict.
