### PR TITLE
Remove commented line from supposedly preprocessed file

### DIFF
--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -679,7 +679,6 @@ int main() {
     pthread_t t;
     int i, n;
     s = 0;
-    //t = 0;
     n = __VERIFIER_nondet_int();
     __VERIFIER_assume(n > 0);
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
The preprocessor removes all comments.
