### PR TITLE
 Removed unitialized accesses from several related benchmarks in ssh-simplified

### DIFF
--- a/c/ssh-simplified/s3_clnt_1.cil-1.c
+++ b/c/ssh-simplified/s3_clnt_1.cil-1.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_clnt_1.cil-2.c
+++ b/c/ssh-simplified/s3_clnt_1.cil-2.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_clnt_2.cil-1.c
+++ b/c/ssh-simplified/s3_clnt_2.cil-1.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_clnt_2.cil-2.c
+++ b/c/ssh-simplified/s3_clnt_2.cil-2.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_clnt_3.cil-1.c
+++ b/c/ssh-simplified/s3_clnt_3.cil-1.c
@@ -17,7 +17,7 @@ int ssl3_connect(int initial_state )
   int s__wbio ;
   int s__hit ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug ;
   int s__shutdown ;
   int s__ctx__info_callback ;

--- a/c/ssh-simplified/s3_clnt_3.cil-3.c
+++ b/c/ssh-simplified/s3_clnt_3.cil-3.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_clnt_4.cil-1.c
+++ b/c/ssh-simplified/s3_clnt_4.cil-1.c
@@ -21,7 +21,7 @@ int ssl3_connect(int initial_state )
   int s__wbio = __VERIFIER_nondet_int() ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__ctx__info_callback = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_1.cil-1.c
+++ b/c/ssh-simplified/s3_srvr_1.cil-1.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_1.cil-2.c
+++ b/c/ssh-simplified/s3_srvr_1.cil-2.c
@@ -20,7 +20,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_10.cil.c
+++ b/c/ssh-simplified/s3_srvr_10.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_11.cil.c
+++ b/c/ssh-simplified/s3_srvr_11.cil.c
@@ -20,7 +20,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_12.cil.c
+++ b/c/ssh-simplified/s3_srvr_12.cil.c
@@ -20,7 +20,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_13.cil.c
+++ b/c/ssh-simplified/s3_srvr_13.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_14.cil.c
+++ b/c/ssh-simplified/s3_srvr_14.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_2.cil-1.c
+++ b/c/ssh-simplified/s3_srvr_2.cil-1.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_2.cil-2.c
+++ b/c/ssh-simplified/s3_srvr_2.cil-2.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_3.cil.c
+++ b/c/ssh-simplified/s3_srvr_3.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_4.cil.c
+++ b/c/ssh-simplified/s3_srvr_4.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_6.cil-1.c
+++ b/c/ssh-simplified/s3_srvr_6.cil-1.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_6.cil-2.c
+++ b/c/ssh-simplified/s3_srvr_6.cil-2.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_7.cil.c
+++ b/c/ssh-simplified/s3_srvr_7.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;

--- a/c/ssh-simplified/s3_srvr_8.cil.c
+++ b/c/ssh-simplified/s3_srvr_8.cil.c
@@ -19,7 +19,7 @@ int ssl3_accept(int initial_state )
   int s__init_num ;
   int s__hit = __VERIFIER_nondet_int() ;
   int s__rwstate ;
-  int s__init_buf___0 ;
+  int s__init_buf___0 = 1;
   int s__debug = __VERIFIER_nondet_int() ;
   int s__shutdown ;
   int s__cert = __VERIFIER_nondet_int() ;


### PR DESCRIPTION
It is quite easy to see that the variable `s__init_buf___0` is read without being initialized in this benchmarks, but I confirmed this on a couple of them using MSan.  I discovered this since the Test-Comp validator seemed to incorrectly replay some test cases. 