### PR TITLE
Remove coverage properties from all tasks that may rely on nondet pointers

### DIFF
--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: 'linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,7 +6,3 @@ input_files: '32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--st
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
-  - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--sja1000--sja1000.ko-entry_point.cil.out.yml
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--sja1000--sja1000.ko-entry_point.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_mai
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backli
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-defaul
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.k
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.k
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuners--mc44s803.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuners--mc44s803.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuner
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--dvb_dummy_fe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--dvb_dummy_fe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tua6100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tua6100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bu
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_sc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--wl12x
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topst
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-es
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--ili9320.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--ili9320.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--il
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds240
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds242
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds243
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds243
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds276
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds278
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds278
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-cl
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backligh
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--m
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_9
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_oobtest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_oobtest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_subpagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_subpagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-eb
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-c
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibra
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-free
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f0
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv3
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo24m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo24m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,6 +6,3 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
+++ b/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
@@ -6,7 +6,3 @@ input_files: 'main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
-  - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/rule57_ebda_blast.c_1.yml
+++ b/c/ldv-regression/rule57_ebda_blast.c_1.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/rule57_ebda_blast.yml
+++ b/c/ldv-regression/rule57_ebda_blast.yml
@@ -8,7 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
-  - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/test27-1.yml
+++ b/c/ldv-regression/test27-1.yml
@@ -8,6 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/test27-2.yml
+++ b/c/ldv-regression/test27-2.yml
@@ -8,7 +8,3 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
-  - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
Since `__VERIFIER_nondet_pointer` is neither properly specified, nor is it defined how to model memory
for test generation and validation, tasks that rely on `__VERIFIER_nondet_pointer` can not be used for test-case generation.
This PR is a possible over-approximation, as I did not check whether the calls to `__VERIFIER_nondet_pointer` are necessary to prove reachability of an error call.


Script used to perform these changes:
https://gist.github.com/lembergerth/ac8fe696013b93916c172101a38de337
