### PR TITLE
nested-3: use __VERIFIER_nondet_int for nondet value

### DIFF
--- a/c/loop-industry-pattern/nested-3.c
+++ b/c/loop-industry-pattern/nested-3.c
@@ -13,14 +13,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int nondet()
-{
-	int x = __VERIFIER_nondet_int();
-	return x;
-}
-
 int main() {
-	last = nondet();
+	last = __VERIFIER_nondet_int();
 	int a=0,b=0,c=0,st=0;
 	while(1) {
 		st=1;  


### PR DESCRIPTION
Use __VERIFIER_nondet_int() instead of uninitialized value.