### PR TITLE
Appropriate property changes in YML for non-terminating seq-mthread programs

### DIFF
--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_STARTPALS_ActiveStandby.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_STARTPALS_ActiveStandby.4_1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_STARTPALS_ActiveStandby.4_2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_STARTPALS_ActiveStandby.5.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_STARTPALS_ActiveStandby.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,7 @@ input_files: 'pals_STARTPALS_Triplicated.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_STARTPALS_Triplicated.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,7 @@ input_files: 'pals_STARTPALS_Triplicated.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+

--- a/c/seq-mthreaded/pals_floodmax.3.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.1.ufo.UNBOUNDED.pals.yml
@@ -4,9 +4,8 @@ format_version: '1.0'
 input_files: 'pals_floodmax.3.1.ufo.UNBOUNDED.pals.c'
 
 properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.3.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.3.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.3.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.3.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.3.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_floodmax.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_floodmax.3_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.3_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.4.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.4.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.4.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.4.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.4.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.4.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_floodmax.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.5.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.5.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.5.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.5.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.5.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.5.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.5.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_floodmax.5.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_floodmax.5.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.3.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.3.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr-var-start-time.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.4.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.4.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr-var-start-time.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.5.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.5.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr-var-start-time.5.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.6.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr-var-start-time.6.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr-var-start-time.6.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.3.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.3.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.3.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.3.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.3_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.3_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.3_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.4.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.4.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.4.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.4.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.4_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.4_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.4_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.5.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.5.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.5.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.5.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.5.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.5.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.5_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.5_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.5_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.6.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.6.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.6.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.6.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.6.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.6.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.6_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.7.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.7.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.7.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.7.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.7.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.7.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.7_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.8.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.8.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.8.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_lcr.8.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.8.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_lcr.8.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_lcr.8_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.8_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_lcr.8_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.3.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.3.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.3.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.3.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_opt-floodmax.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_opt-floodmax.3_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.3_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.4.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.4.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_opt-floodmax.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.5.1.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.5.3.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,7 @@ input_files: 'pals_opt-floodmax.5.4.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  

--- a/c/seq-mthreaded/pals_opt-floodmax.5.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.ufo.UNBOUNDED.pals.yml
@@ -6,6 +6,5 @@ input_files: 'pals_opt-floodmax.5.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/termination.prp
+    expected_verdict: false

--- a/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
@@ -6,7 +6,6 @@ input_files: 'pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
-  - property_file: ../properties/coverage-branches.prp
-  - property_file: ../properties/coverage-conditions.prp
-  - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
Hi,

I have appropriately removed "coverage-branches" property from seq-mthread category programs which behave in non-terminating fashion. Also, I have added termination property to such programs.

This is intended for TESTCOMP purpose. Coverage is not reported properly for testcases which results in non-terminating behavior.

However, I feel the program name do emit critical information about program behaviors. 
For eg. -
*BOUNDED-8*.c or *BOUNDED-6*.c or *UNBOUNDED* in program name can emit critical information. When YML task definition has been introduced for this case, it is better to rename such files also.

 (As discussed with Dirk over mail)

Best Regards,
Animesh

