### PR TITLE
seq-mthreaded: get rid of unknown __VERIFIER_nondet_*

### DIFF
--- a/c/seq-mthreaded/rekcba_aso.1.M1-1.c
+++ b/c/seq-mthreaded/rekcba_aso.1.M1-1.c
@@ -178,8 +178,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -207,7 +207,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -248,7 +248,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.1.M1-2.c
+++ b/c/seq-mthreaded/rekcba_aso.1.M1-2.c
@@ -180,8 +180,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -209,7 +209,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -230,7 +230,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -250,7 +250,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.1.M4-1.c
+++ b/c/seq-mthreaded/rekcba_aso.1.M4-1.c
@@ -184,8 +184,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -213,7 +213,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -234,7 +234,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -254,7 +254,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.1.M4-2.c
+++ b/c/seq-mthreaded/rekcba_aso.1.M4-2.c
@@ -182,8 +182,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -211,7 +211,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -232,7 +232,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -252,7 +252,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.2.M1-1.c
+++ b/c/seq-mthreaded/rekcba_aso.2.M1-1.c
@@ -191,8 +191,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -225,7 +225,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -246,7 +246,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -266,7 +266,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.2.M1-2.c
+++ b/c/seq-mthreaded/rekcba_aso.2.M1-2.c
@@ -185,8 +185,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -214,7 +214,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -235,7 +235,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -255,7 +255,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.2.M4-1.c
+++ b/c/seq-mthreaded/rekcba_aso.2.M4-1.c
@@ -193,8 +193,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -222,7 +222,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -243,7 +243,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -263,7 +263,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.2.M4-2.c
+++ b/c/seq-mthreaded/rekcba_aso.2.M4-2.c
@@ -195,8 +195,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -229,7 +229,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -250,7 +250,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -270,7 +270,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.3.M1.c
+++ b/c/seq-mthreaded/rekcba_aso.3.M1.c
@@ -191,8 +191,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -225,7 +225,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -246,7 +246,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -266,7 +266,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.3.M4.c
+++ b/c/seq-mthreaded/rekcba_aso.3.M4.c
@@ -194,8 +194,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -228,7 +228,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -249,7 +249,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -269,7 +269,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.4.M1.c
+++ b/c/seq-mthreaded/rekcba_aso.4.M1.c
@@ -191,8 +191,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -225,7 +225,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -246,7 +246,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -266,7 +266,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso.4.M4.c
+++ b/c/seq-mthreaded/rekcba_aso.4.M4.c
@@ -194,8 +194,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -228,7 +228,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -249,7 +249,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -269,7 +269,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.1.M1-1.c
+++ b/c/seq-mthreaded/rekcba_nxt.1.M1-1.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -191,7 +191,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -212,7 +212,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -233,7 +233,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.1.M1-2.c
+++ b/c/seq-mthreaded/rekcba_nxt.1.M1-2.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -191,7 +191,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -212,7 +212,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -233,7 +233,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.1.M4-1.c
+++ b/c/seq-mthreaded/rekcba_nxt.1.M4-1.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -191,7 +191,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -212,7 +212,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -233,7 +233,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.1.M4-2.c
+++ b/c/seq-mthreaded/rekcba_nxt.1.M4-2.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -191,7 +191,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -212,7 +212,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -233,7 +233,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.2.M1-1.c
+++ b/c/seq-mthreaded/rekcba_nxt.2.M1-1.c
@@ -179,8 +179,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -203,7 +203,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -224,7 +224,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -245,7 +245,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.2.M1-2.c
+++ b/c/seq-mthreaded/rekcba_nxt.2.M1-2.c
@@ -177,8 +177,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -196,7 +196,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -217,7 +217,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -238,7 +238,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.2.M4-1.c
+++ b/c/seq-mthreaded/rekcba_nxt.2.M4-1.c
@@ -181,8 +181,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -200,7 +200,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -221,7 +221,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -242,7 +242,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.2.M4-2.c
+++ b/c/seq-mthreaded/rekcba_nxt.2.M4-2.c
@@ -183,8 +183,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -207,7 +207,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -249,7 +249,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.3.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt.3.M1.c
@@ -179,8 +179,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -203,7 +203,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -224,7 +224,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -245,7 +245,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt.3.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt.3.M4.c
@@ -183,8 +183,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -207,7 +207,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -249,7 +249,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.1.M1-1.c
+++ b/c/seq-mthreaded/rekh_aso.1.M1-1.c
@@ -175,8 +175,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -204,7 +204,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -225,7 +225,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -245,7 +245,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.1.M1-2.c
+++ b/c/seq-mthreaded/rekh_aso.1.M1-2.c
@@ -173,8 +173,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -202,7 +202,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -223,7 +223,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -243,7 +243,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.1.M4-1.c
+++ b/c/seq-mthreaded/rekh_aso.1.M4-1.c
@@ -174,8 +174,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -203,7 +203,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -224,7 +224,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -244,7 +244,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.1.M4-2.c
+++ b/c/seq-mthreaded/rekh_aso.1.M4-2.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -201,7 +201,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -222,7 +222,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -242,7 +242,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.2.M1-1.c
+++ b/c/seq-mthreaded/rekh_aso.2.M1-1.c
@@ -186,8 +186,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -220,7 +220,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -241,7 +241,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -261,7 +261,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.2.M1-2.c
+++ b/c/seq-mthreaded/rekh_aso.2.M1-2.c
@@ -179,8 +179,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -208,7 +208,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -229,7 +229,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -249,7 +249,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.2.M4-1.c
+++ b/c/seq-mthreaded/rekh_aso.2.M4-1.c
@@ -178,8 +178,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -207,7 +207,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -248,7 +248,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.2.M4-2.c
+++ b/c/seq-mthreaded/rekh_aso.2.M4-2.c
@@ -185,8 +185,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -219,7 +219,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -240,7 +240,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -260,7 +260,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.3.M1.c
+++ b/c/seq-mthreaded/rekh_aso.3.M1.c
@@ -186,8 +186,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -220,7 +220,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -241,7 +241,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -261,7 +261,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.3.M4.c
+++ b/c/seq-mthreaded/rekh_aso.3.M4.c
@@ -185,8 +185,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -219,7 +219,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -240,7 +240,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -260,7 +260,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.4.M1.c
+++ b/c/seq-mthreaded/rekh_aso.4.M1.c
@@ -186,8 +186,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -220,7 +220,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -241,7 +241,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -261,7 +261,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso.4.M4.c
+++ b/c/seq-mthreaded/rekh_aso.4.M4.c
@@ -185,8 +185,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -219,7 +219,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -240,7 +240,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -260,7 +260,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.1.M1-1.c
+++ b/c/seq-mthreaded/rekh_nxt.1.M1-1.c
@@ -168,8 +168,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -187,7 +187,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -208,7 +208,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -229,7 +229,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.1.M1-2.c
+++ b/c/seq-mthreaded/rekh_nxt.1.M1-2.c
@@ -168,8 +168,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -187,7 +187,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -208,7 +208,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -229,7 +229,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.1.M4-1.c
+++ b/c/seq-mthreaded/rekh_nxt.1.M4-1.c
@@ -167,8 +167,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -186,7 +186,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -207,7 +207,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.1.M4-2.c
+++ b/c/seq-mthreaded/rekh_nxt.1.M4-2.c
@@ -167,8 +167,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -186,7 +186,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -207,7 +207,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -228,7 +228,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.2.M1-1.c
+++ b/c/seq-mthreaded/rekh_nxt.2.M1-1.c
@@ -174,8 +174,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -198,7 +198,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -219,7 +219,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -240,7 +240,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.2.M1-2.c
+++ b/c/seq-mthreaded/rekh_nxt.2.M1-2.c
@@ -172,8 +172,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -191,7 +191,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -212,7 +212,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -233,7 +233,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.2.M4-1.c
+++ b/c/seq-mthreaded/rekh_nxt.2.M4-1.c
@@ -171,8 +171,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -190,7 +190,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -211,7 +211,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -232,7 +232,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.2.M4-2.c
+++ b/c/seq-mthreaded/rekh_nxt.2.M4-2.c
@@ -173,8 +173,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -197,7 +197,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -218,7 +218,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -239,7 +239,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.3.M1.c
+++ b/c/seq-mthreaded/rekh_nxt.3.M1.c
@@ -174,8 +174,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -198,7 +198,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -219,7 +219,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -240,7 +240,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt.3.M4.c
+++ b/c/seq-mthreaded/rekh_nxt.3.M4.c
@@ -173,8 +173,8 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   return;
 }
 }
-extern unsigned int __VERIFIER_nondet_U32() ;
-extern char __VERIFIER_nondet_S8() ;
+extern unsigned int __VERIFIER_nondet_uint() ;
+extern char __VERIFIER_nondet_char() ;
 extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
@@ -197,7 +197,7 @@ char nxt_motor_get_count(unsigned char port )
   char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_S8();
+  tmp = __VERIFIER_nondet_char();
   return (tmp);
 }
 }
@@ -218,7 +218,7 @@ unsigned int ecrobot_get_gyro_sensor(unsigned char port )
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }
@@ -239,7 +239,7 @@ unsigned int ecrobot_get_battery_voltage(void)
   unsigned int tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U32();
+  tmp = __VERIFIER_nondet_uint();
   return (tmp);
 }
 }


### PR DESCRIPTION
__VERIFIER_nondet_S8 and __VERIFIER_nondet_U32 are not listed
in the SV-COMP rules. Use the proper SV-COMP functions instead.
