### PR TITLE
Transformed VLA allocation into heap allocation and bounded the allocation size

### DIFF
--- a/c/array-crafted/zero_sum_const1.c
+++ b/c/array-crafted/zero_sum_const1.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const1.c
+++ b/c/array-crafted/zero_sum_const1.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const2.c
+++ b/c/array-crafted/zero_sum_const2.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const2.c
+++ b/c/array-crafted/zero_sum_const2.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const3.c
+++ b/c/array-crafted/zero_sum_const3.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const3.c
+++ b/c/array-crafted/zero_sum_const3.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const4.c
+++ b/c/array-crafted/zero_sum_const4.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const4.c
+++ b/c/array-crafted/zero_sum_const4.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const5.c
+++ b/c/array-crafted/zero_sum_const5.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const5.c
+++ b/c/array-crafted/zero_sum_const5.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const_m2.c
+++ b/c/array-crafted/zero_sum_const_m2.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const_m2.c
+++ b/c/array-crafted/zero_sum_const_m2.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const_m3.c
+++ b/c/array-crafted/zero_sum_const_m3.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const_m3.c
+++ b/c/array-crafted/zero_sum_const_m3.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const_m4.c
+++ b/c/array-crafted/zero_sum_const_m4.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const_m4.c
+++ b/c/array-crafted/zero_sum_const_m4.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-crafted/zero_sum_const_m5.c
+++ b/c/array-crafted/zero_sum_const_m5.c
@@ -5,13 +5,15 @@ extern long __VERIFIER_nondet_long(void);
 
 long SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_long();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		long a[SIZE];
+		long *a = malloc(sizeof(long)*SIZE);
 		long long sum=0;
 
 		for(i = 0; i < SIZE; i++ )

--- a/c/array-crafted/zero_sum_const_m5.c
+++ b/c/array-crafted/zero_sum_const_m5.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern long __VERIFIER_nondet_long(void);
+void *malloc(unsigned long size);
 
 long SIZE;
 

--- a/c/array-tiling/mlceu.c
+++ b/c/array-tiling/mlceu.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 
 		for(i=0; i<SIZE; i++)
 		{

--- a/c/array-tiling/mlceu.c
+++ b/c/array-tiling/mlceu.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/pnr2.c
+++ b/c/array-tiling/pnr2.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int ReadFromPort()
 {

--- a/c/array-tiling/pnr2.c
+++ b/c/array-tiling/pnr2.c
@@ -8,16 +8,19 @@ int ReadFromPort()
 	int x = __VERIFIER_nondet_int();
 	return x;
 }
+
 int SIZE;
+
+const int MAX = 100000;
 
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
 		int value;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int DEFAULTVAL = 0; 
 		int FIXEDVAL = 10; 
 

--- a/c/array-tiling/pnr3.c
+++ b/c/array-tiling/pnr3.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int ReadFromPort()
 {

--- a/c/array-tiling/pnr3.c
+++ b/c/array-tiling/pnr3.c
@@ -8,16 +8,19 @@ int ReadFromPort()
 	int x = __VERIFIER_nondet_int();
 	return x;
 }
+
 int SIZE;
+
+const int MAX = 100000;
 
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
 		int value;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int DEFAULTVAL = 0; 
 		int FIXEDVAL = 10; 
 

--- a/c/array-tiling/pnr4.c
+++ b/c/array-tiling/pnr4.c
@@ -10,14 +10,16 @@ int ReadFromPort()
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
 		int value;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int DEFAULTVAL = 0; 
 		int FIXEDVAL = 10; 
 

--- a/c/array-tiling/pnr4.c
+++ b/c/array-tiling/pnr4.c
@@ -2,6 +2,8 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
+
 int ReadFromPort()
 {
 	int x = __VERIFIER_nondet_int();

--- a/c/array-tiling/pnr5.c
+++ b/c/array-tiling/pnr5.c
@@ -10,14 +10,16 @@ int ReadFromPort()
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
 		int value;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int DEFAULTVAL = 0; 
 		int FIXEDVAL = 10; 
 

--- a/c/array-tiling/pnr5.c
+++ b/c/array-tiling/pnr5.c
@@ -2,6 +2,8 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
+
 int ReadFromPort()
 {
 	int x = __VERIFIER_nondet_int();

--- a/c/array-tiling/poly1.c
+++ b/c/array-tiling/poly1.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		long long i;
-		long long a[SIZE];
+		long long *a = malloc(sizeof(long long)*SIZE);
 
 		for(i=0; i<SIZE; i++)
 		{

--- a/c/array-tiling/poly1.c
+++ b/c/array-tiling/poly1.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/poly2.c
+++ b/c/array-tiling/poly2.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
 	if(SIZE > 1)
 	{
 		long long i;
-		long long a[SIZE];
+		long long *a = malloc(sizeof(long long)*SIZE);
 
 		for(i=0; i<SIZE; i++)
 		{

--- a/c/array-tiling/poly2.c
+++ b/c/array-tiling/poly2.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 
@@ -10,7 +11,7 @@ const int MAX = 100000;
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		long long i;
 		long long *a = malloc(sizeof(long long)*SIZE);

--- a/c/array-tiling/revcpyswp2.c
+++ b/c/array-tiling/revcpyswp2.c
@@ -3,6 +3,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/revcpyswp2.c
+++ b/c/array-tiling/revcpyswp2.c
@@ -6,17 +6,19 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
 		int tmp;
-		int a[SIZE];
-		int b[SIZE];
-		int a_copy[SIZE];
-		int b_copy[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
+		int *b = malloc(sizeof(int)*SIZE);
+		int *a_copy = malloc(sizeof(int)*SIZE);
+		int *b_copy = malloc(sizeof(int)*SIZE);
 		
 		for(i=0; i<SIZE; i++)
 		{

--- a/c/array-tiling/rew.c
+++ b/c/array-tiling/rew.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int val2 = 3;
 		int val1 = 0;
 		int low=2;

--- a/c/array-tiling/rew.c
+++ b/c/array-tiling/rew.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/rewnif.c
+++ b/c/array-tiling/rewnif.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 
 		for( i = 0; i < SIZE ; i++ )
 		{

--- a/c/array-tiling/rewnif.c
+++ b/c/array-tiling/rewnif.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/rewnifrev.c
+++ b/c/array-tiling/rewnifrev.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 
 		for( i=SIZE-1; i>=0; i-- )
 		{

--- a/c/array-tiling/rewnifrev.c
+++ b/c/array-tiling/rewnifrev.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/rewnifrev2.c
+++ b/c/array-tiling/rewnifrev2.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
 	int i;
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 
 		for( i=SIZE-2; i >= 0; i-- )
 		{

--- a/c/array-tiling/rewnifrev2.c
+++ b/c/array-tiling/rewnifrev2.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/rewrev.c
+++ b/c/array-tiling/rewrev.c
@@ -3,15 +3,16 @@ extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
 
+const int MAX = 100000;
 int SIZE;
 
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		int val2 = 3;
 		int val1 = 7;
 		int low=2;

--- a/c/array-tiling/rewrev.c
+++ b/c/array-tiling/rewrev.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 const int MAX = 100000;
 int SIZE;

--- a/c/array-tiling/skipped.c
+++ b/c/array-tiling/skipped.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		
     for(i = 0; i < SIZE; i++)
 		{

--- a/c/array-tiling/skipped.c
+++ b/c/array-tiling/skipped.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/skippedu.c
+++ b/c/array-tiling/skippedu.c
@@ -5,13 +5,15 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
 		
 		for(i = 0; i < SIZE; i++)
 		{

--- a/c/array-tiling/skippedu.c
+++ b/c/array-tiling/skippedu.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/array-tiling/tcpy.c
+++ b/c/array-tiling/tcpy.c
@@ -5,14 +5,16 @@ extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 
+const int MAX = 100000;
+
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1)
+	if(SIZE > 1 && SIZE < MAX)
 	{
 		int i;
-		int a[SIZE];
-		int acopy[SIZE];
+		int *a = malloc(sizeof(int)*SIZE);
+		int *acopy = malloc(sizeof(int)*SIZE);
 		
 		for(i = 0; i < SIZE; i++)
 		{

--- a/c/array-tiling/tcpy.c
+++ b/c/array-tiling/tcpy.c
@@ -2,6 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned long size);
 
 int SIZE;
 

--- a/c/loops/linear_sea.ch.c
+++ b/c/loops/linear_sea.ch.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void *malloc(unsigned long size);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {

--- a/c/loops/linear_sea.ch.c
+++ b/c/loops/linear_sea.ch.c
@@ -8,6 +8,7 @@ void __VERIFIER_assert(int cond) {
 }
 unsigned int __VERIFIER_nondet_uint();
 unsigned int  SIZE;
+const unsigned int MAX = 100000;
 int linear_search(int *a, int n, int q) {
   unsigned int j=0;
   while (j<n && a[j]!=q) {
@@ -18,7 +19,10 @@ int linear_search(int *a, int n, int q) {
 }
 int main() { 
   SIZE=(__VERIFIER_nondet_uint()/8)+1;
-  int a[SIZE];
-  a[SIZE/2]=3;
-  __VERIFIER_assert(linear_search(a,SIZE,3));
+
+  if (SIZE > 1 && SIZE < MAX) {
+    int *a = malloc(sizeof(int)*SIZE);
+    a[SIZE/2]=3;
+    __VERIFIER_assert(linear_search(a,SIZE,3));
+  }
 }

--- a/c/loops/linear_search.c
+++ b/c/loops/linear_search.c
@@ -8,6 +8,7 @@ void __VERIFIER_assert(int cond) {
 }
 unsigned int __VERIFIER_nondet_uint();
 unsigned int  SIZE;
+const unsigned int MAX = 100000;
 int linear_search(int *a, int n, int q) {
   unsigned int j=0;
   while (j<n && a[j]!=q) {
@@ -19,7 +20,10 @@ int linear_search(int *a, int n, int q) {
 }
 int main() { 
   SIZE=(__VERIFIER_nondet_uint()/2)+1;
-  int a[SIZE];
-  a[SIZE/2]=3;
-  __VERIFIER_assert(linear_search(a,SIZE,3));
+
+  if (SIZE > 1 && SIZE < MAX) {
+    int *a = malloc(sizeof(int)*SIZE);
+    a[SIZE/2]=3;
+    __VERIFIER_assert(linear_search(a,SIZE,3));
+  }
 }

--- a/c/loops/linear_search.c
+++ b/c/loops/linear_search.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void *malloc(unsigned long size);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {


### PR DESCRIPTION
There are several benchmarks which use variable-length arrays (VLAs), which look like this:

```
...
SIZE = __VERIFIER_nondet_int();
if (SIZE > 1) {
   int a[SIZE];
...
```
There are several issues with this pattern:
1) VLAs are an optional feature in C11
2) The Test-Comp rules say nothing about VLA allocation (they only talk about malloc and alloca)
3) Huge values of SIZE can lead to unpredictible results.

For instance, consider this program:
```
int main() {
  int a[1073745936], i;

  for (i=0; i < 1000; i++)
    a[i] = 1;

  return 0;
}
```
At least on my machine, if you compile it with gcc and then run the resulting binary with Valgrind, you'll see that Valgrind complains about invalid writes, because the large VLA allocation has failed.

My proposal is to replace all such allocations with `malloc`, and set a bound on the allocation size.  The latter is also needed to make sure that the allocation succeeds during validation in Test-Comp.

I changed two benchmarks as an example of what I mean.  If you are happy with these changes, I can try to update the other benchmarks using this pattern too (although there's quite a large number of them).