### PR TITLE
Fix yaml compare script

### DIFF
--- a/c/compare.sh
+++ b/c/compare.sh
@@ -84,6 +84,16 @@ for f in $SETS ; do
 
     if echo $ff | grep -q ".yml$"; then
       input_basename=$(yq --raw-output '.input_files' "$ff")
+      # check whether the input_basename exists (nobody should ever use "null" as a filename!)
+      if [ "null" = "$input_basename" ] ; then
+        echo "No input files defined in $ff" 1>&2
+        exit 1
+      fi
+      # simple check whether input_basename is a list like "[...]"
+      if [ -z "${input_basename##*\[*\]*}" ] ; then
+        echo "ignoring task consisting of multiple sourcefiles"
+        continue
+      fi
       ff=$(echo "$(dirname "$ff")/${input_basename}")
     fi
 

--- a/c/compare.sh
+++ b/c/compare.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This script iterates over all tasks and performs the following check:
+# For each file with existing ".c"- and ".i"-file
+# we generate the goto-cc program (i.e., intermediate representation of cbmc)
+# and compare the goto-cc programs with goto-diff.
+# Finding a difference implies a wrong preprocessing.
+
 set -e
 
 BLACKLIST="\
@@ -12,6 +18,7 @@ SHOW_DIFF=0
 SKIP_LARGE=0
 SETS=""
 
+# parse comandline options
 for a in "$@" ; do
   case "$a" in
     --keep-going|-k) KEEP_GOING=1 ;;
@@ -21,10 +28,12 @@ for a in "$@" ; do
   esac
 done
 
-if [ "x$SETS" = "x" ] ; then
+# if the user did not directly specify sets, we select all sets
+if [ -z "$SETS" ] ; then
   SETS="*.set"
 fi
 
+# build goto-cc and goto-diff if not available, and then set PATH to find it
 if ! (which goto-cc && which goto-diff); then
   if [ ! -e ../cbmc.git/src/goto-cc/goto-cc ] ; then
     git clone --depth=1 http://github.com/diffblue/cbmc.git ../cbmc.git
@@ -38,6 +47,7 @@ fi
 
 EC=0
 
+# iterate over all sets
 for f in $SETS ; do
   if [ ! -s $f ] ; then
     echo "Invalid set $f"
@@ -46,7 +56,7 @@ for f in $SETS ; do
 
   setf=$(basename $f .set)
 
-  # pthread headers are very platform dependent
+  # skip some sets, like LDV (too big) or Concurrency (pthread headers are very platform dependent)
   if [ $setf = ConcurrencySafety-Main ] ; then
     echo "Skipping category $setf (platform-dependent types)"
     continue
@@ -67,6 +77,7 @@ for f in $SETS ; do
     exit 1
   fi
 
+  # iterate over all files in the set
   i=0
   for ff in $(ls $(grep -v "^#" $f)) ; do
     orig=$ff
@@ -113,6 +124,8 @@ for f in $SETS ; do
       echo "Processing file $i of category $setf"
     fi
 
+    # now we have found all required files and start with the actual check:
+    # convert both files into goto-cc intermediate language and compare them.
     goto-cc -m$bits $orig
     goto-cc -m$bits $ff -o b.out
     c=$(goto-diff --verbosity 2 -u a.out b.out | wc -l)


### PR DESCRIPTION
For multi-file task definitions the compare-script crashes.
This fix allows to ignore such tasks and only print a warning.

Currently there are no such tasks in the repository,
but we should try to support them with our scripts anyway.