### PR TITLE
Compare parses yml

### DIFF
--- a/c/.Dockerfile.preprocessing-consistency
+++ b/c/.Dockerfile.preprocessing-consistency
@@ -21,7 +21,11 @@ RUN make -C cbmc/src -j2 goto-diff.dir goto-cc.dir
 FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y \
-  libc6-dev-i386
+  libc6-dev-i386 \
+  jq \
+  python3-pip
+
+RUN pip3 install yq
 
 COPY --from=0 /cbmc .
 

--- a/c/compare.sh
+++ b/c/compare.sh
@@ -71,14 +71,9 @@ for f in $SETS ; do
   for ff in $(ls $(grep -v "^#" $f)) ; do
     orig=$ff
 
-    # Get file that belongs to task definition (by file name)
-    # It would be more precise, but also a lot more complicated,
-    # to use the input-file value of the task definition.
     if echo $ff | grep -q ".yml$"; then
-      ff=$(echo $ff | sed 's/\.yml$/.i/')
-      if [ ! -f $ff ]; then
-        ff=$(echo $ff | sed 's/\.i$/.c/')
-      fi
+      input_basename=$(yq --raw-output '.input_files' "$ff")
+      ff=$(echo "$(dirname "$ff")/${input_basename}")
     fi
 
     if [ ! -s $ff ] ; then


### PR DESCRIPTION
Through this PR, the `compare.sh` CI check actually parses the task definition file
to get the input file, instead of using a heuristic based on file names.