### PR TITLE
Rename error function in ECA/RERS tasks

### DIFF
--- a/c/eca-rers2018/Problem10.c
+++ b/c/eca-rers2018/Problem10.c
@@ -1,5 +1,105 @@
 extern int __VERIFIER_nondet_int();
-    extern void __VERIFIER_error(int);
+extern void __VERIFIER_error_0();
+extern void __VERIFIER_error_1();
+extern void __VERIFIER_error_2();
+extern void __VERIFIER_error_3();
+extern void __VERIFIER_error_4();
+extern void __VERIFIER_error_5();
+extern void __VERIFIER_error_6();
+extern void __VERIFIER_error_7();
+extern void __VERIFIER_error_8();
+extern void __VERIFIER_error_9();
+extern void __VERIFIER_error_10();
+extern void __VERIFIER_error_11();
+extern void __VERIFIER_error_12();
+extern void __VERIFIER_error_13();
+extern void __VERIFIER_error_14();
+extern void __VERIFIER_error_15();
+extern void __VERIFIER_error_16();
+extern void __VERIFIER_error_17();
+extern void __VERIFIER_error_18();
+extern void __VERIFIER_error_19();
+extern void __VERIFIER_error_20();
+extern void __VERIFIER_error_21();
+extern void __VERIFIER_error_22();
+extern void __VERIFIER_error_23();
+extern void __VERIFIER_error_24();
+extern void __VERIFIER_error_25();
+extern void __VERIFIER_error_26();
+extern void __VERIFIER_error_27();
+extern void __VERIFIER_error_28();
+extern void __VERIFIER_error_29();
+extern void __VERIFIER_error_30();
+extern void __VERIFIER_error_31();
+extern void __VERIFIER_error_32();
+extern void __VERIFIER_error_33();
+extern void __VERIFIER_error_34();
+extern void __VERIFIER_error_35();
+extern void __VERIFIER_error_36();
+extern void __VERIFIER_error_37();
+extern void __VERIFIER_error_38();
+extern void __VERIFIER_error_39();
+extern void __VERIFIER_error_40();
+extern void __VERIFIER_error_41();
+extern void __VERIFIER_error_42();
+extern void __VERIFIER_error_43();
+extern void __VERIFIER_error_44();
+extern void __VERIFIER_error_45();
+extern void __VERIFIER_error_46();
+extern void __VERIFIER_error_47();
+extern void __VERIFIER_error_48();
+extern void __VERIFIER_error_49();
+extern void __VERIFIER_error_50();
+extern void __VERIFIER_error_51();
+extern void __VERIFIER_error_52();
+extern void __VERIFIER_error_53();
+extern void __VERIFIER_error_54();
+extern void __VERIFIER_error_55();
+extern void __VERIFIER_error_56();
+extern void __VERIFIER_error_57();
+extern void __VERIFIER_error_58();
+extern void __VERIFIER_error_59();
+extern void __VERIFIER_error_60();
+extern void __VERIFIER_error_61();
+extern void __VERIFIER_error_62();
+extern void __VERIFIER_error_63();
+extern void __VERIFIER_error_64();
+extern void __VERIFIER_error_65();
+extern void __VERIFIER_error_66();
+extern void __VERIFIER_error_67();
+extern void __VERIFIER_error_68();
+extern void __VERIFIER_error_69();
+extern void __VERIFIER_error_70();
+extern void __VERIFIER_error_71();
+extern void __VERIFIER_error_72();
+extern void __VERIFIER_error_73();
+extern void __VERIFIER_error_74();
+extern void __VERIFIER_error_75();
+extern void __VERIFIER_error_76();
+extern void __VERIFIER_error_77();
+extern void __VERIFIER_error_78();
+extern void __VERIFIER_error_79();
+extern void __VERIFIER_error_80();
+extern void __VERIFIER_error_81();
+extern void __VERIFIER_error_82();
+extern void __VERIFIER_error_83();
+extern void __VERIFIER_error_84();
+extern void __VERIFIER_error_85();
+extern void __VERIFIER_error_86();
+extern void __VERIFIER_error_87();
+extern void __VERIFIER_error_88();
+extern void __VERIFIER_error_89();
+extern void __VERIFIER_error_90();
+extern void __VERIFIER_error_91();
+extern void __VERIFIER_error_92();
+extern void __VERIFIER_error_93();
+extern void __VERIFIER_error_94();
+extern void __VERIFIER_error_95();
+extern void __VERIFIER_error_96();
+extern void __VERIFIER_error_97();
+extern void __VERIFIER_error_98();
+extern void __VERIFIER_error_99();
+
 
 	// inputs
 	int inputs[] = {5,1,3,2,4};
@@ -199,403 +299,403 @@ extern int __VERIFIER_nondet_int();
 	void errorCheck() {
 	    if(((a1554992028 == 9 && a1933271548 == 3) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(0);
+	    __VERIFIER_error_0();
 	    }
 	    if(((a1649592707 == 35 && a1933271548 == 5) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(1);
+	    __VERIFIER_error_1();
 	    }
 	    if(((a469914660 == 8 && a1868984816 == 8) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(2);
+	    __VERIFIER_error_2();
 	    }
 	    if(((a1554992028 == 12 && a1041640432 == 4) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(3);
+	    __VERIFIER_error_3();
 	    }
 	    if(((a2077863541 == 11 && a1868984816 == 10) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(4);
+	    __VERIFIER_error_4();
 	    }
 	    if(((a1591641889 == 9 && a1933271548 == 8) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(5);
+	    __VERIFIER_error_5();
 	    }
 	    if(((a1384943560 == 33 && a1669722568 == 35) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(6);
+	    __VERIFIER_error_6();
 	    }
 	    if(((a1554992028 == 15 && a1933271548 == 3) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(7);
+	    __VERIFIER_error_7();
 	    }
 	    if(((a1554992028 == 11 && a1669722568 == 33) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(8);
+	    __VERIFIER_error_8();
 	    }
 	    if(((a1944816302 == 35 && a43901077 == 33) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(9);
+	    __VERIFIER_error_9();
 	    }
 	    if(((a1136264456 == 36 && a1041640432 == 5) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(10);
+	    __VERIFIER_error_10();
 	    }
 	    if(((a1384943560 == 35 && a1669722568 == 35) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(11);
+	    __VERIFIER_error_11();
 	    }
 	    if(((a1583922005 == 7 && a1669722568 == 32) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(12);
+	    __VERIFIER_error_12();
 	    }
 	    if(((a1583922005 == 9 && a1669722568 == 32) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(13);
+	    __VERIFIER_error_13();
 	    }
 	    if(((a469914660 == 7 && a1868984816 == 8) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(14);
+	    __VERIFIER_error_14();
 	    }
 	    if(((a1136264456 == 35 && a1041640432 == 8) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(15);
+	    __VERIFIER_error_15();
 	    }
 	    if(((a2077863541 == 14 && a1868984816 == 10) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(16);
+	    __VERIFIER_error_16();
 	    }
 	    if(((a1583922005 == 12 && a1669722568 == 32) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(17);
+	    __VERIFIER_error_17();
 	    }
 	    if(((a1591641889 == 5 && a1868984816 == 9) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(18);
+	    __VERIFIER_error_18();
 	    }
 	    if(((a1583922005 == 11 && a1669722568 == 32) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(19);
+	    __VERIFIER_error_19();
 	    }
 	    if(((a1591641889 == 6 && a1933271548 == 8) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(20);
+	    __VERIFIER_error_20();
 	    }
 	    if(((a1431178715 == 32 && a1041640432 == 9) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(21);
+	    __VERIFIER_error_21();
 	    }
 	    if(((a1933271548 == 3 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(22);
+	    __VERIFIER_error_22();
 	    }
 	    if(((a927814483 == 9 && a43901077 == 35) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(23);
+	    __VERIFIER_error_23();
 	    }
 	    if(((a1384943560 == 34 && a1669722568 == 35) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(24);
+	    __VERIFIER_error_24();
 	    }
 	    if(((a1583922005 == 5 && a1669722568 == 32) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(25);
+	    __VERIFIER_error_25();
 	    }
 	    if(((a1554992028 == 13 && a1669722568 == 33) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(26);
+	    __VERIFIER_error_26();
 	    }
 	    if(((a1136264456 == 32 && a1041640432 == 8) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(27);
+	    __VERIFIER_error_27();
 	    }
 	    if(((a1944816302 == 35 && a1041640432 == 10) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(28);
+	    __VERIFIER_error_28();
 	    }
 	    if(((a1591641889 == 8 && a1868984816 == 9) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(29);
+	    __VERIFIER_error_29();
 	    }
 	    if(((a1554992028 == 10 && a1933271548 == 3) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(30);
+	    __VERIFIER_error_30();
 	    }
 	    if(((a1450658394 == 9 && a1669722568 == 36) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(31);
+	    __VERIFIER_error_31();
 	    }
 	    if(((a1933271548 == 4 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(32);
+	    __VERIFIER_error_32();
 	    }
 	    if(((a1933271548 == 8 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(33);
+	    __VERIFIER_error_33();
 	    }
 	    if(((a231305105 == 12 && a1868984816 == 15) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(34);
+	    __VERIFIER_error_34();
 	    }
 	    if(((a1491567675 == 16 && a43901077 == 34) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(35);
+	    __VERIFIER_error_35();
 	    }
 	    if(((a2077863541 == 13 && a1868984816 == 10) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(36);
+	    __VERIFIER_error_36();
 	    }
 	    if(((a43901077 == 34 && a1041640432 == 7) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(37);
+	    __VERIFIER_error_37();
 	    }
 	    if(((a1649592707 == 32 && a1041640432 == 11) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(38);
+	    __VERIFIER_error_38();
 	    }
 	    if(((a1491567675 == 11 && a43901077 == 34) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(39);
+	    __VERIFIER_error_39();
 	    }
 	    if(((a927814483 == 8 && a1933271548 == 9) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(40);
+	    __VERIFIER_error_40();
 	    }
 	    if(((a1554992028 == 10 && a1041640432 == 4) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(41);
+	    __VERIFIER_error_41();
 	    }
 	    if(((a927814483 == 13 && a1868984816 == 11) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(42);
+	    __VERIFIER_error_42();
 	    }
 	    if(((a1554992028 == 12 && a1933271548 == 10) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(43);
+	    __VERIFIER_error_43();
 	    }
 	    if(((a927814483 == 13 && a43901077 == 35) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(44);
+	    __VERIFIER_error_44();
 	    }
 	    if(((a1944816302 == 33 && a1041640432 == 10) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(45);
+	    __VERIFIER_error_45();
 	    }
 	    if(((a938827910 == 35 && a1868984816 == 12) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(46);
+	    __VERIFIER_error_46();
 	    }
 	    if(((a1649592707 == 32 && a1933271548 == 5) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(47);
+	    __VERIFIER_error_47();
 	    }
 	    if(((a1591641889 == 9 && a1868984816 == 9) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(48);
+	    __VERIFIER_error_48();
 	    }
 	    if(((a1796618233 == 33 && a1868984816 == 13) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(49);
+	    __VERIFIER_error_49();
 	    }
 	    if(((a1554992028 == 11 && a1041640432 == 4) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(50);
+	    __VERIFIER_error_50();
 	    }
 	    if(((a1136264456 == 36 && a1041640432 == 8) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(51);
+	    __VERIFIER_error_51();
 	    }
 	    if(((a1554992028 == 13 && a1933271548 == 10) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(52);
+	    __VERIFIER_error_52();
 	    }
 	    if(((a43901077 == 35 && a1041640432 == 7) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(53);
+	    __VERIFIER_error_53();
 	    }
 	    if(((a1649592707 == 35 && a1041640432 == 11) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(54);
+	    __VERIFIER_error_54();
 	    }
 	    if(((a1491567675 == 12 && a43901077 == 34) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(55);
+	    __VERIFIER_error_55();
 	    }
 	    if(((a1591641889 == 10 && a1933271548 == 8) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(56);
+	    __VERIFIER_error_56();
 	    }
 	    if(((a927814483 == 11 && a1933271548 == 9) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(57);
+	    __VERIFIER_error_57();
 	    }
 	    if(((a1933271548 == 9 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(58);
+	    __VERIFIER_error_58();
 	    }
 	    if(((a927814483 == 10 && a1933271548 == 9) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(59);
+	    __VERIFIER_error_59();
 	    }
 	    if(((a1944816302 == 34 && a1041640432 == 10) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(60);
+	    __VERIFIER_error_60();
 	    }
 	    if(((a1379546326 == 11 && a1041640432 == 6) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(61);
+	    __VERIFIER_error_61();
 	    }
 	    if(((a2077863541 == 8 && a1868984816 == 10) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(62);
+	    __VERIFIER_error_62();
 	    }
 	    if(((a938827910 == 34 && a1868984816 == 12) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(63);
+	    __VERIFIER_error_63();
 	    }
 	    if(((a469914660 == 14 && a1868984816 == 8) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(64);
+	    __VERIFIER_error_64();
 	    }
 	    if(((a2108703896 == 33 && a1933271548 == 4) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(65);
+	    __VERIFIER_error_65();
 	    }
 	    if(((a843079661 == 33 && a43901077 == 36) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(66);
+	    __VERIFIER_error_66();
 	    }
 	    if(((a1379546326 == 9 && a1041640432 == 6) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(67);
+	    __VERIFIER_error_67();
 	    }
 	    if(((a927814483 == 12 && a1868984816 == 11) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(68);
+	    __VERIFIER_error_68();
 	    }
 	    if(((a927814483 == 9 && a1933271548 == 9) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(69);
+	    __VERIFIER_error_69();
 	    }
 	    if(((a1796618233 == 36 && a1868984816 == 13) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(70);
+	    __VERIFIER_error_70();
 	    }
 	    if(((a1384943560 == 36 && a1669722568 == 35) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(71);
+	    __VERIFIER_error_71();
 	    }
 	    if(((a1554992028 == 15 && a1041640432 == 4) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(72);
+	    __VERIFIER_error_72();
 	    }
 	    if(((a1379546326 == 8 && a1041640432 == 6) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(73);
+	    __VERIFIER_error_73();
 	    }
 	    if(((a1933271548 == 7 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(74);
+	    __VERIFIER_error_74();
 	    }
 	    if(((a231305105 == 13 && a1868984816 == 15) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(75);
+	    __VERIFIER_error_75();
 	    }
 	    if(((a1591641889 == 11 && a1933271548 == 8) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(76);
+	    __VERIFIER_error_76();
 	    }
 	    if(((a1384943560 == 32 && a1669722568 == 35) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(77);
+	    __VERIFIER_error_77();
 	    }
 	    if(((a1554992028 == 8 && a1933271548 == 3) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(78);
+	    __VERIFIER_error_78();
 	    }
 	    if(((a1554992028 == 9 && a1041640432 == 4) && a1551570219 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(79);
+	    __VERIFIER_error_79();
 	    }
 	    if(((a1591641889 == 7 && a1868984816 == 9) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(80);
+	    __VERIFIER_error_80();
 	    }
 	    if(((a1554992028 == 11 && a1933271548 == 10) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(81);
+	    __VERIFIER_error_81();
 	    }
 	    if(((a1591641889 == 6 && a1868984816 == 9) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(82);
+	    __VERIFIER_error_82();
 	    }
 	    if(((a938827910 == 36 && a1868984816 == 12) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(83);
+	    __VERIFIER_error_83();
 	    }
 	    if(((a1580663338 == 32 && a1868984816 == 14) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(84);
+	    __VERIFIER_error_84();
 	    }
 	    if(((a1450658394 == 10 && a1669722568 == 36) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(85);
+	    __VERIFIER_error_85();
 	    }
 	    if(((a938827910 == 33 && a1868984816 == 12) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(86);
+	    __VERIFIER_error_86();
 	    }
 	    if(((a1554992028 == 10 && a1933271548 == 10) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(87);
+	    __VERIFIER_error_87();
 	    }
 	    if(((a1933271548 == 5 && a1669722568 == 34) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(88);
+	    __VERIFIER_error_88();
 	    }
 	    if(((a1294378386 == 8 && a43901077 == 32) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(89);
+	    __VERIFIER_error_89();
 	    }
 	    if(((a1450658394 == 8 && a1669722568 == 36) && a1551570219 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(90);
+	    __VERIFIER_error_90();
 	    }
 	    if(((a231305105 == 9 && a1868984816 == 15) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(91);
+	    __VERIFIER_error_91();
 	    }
 	    if(((a1554992028 == 8 && a1933271548 == 10) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(92);
+	    __VERIFIER_error_92();
 	    }
 	    if(((a1944816302 == 34 && a43901077 == 33) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(93);
+	    __VERIFIER_error_93();
 	    }
 	    if(((a1294378386 == 4 && a43901077 == 32) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(94);
+	    __VERIFIER_error_94();
 	    }
 	    if(((a2108703896 == 34 && a1933271548 == 4) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(95);
+	    __VERIFIER_error_95();
 	    }
 	    if(((a1796618233 == 32 && a1868984816 == 13) && a1551570219 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(96);
+	    __VERIFIER_error_96();
 	    }
 	    if(((a927814483 == 13 && a1933271548 == 9) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(97);
+	    __VERIFIER_error_97();
 	    }
 	    if(((a1294378386 == 9 && a43901077 == 32) && a1551570219 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(98);
+	    __VERIFIER_error_98();
 	    }
 	    if(((a181636438 == 35 && a1933271548 == 7) && a1551570219 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(99);
+	    __VERIFIER_error_99();
 	    }
 	}
  void calculate_outputm37(int input) {

--- a/c/eca-rers2018/Problem11.c
+++ b/c/eca-rers2018/Problem11.c
@@ -1,5 +1,105 @@
 extern int __VERIFIER_nondet_int();
-    extern void __VERIFIER_error(int);
+extern void __VERIFIER_error_0();
+extern void __VERIFIER_error_1();
+extern void __VERIFIER_error_2();
+extern void __VERIFIER_error_3();
+extern void __VERIFIER_error_4();
+extern void __VERIFIER_error_5();
+extern void __VERIFIER_error_6();
+extern void __VERIFIER_error_7();
+extern void __VERIFIER_error_8();
+extern void __VERIFIER_error_9();
+extern void __VERIFIER_error_10();
+extern void __VERIFIER_error_11();
+extern void __VERIFIER_error_12();
+extern void __VERIFIER_error_13();
+extern void __VERIFIER_error_14();
+extern void __VERIFIER_error_15();
+extern void __VERIFIER_error_16();
+extern void __VERIFIER_error_17();
+extern void __VERIFIER_error_18();
+extern void __VERIFIER_error_19();
+extern void __VERIFIER_error_20();
+extern void __VERIFIER_error_21();
+extern void __VERIFIER_error_22();
+extern void __VERIFIER_error_23();
+extern void __VERIFIER_error_24();
+extern void __VERIFIER_error_25();
+extern void __VERIFIER_error_26();
+extern void __VERIFIER_error_27();
+extern void __VERIFIER_error_28();
+extern void __VERIFIER_error_29();
+extern void __VERIFIER_error_30();
+extern void __VERIFIER_error_31();
+extern void __VERIFIER_error_32();
+extern void __VERIFIER_error_33();
+extern void __VERIFIER_error_34();
+extern void __VERIFIER_error_35();
+extern void __VERIFIER_error_36();
+extern void __VERIFIER_error_37();
+extern void __VERIFIER_error_38();
+extern void __VERIFIER_error_39();
+extern void __VERIFIER_error_40();
+extern void __VERIFIER_error_41();
+extern void __VERIFIER_error_42();
+extern void __VERIFIER_error_43();
+extern void __VERIFIER_error_44();
+extern void __VERIFIER_error_45();
+extern void __VERIFIER_error_46();
+extern void __VERIFIER_error_47();
+extern void __VERIFIER_error_48();
+extern void __VERIFIER_error_49();
+extern void __VERIFIER_error_50();
+extern void __VERIFIER_error_51();
+extern void __VERIFIER_error_52();
+extern void __VERIFIER_error_53();
+extern void __VERIFIER_error_54();
+extern void __VERIFIER_error_55();
+extern void __VERIFIER_error_56();
+extern void __VERIFIER_error_57();
+extern void __VERIFIER_error_58();
+extern void __VERIFIER_error_59();
+extern void __VERIFIER_error_60();
+extern void __VERIFIER_error_61();
+extern void __VERIFIER_error_62();
+extern void __VERIFIER_error_63();
+extern void __VERIFIER_error_64();
+extern void __VERIFIER_error_65();
+extern void __VERIFIER_error_66();
+extern void __VERIFIER_error_67();
+extern void __VERIFIER_error_68();
+extern void __VERIFIER_error_69();
+extern void __VERIFIER_error_70();
+extern void __VERIFIER_error_71();
+extern void __VERIFIER_error_72();
+extern void __VERIFIER_error_73();
+extern void __VERIFIER_error_74();
+extern void __VERIFIER_error_75();
+extern void __VERIFIER_error_76();
+extern void __VERIFIER_error_77();
+extern void __VERIFIER_error_78();
+extern void __VERIFIER_error_79();
+extern void __VERIFIER_error_80();
+extern void __VERIFIER_error_81();
+extern void __VERIFIER_error_82();
+extern void __VERIFIER_error_83();
+extern void __VERIFIER_error_84();
+extern void __VERIFIER_error_85();
+extern void __VERIFIER_error_86();
+extern void __VERIFIER_error_87();
+extern void __VERIFIER_error_88();
+extern void __VERIFIER_error_89();
+extern void __VERIFIER_error_90();
+extern void __VERIFIER_error_91();
+extern void __VERIFIER_error_92();
+extern void __VERIFIER_error_93();
+extern void __VERIFIER_error_94();
+extern void __VERIFIER_error_95();
+extern void __VERIFIER_error_96();
+extern void __VERIFIER_error_97();
+extern void __VERIFIER_error_98();
+extern void __VERIFIER_error_99();
+
 
 	// inputs
 	int inputs[] = {7,10,6,2,5,3,9,4,8,1};
@@ -273,403 +373,403 @@ extern int __VERIFIER_nondet_int();
 	void errorCheck() {
 	    if(((a824024208 == 33 && ((330 < a621522874) && (523 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(0);
+	    __VERIFIER_error_0();
 	    }
 	    if(((a1944090451 == 34 && a44138666 == 32) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(1);
+	    __VERIFIER_error_1();
 	    }
 	    if(((a910748832 == 32 && a236788248 == 17) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(2);
+	    __VERIFIER_error_2();
 	    }
 	    if(((a812175843 == 33 && a2122722213 == 7) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(3);
+	    __VERIFIER_error_3();
 	    }
 	    if(((a1944090451 == 36 && a44138666 == 32) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(4);
+	    __VERIFIER_error_4();
 	    }
 	    if(((a166920931 == 11 && a2122722213 == 8) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(5);
+	    __VERIFIER_error_5();
 	    }
 	    if(((a1422023390 <=  -145 && a236788248 == 10) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(6);
+	    __VERIFIER_error_6();
 	    }
 	    if(((a236788248 == 10 && a44138666 == 35) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(7);
+	    __VERIFIER_error_7();
 	    }
 	    if(((a808219163 == 32 && a418218587 == 33) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(8);
+	    __VERIFIER_error_8();
 	    }
 	    if(((a824024208 == 35 && ((330 < a621522874) && (523 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(9);
+	    __VERIFIER_error_9();
 	    }
 	    if(((((22 < a1422023390) && (156 >= a1422023390)) && a236788248 == 10) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(10);
+	    __VERIFIER_error_10();
 	    }
 	    if(((a236788248 == 10 && a44138666 == 36) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(11);
+	    __VERIFIER_error_11();
 	    }
 	    if(((a1864015649 == 33 && a236788248 == 13) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(12);
+	    __VERIFIER_error_12();
 	    }
 	    if(((a824024208 == 34 && a2122722213 == 4) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(13);
+	    __VERIFIER_error_13();
 	    }
 	    if(((a2083223046 == 33 && a418218587 == 34) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(14);
+	    __VERIFIER_error_14();
 	    }
 	    if(((a236788248 == 12 && a44138666 == 35) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(15);
+	    __VERIFIER_error_15();
 	    }
 	    if(((a1821141922 == 35 && a2122722213 == 2) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(16);
+	    __VERIFIER_error_16();
 	    }
 	    if(((((-101 < a1889803145) && (114 >= a1889803145)) && a45685611 == 12) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(17);
+	    __VERIFIER_error_17();
 	    }
 	    if(((a946891643 == 5 && a45685611 == 7) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(18);
+	    __VERIFIER_error_18();
 	    }
 	    if(((a1944090451 == 33 && a44138666 == 32) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(19);
+	    __VERIFIER_error_19();
 	    }
 	    if(((((383 < a552913881) && (501 >= a552913881)) && a44138666 == 34) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(20);
+	    __VERIFIER_error_20();
 	    }
 	    if(((a946891643 == 9 && a45685611 == 7) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(21);
+	    __VERIFIER_error_21();
 	    }
 	    if(((a2139179119 == 15 && a45685611 == 13) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(22);
+	    __VERIFIER_error_22();
 	    }
 	    if(((a1218264876 == 33 && a236788248 == 14) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(23);
+	    __VERIFIER_error_23();
 	    }
 	    if(((a236788248 == 12 && a44138666 == 36) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(24);
+	    __VERIFIER_error_24();
 	    }
 	    if(((((114 < a1889803145) && (196 >= a1889803145)) && a45685611 == 12) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(25);
+	    __VERIFIER_error_25();
 	    }
 	    if(((a910748832 == 34 && a236788248 == 17) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(26);
+	    __VERIFIER_error_26();
 	    }
 	    if(((a482477713 == 8 && a236788248 == 16) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(27);
+	    __VERIFIER_error_27();
 	    }
 	    if(((a808219163 == 34 && a418218587 == 33) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(28);
+	    __VERIFIER_error_28();
 	    }
 	    if(((((330 < a621522874) && (523 >= a621522874)) && a418218587 == 32) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(29);
+	    __VERIFIER_error_29();
 	    }
 	    if(((((75 < a589117628) && (276 >= a589117628)) && a236788248 == 12) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(30);
+	    __VERIFIER_error_30();
 	    }
 	    if(((a1071924404 == 35 && a1179664392 == 32) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(31);
+	    __VERIFIER_error_31();
 	    }
 	    if(((a1684594625 <=  -160 && a44138666 == 33) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(32);
+	    __VERIFIER_error_32();
 	    }
 	    if(((a1218264876 == 36 && a236788248 == 14) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(33);
+	    __VERIFIER_error_33();
 	    }
 	    if(((105 < a1684594625 && ((116 < a621522874) && (330 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(34);
+	    __VERIFIER_error_34();
 	    }
 	    if(((a166920931 == 13 && a2122722213 == 8) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(35);
+	    __VERIFIER_error_35();
 	    }
 	    if(((a430318312 == 9 && a1179664392 == 36) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(36);
+	    __VERIFIER_error_36();
 	    }
 	    if(((((-160 < a1684594625) && (-26 >= a1684594625)) && ((116 < a621522874) && (330 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(37);
+	    __VERIFIER_error_37();
 	    }
 	    if(((a648283191 <=  -91 && ((168 < a552913881) && (383 >= a552913881))) && a471011792 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(38);
+	    __VERIFIER_error_38();
 	    }
 	    if(((a2139179119 == 13 && a236788248 == 11) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(39);
+	    __VERIFIER_error_39();
 	    }
 	    if(((a1218264876 == 32 && a45685611 == 9) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(40);
+	    __VERIFIER_error_40();
 	    }
 	    if(((a1218264876 == 34 && a236788248 == 14) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(41);
+	    __VERIFIER_error_41();
 	    }
 	    if(((((-69 < a648283191) && (120 >= a648283191)) && a621522874 <=  116) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(42);
+	    __VERIFIER_error_42();
 	    }
 	    if(((156 < a1422023390 && a236788248 == 10) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(43);
+	    __VERIFIER_error_43();
 	    }
 	    if(((a1218264876 == 36 && a45685611 == 14) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(44);
+	    __VERIFIER_error_44();
 	    }
 	    if(((a824024208 == 34 && ((330 < a621522874) && (523 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(45);
+	    __VERIFIER_error_45();
 	    }
 	    if(((a2139179119 == 11 && a236788248 == 11) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(46);
+	    __VERIFIER_error_46();
 	    }
 	    if(((a482477713 == 7 && a236788248 == 16) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(47);
+	    __VERIFIER_error_47();
 	    }
 	    if(((a1071924404 == 36 && a1179664392 == 32) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(48);
+	    __VERIFIER_error_48();
 	    }
 	    if(((a499699109 == 3 && 523 < a621522874) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(49);
+	    __VERIFIER_error_49();
 	    }
 	    if(((a418218587 == 32 && a2122722213 == 3) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(50);
+	    __VERIFIER_error_50();
 	    }
 	    if(((a482477713 == 9 && a236788248 == 16) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(51);
+	    __VERIFIER_error_51();
 	    }
 	    if(((a2079503415 == 13 && a236788248 == 15) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(52);
+	    __VERIFIER_error_52();
 	    }
 	    if(((a482477713 == 6 && a236788248 == 16) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(53);
+	    __VERIFIER_error_53();
 	    }
 	    if(((276 < a589117628 && a236788248 == 12) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(54);
+	    __VERIFIER_error_54();
 	    }
 	    if(((((160 < a173429297) && (321 >= a173429297)) && a418218587 == 35) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(55);
+	    __VERIFIER_error_55();
 	    }
 	    if(((((-59 < a173429297) && (160 >= a173429297)) && a45685611 == 10) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(56);
+	    __VERIFIER_error_56();
 	    }
 	    if(((a71064409 <=  -150 && a1179664392 == 34) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(57);
+	    __VERIFIER_error_57();
 	    }
 	    if(((a2139179119 == 10 && a45685611 == 13) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(58);
+	    __VERIFIER_error_58();
 	    }
 	    if(((a1605463015 == 8 && a1179664392 == 33) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(59);
+	    __VERIFIER_error_59();
 	    }
 	    if(((a236788248 == 16 && a44138666 == 35) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(60);
+	    __VERIFIER_error_60();
 	    }
 	    if(((a1864015649 == 36 && a236788248 == 13) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(61);
+	    __VERIFIER_error_61();
 	    }
 	    if(((a1859402009 == 11 && a45685611 == 11) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(62);
+	    __VERIFIER_error_62();
 	    }
 	    if(((a808219163 == 36 && a418218587 == 33) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(63);
+	    __VERIFIER_error_63();
 	    }
 	    if(((a430318312 == 8 && a1179664392 == 36) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(64);
+	    __VERIFIER_error_64();
 	    }
 	    if(((a173429297 <=  -59 && a45685611 == 10) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(65);
+	    __VERIFIER_error_65();
 	    }
 	    if(((((-91 < a648283191) && (-69 >= a648283191)) && a418218587 == 36) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(66);
+	    __VERIFIER_error_66();
 	    }
 	    if(((a430318312 == 10 && a1179664392 == 36) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(67);
+	    __VERIFIER_error_67();
 	    }
 	    if(((a1864015649 == 34 && a236788248 == 13) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(68);
+	    __VERIFIER_error_68();
 	    }
 	    if(((a589117628 <=  50 && a236788248 == 12) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(69);
+	    __VERIFIER_error_69();
 	    }
 	    if(((a1605463015 == 4 && a1179664392 == 33) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(70);
+	    __VERIFIER_error_70();
 	    }
 	    if(((((-160 < a1684594625) && (-26 >= a1684594625)) && a44138666 == 33) && a471011792 == 5)){
 	    cf = 0;
-	    __VERIFIER_error(71);
+	    __VERIFIER_error_71();
 	    }
 	    if(((a499699109 == 4 && 523 < a621522874) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(72);
+	    __VERIFIER_error_72();
 	    }
 	    if(((a946891643 == 12 && a45685611 == 7) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(73);
+	    __VERIFIER_error_73();
 	    }
 	    if(((((-145 < a1422023390) && (22 >= a1422023390)) && a236788248 == 10) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(74);
+	    __VERIFIER_error_74();
 	    }
 	    if(((a2139179119 == 16 && a45685611 == 13) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(75);
+	    __VERIFIER_error_75();
 	    }
 	    if(((((-69 < a648283191) && (120 >= a648283191)) && ((168 < a552913881) && (383 >= a552913881))) && a471011792 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(76);
+	    __VERIFIER_error_76();
 	    }
 	    if(((a1071924404 == 34 && a1179664392 == 32) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(77);
+	    __VERIFIER_error_77();
 	    }
 	    if(((a812175843 == 34 && a2122722213 == 9) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(78);
+	    __VERIFIER_error_78();
 	    }
 	    if(((a430318312 == 3 && a1179664392 == 36) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(79);
+	    __VERIFIER_error_79();
 	    }
 	    if(((a1218264876 == 34 && a45685611 == 9) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(80);
+	    __VERIFIER_error_80();
 	    }
 	    if(((a1179664392 == 36 && ((383 < a552913881) && (501 >= a552913881))) && a471011792 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(81);
+	    __VERIFIER_error_81();
 	    }
 	    if(((((-91 < a648283191) && (-69 >= a648283191)) && a621522874 <=  116) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(82);
+	    __VERIFIER_error_82();
 	    }
 	    if(((((160 < a173429297) && (321 >= a173429297)) && a45685611 == 10) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(83);
+	    __VERIFIER_error_83();
 	    }
 	    if(((a482477713 == 3 && a236788248 == 16) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(84);
+	    __VERIFIER_error_84();
 	    }
 	    if(((a808219163 == 35 && a418218587 == 33) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(85);
+	    __VERIFIER_error_85();
 	    }
 	    if(((a1218264876 == 35 && a236788248 == 14) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(86);
+	    __VERIFIER_error_86();
 	    }
 	    if(((a812175843 == 36 && a2122722213 == 9) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(87);
+	    __VERIFIER_error_87();
 	    }
 	    if(((a430318312 == 5 && a1179664392 == 36) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(88);
+	    __VERIFIER_error_88();
 	    }
 	    if(((a2079503415 == 16 && a236788248 == 15) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(89);
+	    __VERIFIER_error_89();
 	    }
 	    if(((a1684594625 <=  -160 && ((116 < a621522874) && (330 >= a621522874))) && a471011792 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(90);
+	    __VERIFIER_error_90();
 	    }
 	    if(((a2079503415 == 9 && a236788248 == 15) && a471011792 == 9)){
 	    cf = 0;
-	    __VERIFIER_error(91);
+	    __VERIFIER_error_91();
 	    }
 	    if(((a1535937505 == 36 && a2122722213 == 6) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(92);
+	    __VERIFIER_error_92();
 	    }
 	    if(((((116 < a621522874) && (330 >= a621522874)) && a418218587 == 32) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(93);
+	    __VERIFIER_error_93();
 	    }
 	    if(((196 < a1889803145 && a45685611 == 8) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(94);
+	    __VERIFIER_error_94();
 	    }
 	    if(((a418218587 == 33 && a2122722213 == 3) && a471011792 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(95);
+	    __VERIFIER_error_95();
 	    }
 	    if(((a2139179119 == 9 && a45685611 == 13) && a471011792 == 6)){
 	    cf = 0;
-	    __VERIFIER_error(96);
+	    __VERIFIER_error_96();
 	    }
 	    if(((a2083223046 == 35 && a418218587 == 34) && a471011792 == 7)){
 	    cf = 0;
-	    __VERIFIER_error(97);
+	    __VERIFIER_error_97();
 	    }
 	    if(((a1071924404 == 33 && a1179664392 == 32) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(98);
+	    __VERIFIER_error_98();
 	    }
 	    if(((a1071924404 == 32 && a1179664392 == 32) && a471011792 == 8)){
 	    cf = 0;
-	    __VERIFIER_error(99);
+	    __VERIFIER_error_99();
 	    }
 	}
  void calculate_outputm57(int input) {

--- a/c/eca-rers2018/Problem12.c
+++ b/c/eca-rers2018/Problem12.c
@@ -1,5 +1,105 @@
 extern int __VERIFIER_nondet_int();
-    extern void __VERIFIER_error(int);
+extern void __VERIFIER_error_0();
+extern void __VERIFIER_error_1();
+extern void __VERIFIER_error_2();
+extern void __VERIFIER_error_3();
+extern void __VERIFIER_error_4();
+extern void __VERIFIER_error_5();
+extern void __VERIFIER_error_6();
+extern void __VERIFIER_error_7();
+extern void __VERIFIER_error_8();
+extern void __VERIFIER_error_9();
+extern void __VERIFIER_error_10();
+extern void __VERIFIER_error_11();
+extern void __VERIFIER_error_12();
+extern void __VERIFIER_error_13();
+extern void __VERIFIER_error_14();
+extern void __VERIFIER_error_15();
+extern void __VERIFIER_error_16();
+extern void __VERIFIER_error_17();
+extern void __VERIFIER_error_18();
+extern void __VERIFIER_error_19();
+extern void __VERIFIER_error_20();
+extern void __VERIFIER_error_21();
+extern void __VERIFIER_error_22();
+extern void __VERIFIER_error_23();
+extern void __VERIFIER_error_24();
+extern void __VERIFIER_error_25();
+extern void __VERIFIER_error_26();
+extern void __VERIFIER_error_27();
+extern void __VERIFIER_error_28();
+extern void __VERIFIER_error_29();
+extern void __VERIFIER_error_30();
+extern void __VERIFIER_error_31();
+extern void __VERIFIER_error_32();
+extern void __VERIFIER_error_33();
+extern void __VERIFIER_error_34();
+extern void __VERIFIER_error_35();
+extern void __VERIFIER_error_36();
+extern void __VERIFIER_error_37();
+extern void __VERIFIER_error_38();
+extern void __VERIFIER_error_39();
+extern void __VERIFIER_error_40();
+extern void __VERIFIER_error_41();
+extern void __VERIFIER_error_42();
+extern void __VERIFIER_error_43();
+extern void __VERIFIER_error_44();
+extern void __VERIFIER_error_45();
+extern void __VERIFIER_error_46();
+extern void __VERIFIER_error_47();
+extern void __VERIFIER_error_48();
+extern void __VERIFIER_error_49();
+extern void __VERIFIER_error_50();
+extern void __VERIFIER_error_51();
+extern void __VERIFIER_error_52();
+extern void __VERIFIER_error_53();
+extern void __VERIFIER_error_54();
+extern void __VERIFIER_error_55();
+extern void __VERIFIER_error_56();
+extern void __VERIFIER_error_57();
+extern void __VERIFIER_error_58();
+extern void __VERIFIER_error_59();
+extern void __VERIFIER_error_60();
+extern void __VERIFIER_error_61();
+extern void __VERIFIER_error_62();
+extern void __VERIFIER_error_63();
+extern void __VERIFIER_error_64();
+extern void __VERIFIER_error_65();
+extern void __VERIFIER_error_66();
+extern void __VERIFIER_error_67();
+extern void __VERIFIER_error_68();
+extern void __VERIFIER_error_69();
+extern void __VERIFIER_error_70();
+extern void __VERIFIER_error_71();
+extern void __VERIFIER_error_72();
+extern void __VERIFIER_error_73();
+extern void __VERIFIER_error_74();
+extern void __VERIFIER_error_75();
+extern void __VERIFIER_error_76();
+extern void __VERIFIER_error_77();
+extern void __VERIFIER_error_78();
+extern void __VERIFIER_error_79();
+extern void __VERIFIER_error_80();
+extern void __VERIFIER_error_81();
+extern void __VERIFIER_error_82();
+extern void __VERIFIER_error_83();
+extern void __VERIFIER_error_84();
+extern void __VERIFIER_error_85();
+extern void __VERIFIER_error_86();
+extern void __VERIFIER_error_87();
+extern void __VERIFIER_error_88();
+extern void __VERIFIER_error_89();
+extern void __VERIFIER_error_90();
+extern void __VERIFIER_error_91();
+extern void __VERIFIER_error_92();
+extern void __VERIFIER_error_93();
+extern void __VERIFIER_error_94();
+extern void __VERIFIER_error_95();
+extern void __VERIFIER_error_96();
+extern void __VERIFIER_error_97();
+extern void __VERIFIER_error_98();
+extern void __VERIFIER_error_99();
+
 
 	// inputs
 	int inputs[] = {13,1,2,11,3,8,10,7,5,6,4,14,15,12,9};
@@ -371,403 +471,403 @@ extern int __VERIFIER_nondet_int();
 	void errorCheck() {
 	    if(((a593909561 == 11 && a162371808 == 7) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(0);
+	    __VERIFIER_error_0();
 	    }
 	    if(((((113 < a1668434638) && (305 >= a1668434638)) && ((361 < a1833263562) && (530 >= a1833263562))) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(1);
+	    __VERIFIER_error_1();
 	    }
 	    if(((a685494424 == 35 && a103688441 == 35) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(2);
+	    __VERIFIER_error_2();
 	    }
 	    if(((a409357718 == a780570711[7] && a103688441 == 33) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(3);
+	    __VERIFIER_error_3();
 	    }
 	    if(((a685494424 == 32 && a103688441 == 35) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(4);
+	    __VERIFIER_error_4();
 	    }
 	    if(((a1501273556 == a109864168[1] && a396984457 == a1763789991[7]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(5);
+	    __VERIFIER_error_5();
 	    }
 	    if(((a681146451 == a248263220[6] && ((141 < a1833263562) && (361 >= a1833263562))) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(6);
+	    __VERIFIER_error_6();
 	    }
 	    if(((a1394194198 == 32 && a1833263562 <=  141) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(7);
+	    __VERIFIER_error_7();
 	    }
 	    if(((((8 < a1668434638) && (113 >= a1668434638)) && a162371808 == 10) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(8);
+	    __VERIFIER_error_8();
 	    }
 	    if(((a2137307457 == a872351378[7] && a396984457 == a1763789991[2]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(9);
+	    __VERIFIER_error_9();
 	    }
 	    if(((a1606269656 == 2 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(10);
+	    __VERIFIER_error_10();
 	    }
 	    if(((a593909561 == 9 && a162371808 == 7) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(11);
+	    __VERIFIER_error_11();
 	    }
 	    if(((((10 < a949384536) && (91 >= a949384536)) && a103688441 == 36) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(12);
+	    __VERIFIER_error_12();
 	    }
 	    if(((a1801622631 == a1599732691[6] && (27 == a1786843609[3])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(13);
+	    __VERIFIER_error_13();
 	    }
 	    if(((a1501273556 == a109864168[6] && a162371808 == 11) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(14);
+	    __VERIFIER_error_14();
 	    }
 	    if(((((163 < a1401408671) && (201 >= a1401408671)) && a396984457 == a1763789991[3]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(15);
+	    __VERIFIER_error_15();
 	    }
 	    if(((a2137307457 == a872351378[4] && a396984457 == a1763789991[2]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(16);
+	    __VERIFIER_error_16();
 	    }
 	    if(((a143793771 == 12 && ((221 < a1837878870) && (310 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(17);
+	    __VERIFIER_error_17();
 	    }
 	    if(((a1011564321 == 5 && a162371808 == 8) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(18);
+	    __VERIFIER_error_18();
 	    }
 	    if(((a1401408671 <=  163 && a396984457 == a1763789991[3]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(19);
+	    __VERIFIER_error_19();
 	    }
 	    if(((a1944627434 == 10 && a396984457 == a1763789991[6]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(20);
+	    __VERIFIER_error_20();
 	    }
 	    if(((a162371808 == 10 && ((114 < a1837878870) && (221 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(21);
+	    __VERIFIER_error_21();
 	    }
 	    if(((a258159048 == 35 && (72 == a89622481[5])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(22);
+	    __VERIFIER_error_22();
 	    }
 	    if(((a409357718 == a780570711[4] && a103688441 == 33) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(23);
+	    __VERIFIER_error_23();
 	    }
 	    if(((a554161326 <=  -15 && a162371808 == 6) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(24);
+	    __VERIFIER_error_24();
 	    }
 	    if(((a872033453 == 9 && a396984457 == a1763789991[1]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(25);
+	    __VERIFIER_error_25();
 	    }
 	    if(((a1801622631 == a1599732691[7] && a162371808 == 9) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(26);
+	    __VERIFIER_error_26();
 	    }
 	    if(((a681146451 == a248263220[7] && ((141 < a1833263562) && (361 >= a1833263562))) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(27);
+	    __VERIFIER_error_27();
 	    }
 	    if(((a619268073 == a936735530[2] && (78 == a89622481[5])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(28);
+	    __VERIFIER_error_28();
 	    }
 	    if(((a1011564321 == 9 && a162371808 == 8) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(29);
+	    __VERIFIER_error_29();
 	    }
 	    if(((a1501273556 == a109864168[5] && a396984457 == a1763789991[7]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(30);
+	    __VERIFIER_error_30();
 	    }
 	    if(((a1801622631 == a1599732691[4] && (27 == a1786843609[3])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(31);
+	    __VERIFIER_error_31();
 	    }
 	    if(((a1606269656 == 8 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(32);
+	    __VERIFIER_error_32();
 	    }
 	    if(((a275729990 == 36 && (81 == a312349044[4])) && a324444182 == 14)){
 	    cf = 0;
-	    __VERIFIER_error(33);
+	    __VERIFIER_error_33();
 	    }
 	    if(((a1501273556 == a109864168[0] && a396984457 == a1763789991[7]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(34);
+	    __VERIFIER_error_34();
 	    }
 	    if(((((96 < a227116215) && (252 >= a227116215)) && a396984457 == a1763789991[0]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(35);
+	    __VERIFIER_error_35();
 	    }
 	    if(((433 < a227116215 && a396984457 == a1763789991[0]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(36);
+	    __VERIFIER_error_36();
 	    }
 	    if(((a1394194198 == 35 && a1833263562 <=  141) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(37);
+	    __VERIFIER_error_37();
 	    }
 	    if(((a872033453 == 6 && a396984457 == a1763789991[1]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(38);
+	    __VERIFIER_error_38();
 	    }
 	    if(((a1501273556 == a109864168[2] && a162371808 == 11) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(39);
+	    __VERIFIER_error_39();
 	    }
 	    if(((a1501273556 == a109864168[4] && a162371808 == 11) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(40);
+	    __VERIFIER_error_40();
 	    }
 	    if((((91 == a789060929[0]) && (33 == a1786843609[3])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(41);
+	    __VERIFIER_error_41();
 	    }
 	    if(((a1011564321 == 7 && a162371808 == 8) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(42);
+	    __VERIFIER_error_42();
 	    }
 	    if(((a1944627434 == 13 && a396984457 == a1763789991[6]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(43);
+	    __VERIFIER_error_43();
 	    }
 	    if(((a1606269656 == 3 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(44);
+	    __VERIFIER_error_44();
 	    }
 	    if(((a1944627434 == 11 && a396984457 == a1763789991[6]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(45);
+	    __VERIFIER_error_45();
 	    }
 	    if(((a162371808 == 11 && ((114 < a1837878870) && (221 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(46);
+	    __VERIFIER_error_46();
 	    }
 	    if(((a1394194198 == 34 && a1833263562 <=  141) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(47);
+	    __VERIFIER_error_47();
 	    }
 	    if(((a162371808 == 7 && ((114 < a1837878870) && (221 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(48);
+	    __VERIFIER_error_48();
 	    }
 	    if(((a1606269656 == 6 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(49);
+	    __VERIFIER_error_49();
 	    }
 	    if(((a1801622631 == a1599732691[7] && (27 == a1786843609[3])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(50);
+	    __VERIFIER_error_50();
 	    }
 	    if(((a990638568 == a333390270[6] && a396984457 == a1763789991[5]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(51);
+	    __VERIFIER_error_51();
 	    }
 	    if(((a593909561 == 12 && a162371808 == 7) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(52);
+	    __VERIFIER_error_52();
 	    }
 	    if(((a1606269656 == 4 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(53);
+	    __VERIFIER_error_53();
 	    }
 	    if(((a526436628 == a691163450[1] && a396984457 == a1763789991[4]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(54);
+	    __VERIFIER_error_54();
 	    }
 	    if(((a162371808 == 9 && ((114 < a1837878870) && (221 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(55);
+	    __VERIFIER_error_55();
 	    }
 	    if(((a143793771 == 8 && ((221 < a1837878870) && (310 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(56);
+	    __VERIFIER_error_56();
 	    }
 	    if(((a593909561 == 6 && a162371808 == 7) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(57);
+	    __VERIFIER_error_57();
 	    }
 	    if((((41 == a50738105[1]) && a1837878870 <=  114) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(58);
+	    __VERIFIER_error_58();
 	    }
 	    if(((((8 < a1668434638) && (113 >= a1668434638)) && ((361 < a1833263562) && (530 >= a1833263562))) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(59);
+	    __VERIFIER_error_59();
 	    }
 	    if(((a593909561 == 5 && a162371808 == 7) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(60);
+	    __VERIFIER_error_60();
 	    }
 	    if(((a1606269656 == 9 && a162371808 == 5) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(61);
+	    __VERIFIER_error_61();
 	    }
 	    if((((22 == a924937861[4]) && 310 < a1837878870) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(62);
+	    __VERIFIER_error_62();
 	    }
 	    if(((a872033453 == 7 && a396984457 == a1763789991[1]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(63);
+	    __VERIFIER_error_63();
 	    }
 	    if((((47 == a320285760[4]) && (80 == a89622481[1])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(64);
+	    __VERIFIER_error_64();
 	    }
 	    if(((a1227542619 == 34 && (38 == a1786843609[2])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(65);
+	    __VERIFIER_error_65();
 	    }
 	    if(((a1801622631 == a1599732691[3] && a162371808 == 9) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(66);
+	    __VERIFIER_error_66();
 	    }
 	    if(((a2137307457 == a872351378[0] && a396984457 == a1763789991[2]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(67);
+	    __VERIFIER_error_67();
 	    }
 	    if(((a275729990 == 36 && 530 < a1833263562) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(68);
+	    __VERIFIER_error_68();
 	    }
 	    if(((a258159048 == 34 && (72 == a89622481[5])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(69);
+	    __VERIFIER_error_69();
 	    }
 	    if(((a698560326 == 35 && a162371808 == 4) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(70);
+	    __VERIFIER_error_70();
 	    }
 	    if(((a143793771 == 15 && ((221 < a1837878870) && (310 >= a1837878870))) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(71);
+	    __VERIFIER_error_71();
 	    }
 	    if(((a681146451 == a248263220[0] && ((141 < a1833263562) && (361 >= a1833263562))) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(72);
+	    __VERIFIER_error_72();
 	    }
 	    if(((a1227542619 == 32 && (38 == a1786843609[2])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(73);
+	    __VERIFIER_error_73();
 	    }
 	    if(((a275729990 == 34 && (81 == a312349044[4])) && a324444182 == 14)){
 	    cf = 0;
-	    __VERIFIER_error(74);
+	    __VERIFIER_error_74();
 	    }
 	    if(((a2137307457 == a872351378[6] && a396984457 == a1763789991[2]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(75);
+	    __VERIFIER_error_75();
 	    }
 	    if(((a990638568 == a333390270[4] && a396984457 == a1763789991[5]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(76);
+	    __VERIFIER_error_76();
 	    }
 	    if(((a1394194198 == 33 && a1833263562 <=  141) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(77);
+	    __VERIFIER_error_77();
 	    }
 	    if(((a698560326 == 33 && a162371808 == 4) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(78);
+	    __VERIFIER_error_78();
 	    }
 	    if(((a275729990 == 33 && 530 < a1833263562) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(79);
+	    __VERIFIER_error_79();
 	    }
 	    if((((34 == a924937861[4]) && 310 < a1837878870) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(80);
+	    __VERIFIER_error_80();
 	    }
 	    if(((a275729990 == 34 && 530 < a1833263562) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(81);
+	    __VERIFIER_error_81();
 	    }
 	    if(((a1801622631 == a1599732691[2] && (27 == a1786843609[3])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(82);
+	    __VERIFIER_error_82();
 	    }
 	    if(((a1501273556 == a109864168[3] && a162371808 == 11) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(83);
+	    __VERIFIER_error_83();
 	    }
 	    if((((29 == a924937861[5]) && 310 < a1837878870) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(84);
+	    __VERIFIER_error_84();
 	    }
 	    if(((a619268073 == a936735530[0] && (78 == a89622481[5])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(85);
+	    __VERIFIER_error_85();
 	    }
 	    if(((a1801622631 == a1599732691[1] && a162371808 == 9) && a324444182 == 10)){
 	    cf = 0;
-	    __VERIFIER_error(86);
+	    __VERIFIER_error_86();
 	    }
 	    if(((a1227542619 == 35 && (38 == a1786843609[2])) && a324444182 == 12)){
 	    cf = 0;
-	    __VERIFIER_error(87);
+	    __VERIFIER_error_87();
 	    }
 	    if(((a1944627434 == 14 && a396984457 == a1763789991[6]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(88);
+	    __VERIFIER_error_88();
 	    }
 	    if(((a275729990 == 35 && 530 < a1833263562) && a324444182 == 15)){
 	    cf = 0;
-	    __VERIFIER_error(89);
+	    __VERIFIER_error_89();
 	    }
 	    if(((((94 < a1390738092) && (314 >= a1390738092)) && a103688441 == 32) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(90);
+	    __VERIFIER_error_90();
 	    }
 	    if(((((8 < a1668434638) && (113 >= a1668434638)) && a103688441 == 34) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(91);
+	    __VERIFIER_error_91();
 	    }
 	    if(((a409357718 == a780570711[2] && a103688441 == 33) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(92);
+	    __VERIFIER_error_92();
 	    }
 	    if((((49 == a320285760[0]) && (80 == a89622481[1])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(93);
+	    __VERIFIER_error_93();
 	    }
 	    if((((37 == a50738105[3]) && a1837878870 <=  114) && a324444182 == 17)){
 	    cf = 0;
-	    __VERIFIER_error(94);
+	    __VERIFIER_error_94();
 	    }
 	    if(((a258159048 == 33 && (72 == a89622481[5])) && a324444182 == 13)){
 	    cf = 0;
-	    __VERIFIER_error(95);
+	    __VERIFIER_error_95();
 	    }
 	    if(((287 < a949384536 && a103688441 == 36) && a324444182 == 16)){
 	    cf = 0;
-	    __VERIFIER_error(96);
+	    __VERIFIER_error_96();
 	    }
 	    if(((a526436628 == a691163450[6] && a396984457 == a1763789991[4]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(97);
+	    __VERIFIER_error_97();
 	    }
 	    if(((a990638568 == a333390270[2] && a396984457 == a1763789991[5]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(98);
+	    __VERIFIER_error_98();
 	    }
 	    if(((a2137307457 == a872351378[1] && a396984457 == a1763789991[2]) && a324444182 == 11)){
 	    cf = 0;
-	    __VERIFIER_error(99);
+	    __VERIFIER_error_99();
 	    }
 	}
  void calculate_outputm40(int input) {

--- a/c/eca-rers2018/Problem13.c
+++ b/c/eca-rers2018/Problem13.c
@@ -1,5 +1,105 @@
 extern int __VERIFIER_nondet_int();
-    extern void __VERIFIER_error(int);
+extern void __VERIFIER_error_0();
+extern void __VERIFIER_error_1();
+extern void __VERIFIER_error_2();
+extern void __VERIFIER_error_3();
+extern void __VERIFIER_error_4();
+extern void __VERIFIER_error_5();
+extern void __VERIFIER_error_6();
+extern void __VERIFIER_error_7();
+extern void __VERIFIER_error_8();
+extern void __VERIFIER_error_9();
+extern void __VERIFIER_error_10();
+extern void __VERIFIER_error_11();
+extern void __VERIFIER_error_12();
+extern void __VERIFIER_error_13();
+extern void __VERIFIER_error_14();
+extern void __VERIFIER_error_15();
+extern void __VERIFIER_error_16();
+extern void __VERIFIER_error_17();
+extern void __VERIFIER_error_18();
+extern void __VERIFIER_error_19();
+extern void __VERIFIER_error_20();
+extern void __VERIFIER_error_21();
+extern void __VERIFIER_error_22();
+extern void __VERIFIER_error_23();
+extern void __VERIFIER_error_24();
+extern void __VERIFIER_error_25();
+extern void __VERIFIER_error_26();
+extern void __VERIFIER_error_27();
+extern void __VERIFIER_error_28();
+extern void __VERIFIER_error_29();
+extern void __VERIFIER_error_30();
+extern void __VERIFIER_error_31();
+extern void __VERIFIER_error_32();
+extern void __VERIFIER_error_33();
+extern void __VERIFIER_error_34();
+extern void __VERIFIER_error_35();
+extern void __VERIFIER_error_36();
+extern void __VERIFIER_error_37();
+extern void __VERIFIER_error_38();
+extern void __VERIFIER_error_39();
+extern void __VERIFIER_error_40();
+extern void __VERIFIER_error_41();
+extern void __VERIFIER_error_42();
+extern void __VERIFIER_error_43();
+extern void __VERIFIER_error_44();
+extern void __VERIFIER_error_45();
+extern void __VERIFIER_error_46();
+extern void __VERIFIER_error_47();
+extern void __VERIFIER_error_48();
+extern void __VERIFIER_error_49();
+extern void __VERIFIER_error_50();
+extern void __VERIFIER_error_51();
+extern void __VERIFIER_error_52();
+extern void __VERIFIER_error_53();
+extern void __VERIFIER_error_54();
+extern void __VERIFIER_error_55();
+extern void __VERIFIER_error_56();
+extern void __VERIFIER_error_57();
+extern void __VERIFIER_error_58();
+extern void __VERIFIER_error_59();
+extern void __VERIFIER_error_60();
+extern void __VERIFIER_error_61();
+extern void __VERIFIER_error_62();
+extern void __VERIFIER_error_63();
+extern void __VERIFIER_error_64();
+extern void __VERIFIER_error_65();
+extern void __VERIFIER_error_66();
+extern void __VERIFIER_error_67();
+extern void __VERIFIER_error_68();
+extern void __VERIFIER_error_69();
+extern void __VERIFIER_error_70();
+extern void __VERIFIER_error_71();
+extern void __VERIFIER_error_72();
+extern void __VERIFIER_error_73();
+extern void __VERIFIER_error_74();
+extern void __VERIFIER_error_75();
+extern void __VERIFIER_error_76();
+extern void __VERIFIER_error_77();
+extern void __VERIFIER_error_78();
+extern void __VERIFIER_error_79();
+extern void __VERIFIER_error_80();
+extern void __VERIFIER_error_81();
+extern void __VERIFIER_error_82();
+extern void __VERIFIER_error_83();
+extern void __VERIFIER_error_84();
+extern void __VERIFIER_error_85();
+extern void __VERIFIER_error_86();
+extern void __VERIFIER_error_87();
+extern void __VERIFIER_error_88();
+extern void __VERIFIER_error_89();
+extern void __VERIFIER_error_90();
+extern void __VERIFIER_error_91();
+extern void __VERIFIER_error_92();
+extern void __VERIFIER_error_93();
+extern void __VERIFIER_error_94();
+extern void __VERIFIER_error_95();
+extern void __VERIFIER_error_96();
+extern void __VERIFIER_error_97();
+extern void __VERIFIER_error_98();
+extern void __VERIFIER_error_99();
+
 
 	// inputs
 	int inputs[] = {1,8,4,10,7,9,5,6,3,2};
@@ -906,403 +1006,403 @@ extern int __VERIFIER_nondet_int();
 	void errorCheck() {
 	    if((((a1505860848 == 13 && a513320595 == 34) && a1725443576 == 34) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(0);
+	    __VERIFIER_error_0();
 	    }
 	    if((((a23876316 == 13 && a1948456105 == 33) && a468838722 == 2) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(1);
+	    __VERIFIER_error_1();
 	    }
 	    if((((a1914758259 == 7 && a468838722 == 9) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(2);
+	    __VERIFIER_error_2();
 	    }
 	    if((((a437859619 == 14 && a175347572 == 9) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(3);
+	    __VERIFIER_error_3();
 	    }
 	    if((((a1401533861 == 33 && a810975817 == 7) && a1462859349 == 14) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(4);
+	    __VERIFIER_error_4();
 	    }
 	    if((((a1067316040 == 34 && a806891390 == 8) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(5);
+	    __VERIFIER_error_5();
 	    }
 	    if((((a265212805 == 3 && a957431625 == 5) && a1905408413 == 9) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(6);
+	    __VERIFIER_error_6();
 	    }
 	    if((((a721350177 == 36 && a1299972107 == 11) && a1462859349 == 11) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(7);
+	    __VERIFIER_error_7();
 	    }
 	    if((((a1902062332 == 32 && a1497388547 == 10) && a1750033128 == 36) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(8);
+	    __VERIFIER_error_8();
 	    }
 	    if((((a695410471 == 35 && a1802350235 == 34) && a1905408413 == 6) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(9);
+	    __VERIFIER_error_9();
 	    }
 	    if((((a1424546470 == 9 && a840876303 == 11) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(10);
+	    __VERIFIER_error_10();
 	    }
 	    if((((a251563597 == 7 && a26763502 == 7) && a1462859349 == 13) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(11);
+	    __VERIFIER_error_11();
 	    }
 	    if((((a909349551 == 4 && a724639062 == 33) && a1725443576 == 36) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(12);
+	    __VERIFIER_error_12();
 	    }
 	    if((((a773719637 == 35 && a468838722 == 3) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(13);
+	    __VERIFIER_error_13();
 	    }
 	    if((((a566188180 == 2 && a806891390 == 14) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(14);
+	    __VERIFIER_error_14();
 	    }
 	    if((((a1424546470 == 7 && a840876303 == 11) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(15);
+	    __VERIFIER_error_15();
 	    }
 	    if((((a777471414 == 5 && a1164846758 == 13) && a1905408413 == 3) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(16);
+	    __VERIFIER_error_16();
 	    }
 	    if((((a245812483 == 32 && a398747685 == 6) && a1462859349 == 9) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(17);
+	    __VERIFIER_error_17();
 	    }
 	    if((((a1057633003 == 2 && a398747685 == 8) && a1462859349 == 9) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(18);
+	    __VERIFIER_error_18();
 	    }
 	    if((((a1737073699 == 35 && a397936755 == 33) && a1462859349 == 8) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(19);
+	    __VERIFIER_error_19();
 	    }
 	    if((((a1905408413 == 10 && a175347572 == 13) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(20);
+	    __VERIFIER_error_20();
 	    }
 	    if((((a1854566063 == 32 && a513320595 == 32) && a1725443576 == 34) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(21);
+	    __VERIFIER_error_21();
 	    }
 	    if((((a1401528060 == 12 && a806891390 == 12) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(22);
+	    __VERIFIER_error_22();
 	    }
 	    if((((a210840944 == 34 && a39198489 == 14) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(23);
+	    __VERIFIER_error_23();
 	    }
 	    if((((a801116378 == 9 && a1737073699 == 36) && a1462859349 == 12) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(24);
+	    __VERIFIER_error_24();
 	    }
 	    if((((a398747685 == 1 && a1299972107 == 15) && a1462859349 == 11) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(25);
+	    __VERIFIER_error_25();
 	    }
 	    if((((a1109108521 == 35 && a39198489 == 11) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(26);
+	    __VERIFIER_error_26();
 	    }
 	    if((((a801116378 == 10 && a26763502 == 9) && a1462859349 == 13) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(27);
+	    __VERIFIER_error_27();
 	    }
 	    if((((a1720612737 == 6 && a1164846758 == 9) && a1905408413 == 3) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(28);
+	    __VERIFIER_error_28();
 	    }
 	    if((((a979230901 == 8 && a1122500563 == 13) && a468838722 == 7) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(29);
+	    __VERIFIER_error_29();
 	    }
 	    if((((a623465944 == 32 && a1061061074 == 13) && a1905408413 == 8) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(30);
+	    __VERIFIER_error_30();
 	    }
 	    if((((a1854566063 == 35 && a513320595 == 32) && a1725443576 == 34) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(31);
+	    __VERIFIER_error_31();
 	    }
 	    if((((a715351018 == 6 && a232140897 == 34) && a468838722 == 8) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(32);
+	    __VERIFIER_error_32();
 	    }
 	    if((((a1914758259 == 11 && a468838722 == 9) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(33);
+	    __VERIFIER_error_33();
 	    }
 	    if((((a1862006028 == 35 && a1122500563 == 10) && a468838722 == 7) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(34);
+	    __VERIFIER_error_34();
 	    }
 	    if((((a1378556243 == 5 && a1341048756 == 32) && a1905408413 == 5) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(35);
+	    __VERIFIER_error_35();
 	    }
 	    if((((a1766645245 == 33 && a806891390 == 13) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(36);
+	    __VERIFIER_error_36();
 	    }
 	    if((((a1429468524 == 35 && a39198489 == 9) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(37);
+	    __VERIFIER_error_37();
 	    }
 	    if((((a371216780 == 36 && a724639062 == 36) && a1725443576 == 36) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(38);
+	    __VERIFIER_error_38();
 	    }
 	    if((((a724773321 == 33 && a39198489 == 12) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(39);
+	    __VERIFIER_error_39();
 	    }
 	    if((((a1186681031 == 33 && a468838722 == 6) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(40);
+	    __VERIFIER_error_40();
 	    }
 	    if((((a695552692 == 11 && a39198489 == 15) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(41);
+	    __VERIFIER_error_41();
 	    }
 	    if((((a182367970 == 5 && a1802350235 == 32) && a1905408413 == 6) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(42);
+	    __VERIFIER_error_42();
 	    }
 	    if((((a633972403 == 9 && a627361662 == 13) && a1750033128 == 33) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(43);
+	    __VERIFIER_error_43();
 	    }
 	    if((((a695552692 == 9 && a39198489 == 15) && a1905408413 == 10) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(44);
+	    __VERIFIER_error_44();
 	    }
 	    if((((a1959901591 == 6 && a957431625 == 10) && a1905408413 == 9) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(45);
+	    __VERIFIER_error_45();
 	    }
 	    if((((a669151770 == 35 && a560765209 == 9) && a468838722 == 6) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(46);
+	    __VERIFIER_error_46();
 	    }
 	    if((((a873704308 == 11 && a26763502 == 10) && a1462859349 == 13) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(47);
+	    __VERIFIER_error_47();
 	    }
 	    if((((a787039193 == 35 && a26763502 == 8) && a1462859349 == 13) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(48);
+	    __VERIFIER_error_48();
 	    }
 	    if((((a1914758259 == 10 && a468838722 == 9) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(49);
+	    __VERIFIER_error_49();
 	    }
 	    if((((a1424546470 == 11 && a840876303 == 11) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(50);
+	    __VERIFIER_error_50();
 	    }
 	    if((((a1337197559 == 9 && a1122500563 == 9) && a468838722 == 7) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(51);
+	    __VERIFIER_error_51();
 	    }
 	    if((((a1401533861 == 36 && a496754142 == 32) && a1462859349 == 15) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(52);
+	    __VERIFIER_error_52();
 	    }
 	    if((((a1752086130 == 12 && a1802350235 == 35) && a1905408413 == 6) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(53);
+	    __VERIFIER_error_53();
 	    }
 	    if((((a773719637 == 35 && a1071599259 == 12) && a1750033128 == 35) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(54);
+	    __VERIFIER_error_54();
 	    }
 	    if((((a1361355830 == 34 && a385678848 == 14) && a1750033128 == 32) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(55);
+	    __VERIFIER_error_55();
 	    }
 	    if((((a939343530 == 3 && a752473649 == 36) && a468838722 == 4) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(56);
+	    __VERIFIER_error_56();
 	    }
 	    if((((a2079651693 == 11 && a887517422 == 6) && a1905408413 == 4) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(57);
+	    __VERIFIER_error_57();
 	    }
 	    if((((a633972403 == 9 && a810975817 == 2) && a1462859349 == 14) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(58);
+	    __VERIFIER_error_58();
 	    }
 	    if((((a873704308 == 7 && a26763502 == 10) && a1462859349 == 13) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(59);
+	    __VERIFIER_error_59();
 	    }
 	    if((((a603072606 == 32 && a627361662 == 6) && a1750033128 == 33) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(60);
+	    __VERIFIER_error_60();
 	    }
 	    if((((a1676892951 == 16 && a496754142 == 36) && a1462859349 == 15) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(61);
+	    __VERIFIER_error_61();
 	    }
 	    if((((a398747685 == 3 && a1299972107 == 15) && a1462859349 == 11) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(62);
+	    __VERIFIER_error_62();
 	    }
 	    if((((a1025082162 == 8 && a1223536872 == 12) && a1725443576 == 32) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(63);
+	    __VERIFIER_error_63();
 	    }
 	    if((((a1937408739 == 36 && a840876303 == 8) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(64);
+	    __VERIFIER_error_64();
 	    }
 	    if((((a1809505832 == 35 && a1341048756 == 36) && a1905408413 == 5) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(65);
+	    __VERIFIER_error_65();
 	    }
 	    if((((a937069423 == 11 && a398747685 == 5) && a1462859349 == 9) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(66);
+	    __VERIFIER_error_66();
 	    }
 	    if((((a1582880737 == 36 && a1937408739 == 33) && a1725443576 == 33) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(67);
+	    __VERIFIER_error_67();
 	    }
 	    if((((a55543278 == 10 && a1497388547 == 11) && a1750033128 == 36) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(68);
+	    __VERIFIER_error_68();
 	    }
 	    if((((a2098478530 == 36 && a1299972107 == 12) && a1462859349 == 11) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(69);
+	    __VERIFIER_error_69();
 	    }
 	    if((((a1529899810 == 11 && a806891390 == 11) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(70);
+	    __VERIFIER_error_70();
 	    }
 	    if((((a1156299070 == 6 && a232140897 == 36) && a468838722 == 8) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(71);
+	    __VERIFIER_error_71();
 	    }
 	    if((((a1057633003 == 1 && a398747685 == 8) && a1462859349 == 9) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(72);
+	    __VERIFIER_error_72();
 	    }
 	    if((((a1948456105 == 34 && a840876303 == 13) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(73);
+	    __VERIFIER_error_73();
 	    }
 	    if((((a1752086130 == 15 && a1802350235 == 35) && a1905408413 == 6) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(74);
+	    __VERIFIER_error_74();
 	    }
 	    if((((a1067791411 == 34 && a752473649 == 34) && a468838722 == 4) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(75);
+	    __VERIFIER_error_75();
 	    }
 	    if((((a773719637 == 33 && a468838722 == 3) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(76);
+	    __VERIFIER_error_76();
 	    }
 	    if((((a1905408413 == 9 && a175347572 == 13) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(77);
+	    __VERIFIER_error_77();
 	    }
 	    if((((a1905408413 == 4 && a175347572 == 13) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(78);
+	    __VERIFIER_error_78();
 	    }
 	    if((((a1401528060 == 10 && a806891390 == 12) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(79);
+	    __VERIFIER_error_79();
 	    }
 	    if((((a1905408413 == 5 && a175347572 == 13) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(80);
+	    __VERIFIER_error_80();
 	    }
 	    if((((a1401528060 == 9 && a806891390 == 12) && a468838722 == 5) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(81);
+	    __VERIFIER_error_81();
 	    }
 	    if((((a1941029792 == 2 && a887517422 == 4) && a1905408413 == 4) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(82);
+	    __VERIFIER_error_82();
 	    }
 	    if((((a1460608966 == 35 && a1802350235 == 33) && a1905408413 == 6) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(83);
+	    __VERIFIER_error_83();
 	    }
 	    if((((a2138286349 == 6 && a232140897 == 32) && a468838722 == 8) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(84);
+	    __VERIFIER_error_84();
 	    }
 	    if((((a566188180 == 4 && a232140897 == 35) && a468838722 == 8) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(85);
+	    __VERIFIER_error_85();
 	    }
 	    if((((a1905408413 == 7 && a175347572 == 13) && a468838722 == 3) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(86);
+	    __VERIFIER_error_86();
 	    }
 	    if((((a664207973 == 8 && a560765209 == 3) && a468838722 == 6) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(87);
+	    __VERIFIER_error_87();
 	    }
 	    if((((a2004477564 == 34 && a957431625 == 7) && a1905408413 == 9) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(88);
+	    __VERIFIER_error_88();
 	    }
 	    if((((a2015184539 == 10 && a1061061074 == 10) && a1905408413 == 8) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(89);
+	    __VERIFIER_error_89();
 	    }
 	    if((((a669584791 == 33 && a1937408739 == 35) && a1725443576 == 33) && a493799204 == 33)){
 	    cf = 0;
-	    __VERIFIER_error(90);
+	    __VERIFIER_error_90();
 	    }
 	    if((((a34818649 == 35 && a468838722 == 4) && a1462859349 == 10) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(91);
+	    __VERIFIER_error_91();
 	    }
 	    if((((a302289357 == 36 && a1497388547 == 8) && a1750033128 == 36) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(92);
+	    __VERIFIER_error_92();
 	    }
 	    if((((a623465944 == 34 && a1061061074 == 13) && a1905408413 == 8) && a493799204 == 36)){
 	    cf = 0;
-	    __VERIFIER_error(93);
+	    __VERIFIER_error_93();
 	    }
 	    if((((a1693203189 == 12 && a627361662 == 10) && a1750033128 == 33) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(94);
+	    __VERIFIER_error_94();
 	    }
 	    if((((a1693203189 == 9 && a627361662 == 10) && a1750033128 == 33) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(95);
+	    __VERIFIER_error_95();
 	    }
 	    if((((a1756023661 == 33 && a1071599259 == 6) && a1750033128 == 35) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(96);
+	    __VERIFIER_error_96();
 	    }
 	    if((((a603072606 == 33 && a848991046 == 34) && a1750033128 == 34) && a493799204 == 35)){
 	    cf = 0;
-	    __VERIFIER_error(97);
+	    __VERIFIER_error_97();
 	    }
 	    if((((a2051298129 == 2 && a1299972107 == 14) && a1462859349 == 11) && a493799204 == 32)){
 	    cf = 0;
-	    __VERIFIER_error(98);
+	    __VERIFIER_error_98();
 	    }
 	    if((((a1937408739 == 32 && a840876303 == 8) && a468838722 == 9) && a493799204 == 34)){
 	    cf = 0;
-	    __VERIFIER_error(99);
+	    __VERIFIER_error_99();
 	    }
 	}
  void calculate_outputm36(int input) {

--- a/c/eca-rers2018/Problem14.c
+++ b/c/eca-rers2018/Problem14.c
@@ -1,5 +1,105 @@
 extern int __VERIFIER_nondet_int();
-    extern void __VERIFIER_error(int);
+extern void __VERIFIER_error_0();
+extern void __VERIFIER_error_1();
+extern void __VERIFIER_error_2();
+extern void __VERIFIER_error_3();
+extern void __VERIFIER_error_4();
+extern void __VERIFIER_error_5();
+extern void __VERIFIER_error_6();
+extern void __VERIFIER_error_7();
+extern void __VERIFIER_error_8();
+extern void __VERIFIER_error_9();
+extern void __VERIFIER_error_10();
+extern void __VERIFIER_error_11();
+extern void __VERIFIER_error_12();
+extern void __VERIFIER_error_13();
+extern void __VERIFIER_error_14();
+extern void __VERIFIER_error_15();
+extern void __VERIFIER_error_16();
+extern void __VERIFIER_error_17();
+extern void __VERIFIER_error_18();
+extern void __VERIFIER_error_19();
+extern void __VERIFIER_error_20();
+extern void __VERIFIER_error_21();
+extern void __VERIFIER_error_22();
+extern void __VERIFIER_error_23();
+extern void __VERIFIER_error_24();
+extern void __VERIFIER_error_25();
+extern void __VERIFIER_error_26();
+extern void __VERIFIER_error_27();
+extern void __VERIFIER_error_28();
+extern void __VERIFIER_error_29();
+extern void __VERIFIER_error_30();
+extern void __VERIFIER_error_31();
+extern void __VERIFIER_error_32();
+extern void __VERIFIER_error_33();
+extern void __VERIFIER_error_34();
+extern void __VERIFIER_error_35();
+extern void __VERIFIER_error_36();
+extern void __VERIFIER_error_37();
+extern void __VERIFIER_error_38();
+extern void __VERIFIER_error_39();
+extern void __VERIFIER_error_40();
+extern void __VERIFIER_error_41();
+extern void __VERIFIER_error_42();
+extern void __VERIFIER_error_43();
+extern void __VERIFIER_error_44();
+extern void __VERIFIER_error_45();
+extern void __VERIFIER_error_46();
+extern void __VERIFIER_error_47();
+extern void __VERIFIER_error_48();
+extern void __VERIFIER_error_49();
+extern void __VERIFIER_error_50();
+extern void __VERIFIER_error_51();
+extern void __VERIFIER_error_52();
+extern void __VERIFIER_error_53();
+extern void __VERIFIER_error_54();
+extern void __VERIFIER_error_55();
+extern void __VERIFIER_error_56();
+extern void __VERIFIER_error_57();
+extern void __VERIFIER_error_58();
+extern void __VERIFIER_error_59();
+extern void __VERIFIER_error_60();
+extern void __VERIFIER_error_61();
+extern void __VERIFIER_error_62();
+extern void __VERIFIER_error_63();
+extern void __VERIFIER_error_64();
+extern void __VERIFIER_error_65();
+extern void __VERIFIER_error_66();
+extern void __VERIFIER_error_67();
+extern void __VERIFIER_error_68();
+extern void __VERIFIER_error_69();
+extern void __VERIFIER_error_70();
+extern void __VERIFIER_error_71();
+extern void __VERIFIER_error_72();
+extern void __VERIFIER_error_73();
+extern void __VERIFIER_error_74();
+extern void __VERIFIER_error_75();
+extern void __VERIFIER_error_76();
+extern void __VERIFIER_error_77();
+extern void __VERIFIER_error_78();
+extern void __VERIFIER_error_79();
+extern void __VERIFIER_error_80();
+extern void __VERIFIER_error_81();
+extern void __VERIFIER_error_82();
+extern void __VERIFIER_error_83();
+extern void __VERIFIER_error_84();
+extern void __VERIFIER_error_85();
+extern void __VERIFIER_error_86();
+extern void __VERIFIER_error_87();
+extern void __VERIFIER_error_88();
+extern void __VERIFIER_error_89();
+extern void __VERIFIER_error_90();
+extern void __VERIFIER_error_91();
+extern void __VERIFIER_error_92();
+extern void __VERIFIER_error_93();
+extern void __VERIFIER_error_94();
+extern void __VERIFIER_error_95();
+extern void __VERIFIER_error_96();
+extern void __VERIFIER_error_97();
+extern void __VERIFIER_error_98();
+extern void __VERIFIER_error_99();
+
 
 	// inputs
 	int inputs[] = {4,6,7,5,15,1,13,9,8,14,2,12,10,3,11};
@@ -698,403 +798,403 @@ extern int __VERIFIER_nondet_int();
 	void errorCheck() {
 	    if((((a313674417 == 36 && a367648246 == 5) && a2018367432 == 4) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(0);
+	    __VERIFIER_error_0();
 	    }
 	    if((((433 < a1513923858 && ((195 < a1496140579) && (321 >= a1496140579))) && a294592648 == 6) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(1);
+	    __VERIFIER_error_1();
 	    }
 	    if((((a1429298572 == 1 && a313674417 == 36) && a975683458 == 8) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(2);
+	    __VERIFIER_error_2();
 	    }
 	    if((((a1674172007 == 5 && a1046141825 == 11) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(3);
+	    __VERIFIER_error_3();
 	    }
 	    if((((a703491081 == 35 && a625666768 == 4) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(4);
+	    __VERIFIER_error_4();
 	    }
 	    if((((a121946400 == 10 && ((-16 < a973178880) && (20 >= a973178880))) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(5);
+	    __VERIFIER_error_5();
 	    }
 	    if((((a328443163 == 36 && ((-90 < a1805728148) && (-25 >= a1805728148))) && a975683458 == 13) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(6);
+	    __VERIFIER_error_6();
 	    }
 	    if((((a2110564575 == 11 && ((-25 < a1805728148) && (129 >= a1805728148))) && a975683458 == 13) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(7);
+	    __VERIFIER_error_7();
 	    }
 	    if((((((-107 < a1479597430) && (-3 >= a1479597430)) && a862153233 == 6) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(8);
+	    __VERIFIER_error_8();
 	    }
 	    if((((a1965985120 == 11 && a30507962 == 32) && a294592648 == 8) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(9);
+	    __VERIFIER_error_9();
 	    }
 	    if((((a1922940353 == 12 && a126761446 == 36) && a2018367432 == 10) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(10);
+	    __VERIFIER_error_10();
 	    }
 	    if((((a141893458 == 33 && 181 < a1168050593) && ((41 < a546648771) && (127 >= a546648771))) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(11);
+	    __VERIFIER_error_11();
 	    }
 	    if((((a1458008316 <=  -1 && a625666768 == 3) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(12);
+	    __VERIFIER_error_12();
 	    }
 	    if((((((98 < a1879861843) && (167 >= a1879861843)) && a367648246 == 11) && a2018367432 == 4) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(13);
+	    __VERIFIER_error_13();
 	    }
 	    if((((a1215933330 == 12 && a1285669847 == 33) && 127 < a546648771) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(14);
+	    __VERIFIER_error_14();
 	    }
 	    if((((a625666768 == 9 && a816395406 == 14) && a294592648 == 12) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(15);
+	    __VERIFIER_error_15();
 	    }
 	    if((((((-130 < a2072350863) && (11 >= a2072350863)) && ((4 < a1168050593) && (47 >= a1168050593))) && ((41 < a546648771) && (127 >= a546648771))) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(16);
+	    __VERIFIER_error_16();
 	    }
 	    if((((a442756898 == 13 && a1285669847 == 33) && a2018367432 == 7) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(17);
+	    __VERIFIER_error_17();
 	    }
 	    if((((a1282565820 == 34 && a313674417 == 33) && a975683458 == 8) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(18);
+	    __VERIFIER_error_18();
 	    }
 	    if((((a58538015 == 32 && a731633408 <=  -179) && a2018367432 == 6) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(19);
+	    __VERIFIER_error_19();
 	    }
 	    if((((a816395406 == 8 && a1285669847 == 34) && a975683458 == 9) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(20);
+	    __VERIFIER_error_20();
 	    }
 	    if((((((160 < a717693434) && (363 >= a717693434)) && a862153233 == 3) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(21);
+	    __VERIFIER_error_21();
 	    }
 	    if((((a1135244651 == 11 && a1285669847 == 36) && a975683458 == 9) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(22);
+	    __VERIFIER_error_22();
 	    }
 	    if((((a1135244651 == 9 && a1285669847 == 36) && a975683458 == 9) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(23);
+	    __VERIFIER_error_23();
 	    }
 	    if((((a1549796041 == 6 && a973178880 <=  -16) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(24);
+	    __VERIFIER_error_24();
 	    }
 	    if((((a703491081 == 34 && a625666768 == 4) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(25);
+	    __VERIFIER_error_25();
 	    }
 	    if((((a190267953 == 16 && ((98 < a1879861843) && (167 >= a1879861843))) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(26);
+	    __VERIFIER_error_26();
 	    }
 	    if((((((363 < a717693434) && (538 >= a717693434)) && a862153233 == 3) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(27);
+	    __VERIFIER_error_27();
 	    }
 	    if((((465 < a760284733 && a304904416 == 33) && a2018367432 == 11) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(28);
+	    __VERIFIER_error_28();
 	    }
 	    if((((((40 < a1505261326) && (173 >= a1505261326)) && a1256788312 == 32) && a975683458 == 14) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(29);
+	    __VERIFIER_error_29();
 	    }
 	    if((((a1215933330 == 7 && a367648246 == 12) && a2018367432 == 4) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(30);
+	    __VERIFIER_error_30();
 	    }
 	    if((((((225 < a1513923858) && (433 >= a1513923858)) && ((195 < a1496140579) && (321 >= a1496140579))) && a294592648 == 6) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(31);
+	    __VERIFIER_error_31();
 	    }
 	    if((((a1503972580 == 34 && 203 < a973178880) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(32);
+	    __VERIFIER_error_32();
 	    }
 	    if((((479 < a272596777 && ((160 < a717693434) && (363 >= a717693434))) && a2018367432 == 9) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(33);
+	    __VERIFIER_error_33();
 	    }
 	    if((((a183213927 == 35 && a304904416 == 34) && a2018367432 == 11) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(34);
+	    __VERIFIER_error_34();
 	    }
 	    if((((a1135244651 == 9 && 181 < a1168050593) && a975683458 == 10) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(35);
+	    __VERIFIER_error_35();
 	    }
 	    if((((a49225837 <=  128 && a242244780 == 35) && a975683458 == 7) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(36);
+	    __VERIFIER_error_36();
 	    }
 	    if((((a257260181 == 32 && a1046141825 == 13) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(37);
+	    __VERIFIER_error_37();
 	    }
 	    if((((203 < a1479597430 && a862153233 == 6) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(38);
+	    __VERIFIER_error_38();
 	    }
 	    if((((a1189587335 == 36 && ((47 < a1168050593) && (181 >= a1168050593))) && a975683458 == 10) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(39);
+	    __VERIFIER_error_39();
 	    }
 	    if((((90 < a311305031 && a304904416 == 35) && a2018367432 == 11) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(40);
+	    __VERIFIER_error_40();
 	    }
 	    if((((184 < a319268630 && a30507962 == 34) && a294592648 == 8) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(41);
+	    __VERIFIER_error_41();
 	    }
 	    if((((a2140825381 == 35 && a356787592 == 33) && a2018367432 == 5) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(42);
+	    __VERIFIER_error_42();
 	    }
 	    if((((a862153233 == 3 && a356787592 == 36) && a2018367432 == 5) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(43);
+	    __VERIFIER_error_43();
 	    }
 	    if((((a1549796041 == 9 && a973178880 <=  -16) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(44);
+	    __VERIFIER_error_44();
 	    }
 	    if((((a1891728990 == 13 && ((47 < a1168050593) && (181 >= a1168050593))) && ((41 < a546648771) && (127 >= a546648771))) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(45);
+	    __VERIFIER_error_45();
 	    }
 	    if((((a862153233 == 4 && a30507962 == 36) && a294592648 == 8) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(46);
+	    __VERIFIER_error_46();
 	    }
 	    if((((a1763293236 == 32 && a1285669847 == 34) && a294592648 == 7) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(47);
+	    __VERIFIER_error_47();
 	    }
 	    if((((((133 < a1244122343) && (227 >= a1244122343)) && a816395406 == 8) && a294592648 == 12) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(48);
+	    __VERIFIER_error_48();
 	    }
 	    if((((a975683458 == 9 && a1285669847 == 36) && 127 < a546648771) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(49);
+	    __VERIFIER_error_49();
 	    }
 	    if((((a1922940353 == 13 && ((20 < a973178880) && (203 >= a973178880))) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(50);
+	    __VERIFIER_error_50();
 	    }
 	    if((((a55651941 == 16 && a385723351 == 2) && a294592648 == 11) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(51);
+	    __VERIFIER_error_51();
 	    }
 	    if((((a336514165 == 14 && a1285669847 == 35) && a2018367432 == 7) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(52);
+	    __VERIFIER_error_52();
 	    }
 	    if((((a328443163 == 34 && ((-90 < a1805728148) && (-25 >= a1805728148))) && a975683458 == 13) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(53);
+	    __VERIFIER_error_53();
 	    }
 	    if((((a1177994981 == 12 && a1046141825 == 9) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(54);
+	    __VERIFIER_error_54();
 	    }
 	    if((((a862153233 == 1 && ((4 < a1168050593) && (47 >= a1168050593))) && a975683458 == 10) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(55);
+	    __VERIFIER_error_55();
 	    }
 	    if((((a205565187 == 6 && a717693434 <=  160) && a2018367432 == 9) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(56);
+	    __VERIFIER_error_56();
 	    }
 	    if((((-15 < a1636371907 && a1285669847 == 36) && a2018367432 == 7) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(57);
+	    __VERIFIER_error_57();
 	    }
 	    if((((a1215933330 == 9 && a816395406 == 10) && a294592648 == 12) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(58);
+	    __VERIFIER_error_58();
 	    }
 	    if((((a176833629 == 34 && a385723351 == 3) && a294592648 == 11) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(59);
+	    __VERIFIER_error_59();
 	    }
 	    if((((a1277253979 == 6 && a625666768 == 8) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(60);
+	    __VERIFIER_error_60();
 	    }
 	    if((((a2077334123 == 36 && a1285669847 == 32) && a2018367432 == 7) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(61);
+	    __VERIFIER_error_61();
 	    }
 	    if((((a257260181 == 36 && a1046141825 == 13) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(62);
+	    __VERIFIER_error_62();
 	    }
 	    if((((a1140027913 == 32 && 353 < a1879861843) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(63);
+	    __VERIFIER_error_63();
 	    }
 	    if((((a682491669 == 12 && a385723351 == 7) && a294592648 == 11) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(64);
+	    __VERIFIER_error_64();
 	    }
 	    if((((a1140027913 == 33 && 353 < a1879861843) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(65);
+	    __VERIFIER_error_65();
 	    }
 	    if((((a313674417 == 33 && a367648246 == 5) && a2018367432 == 4) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(66);
+	    __VERIFIER_error_66();
 	    }
 	    if((((a428423598 == 3 && a862153233 == 5) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(67);
+	    __VERIFIER_error_67();
 	    }
 	    if((((225 < a602149414 && a1168050593 <=  4) && a975683458 == 10) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(68);
+	    __VERIFIER_error_68();
 	    }
 	    if((((a1513923858 <=  36 && ((195 < a1496140579) && (321 >= a1496140579))) && a294592648 == 6) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(69);
+	    __VERIFIER_error_69();
 	    }
 	    if((((a1502971908 == 7 && a625666768 == 6) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(70);
+	    __VERIFIER_error_70();
 	    }
 	    if((((a205565187 == 8 && a717693434 <=  160) && a2018367432 == 9) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(71);
+	    __VERIFIER_error_71();
 	    }
 	    if((((a1135244651 == 12 && 181 < a1168050593) && a975683458 == 10) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(72);
+	    __VERIFIER_error_72();
 	    }
 	    if((((((124 < a1989731250) && (223 >= a1989731250)) && a304904416 == 36) && a2018367432 == 11) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(73);
+	    __VERIFIER_error_73();
 	    }
 	    if((((((-87 < a319268630) && (-2 >= a319268630)) && a30507962 == 34) && a294592648 == 8) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(74);
+	    __VERIFIER_error_74();
 	    }
 	    if((((a367648246 == 10 && a1046141825 == 6) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(75);
+	    __VERIFIER_error_75();
 	    }
 	    if((((a190267953 == 14 && ((98 < a1879861843) && (167 >= a1879861843))) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(76);
+	    __VERIFIER_error_76();
 	    }
 	    if((((a328443163 == 32 && ((-90 < a1805728148) && (-25 >= a1805728148))) && a975683458 == 13) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(77);
+	    __VERIFIER_error_77();
 	    }
 	    if((((a821574921 == 36 && ((167 < a1879861843) && (353 >= a1879861843))) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(78);
+	    __VERIFIER_error_78();
 	    }
 	    if((((a975683458 == 14 && a1285669847 == 36) && 127 < a546648771) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(79);
+	    __VERIFIER_error_79();
 	    }
 	    if((((a126761446 == 34 && a625666768 == 5) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(80);
+	    __VERIFIER_error_80();
 	    }
 	    if((((a126761446 == 36 && a862153233 == 4) && a975683458 == 12) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(81);
+	    __VERIFIER_error_81();
 	    }
 	    if((((((335 < a49225837) && (379 >= a49225837)) && a242244780 == 35) && a975683458 == 7) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(82);
+	    __VERIFIER_error_82();
 	    }
 	    if((((a442756898 == 10 && ((363 < a717693434) && (538 >= a717693434))) && a2018367432 == 9) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(83);
+	    __VERIFIER_error_83();
 	    }
 	    if((((((131 < a160895057) && (261 >= a160895057)) && a1284123881 == 32) && a2018367432 == 8) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(84);
+	    __VERIFIER_error_84();
 	    }
 	    if((((a1796090926 == 36 && a816395406 == 13) && a294592648 == 12) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(85);
+	    __VERIFIER_error_85();
 	    }
 	    if((((a1922940353 == 14 && ((20 < a973178880) && (203 >= a973178880))) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(86);
+	    __VERIFIER_error_86();
 	    }
 	    if((((a1922940353 == 16 && ((20 < a973178880) && (203 >= a973178880))) && a546648771 <=  -97) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(87);
+	    __VERIFIER_error_87();
 	    }
 	    if((((a827510507 == 34 && a1046141825 == 10) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(88);
+	    __VERIFIER_error_88();
 	    }
 	    if((((a1030932066 == 33 && ((105 < a1336401526) && (201 >= a1336401526))) && ((-97 < a546648771) && (41 >= a546648771))) && 179 < a735614807)){
 	    cf = 0;
-	    __VERIFIER_error(89);
+	    __VERIFIER_error_89();
 	    }
 	    if((((a117461022 <=  142 && a385723351 == 9) && a294592648 == 11) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(90);
+	    __VERIFIER_error_90();
 	    }
 	    if((((a2110564575 == 12 && ((-25 < a1805728148) && (129 >= a1805728148))) && a975683458 == 13) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(91);
+	    __VERIFIER_error_91();
 	    }
 	    if((((a827510507 == 32 && a1046141825 == 10) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(92);
+	    __VERIFIER_error_92();
 	    }
 	    if((((a190267953 == 10 && ((98 < a1879861843) && (167 >= a1879861843))) && a294592648 == 13) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(93);
+	    __VERIFIER_error_93();
 	    }
 	    if((((a1674172007 == 7 && a1046141825 == 11) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(94);
+	    __VERIFIER_error_94();
 	    }
 	    if((((((167 < a1879861843) && (353 >= a1879861843)) && a1046141825 == 12) && a975683458 == 11) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(95);
+	    __VERIFIER_error_95();
 	    }
 	    if((((a1429298572 == 7 && a1285669847 == 35) && a975683458 == 9) && ((-20 < a735614807) && (179 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(96);
+	    __VERIFIER_error_96();
 	    }
 	    if((((a141893458 == 32 && a625666768 == 7) && a294592648 == 10) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(97);
+	    __VERIFIER_error_97();
 	    }
 	    if((((a1789034600 == 36 && a385723351 == 8) && a294592648 == 11) && a735614807 <=  -60)){
 	    cf = 0;
-	    __VERIFIER_error(98);
+	    __VERIFIER_error_98();
 	    }
 	    if((((a2140825381 == 33 && a356787592 == 33) && a2018367432 == 5) && ((-60 < a735614807) && (-20 >= a735614807)))){
 	    cf = 0;
-	    __VERIFIER_error(99);
+	    __VERIFIER_error_99();
 	    }
 	}
  void calculate_outputm29(int input) {

--- a/c/eca-rers2018/properties/createProperties.sh
+++ b/c/eca-rers2018/properties/createProperties.sh
@@ -2,5 +2,5 @@
 
 for i in {0..99};
 do
-  echo "CHECK( init(main()), LTL(G ! call(__VERIFIER_error($i))) )" > unreach-call-$i.prp
+  echo "CHECK( init(main()), LTL(G ! call(__VERIFIER_error_$i())) )" > unreach-call-$i.prp
 done

--- a/c/eca-rers2018/properties/unreach-call-0.prp
+++ b/c/eca-rers2018/properties/unreach-call-0.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(0))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_0())) )

--- a/c/eca-rers2018/properties/unreach-call-1.prp
+++ b/c/eca-rers2018/properties/unreach-call-1.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(1))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_1())) )

--- a/c/eca-rers2018/properties/unreach-call-10.prp
+++ b/c/eca-rers2018/properties/unreach-call-10.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(10))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_10())) )

--- a/c/eca-rers2018/properties/unreach-call-11.prp
+++ b/c/eca-rers2018/properties/unreach-call-11.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(11))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_11())) )

--- a/c/eca-rers2018/properties/unreach-call-12.prp
+++ b/c/eca-rers2018/properties/unreach-call-12.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(12))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_12())) )

--- a/c/eca-rers2018/properties/unreach-call-13.prp
+++ b/c/eca-rers2018/properties/unreach-call-13.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(13))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_13())) )

--- a/c/eca-rers2018/properties/unreach-call-14.prp
+++ b/c/eca-rers2018/properties/unreach-call-14.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(14))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_14())) )

--- a/c/eca-rers2018/properties/unreach-call-15.prp
+++ b/c/eca-rers2018/properties/unreach-call-15.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(15))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_15())) )

--- a/c/eca-rers2018/properties/unreach-call-16.prp
+++ b/c/eca-rers2018/properties/unreach-call-16.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(16))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_16())) )

--- a/c/eca-rers2018/properties/unreach-call-17.prp
+++ b/c/eca-rers2018/properties/unreach-call-17.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(17))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_17())) )

--- a/c/eca-rers2018/properties/unreach-call-18.prp
+++ b/c/eca-rers2018/properties/unreach-call-18.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(18))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_18())) )

--- a/c/eca-rers2018/properties/unreach-call-19.prp
+++ b/c/eca-rers2018/properties/unreach-call-19.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(19))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_19())) )

--- a/c/eca-rers2018/properties/unreach-call-2.prp
+++ b/c/eca-rers2018/properties/unreach-call-2.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(2))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_2())) )

--- a/c/eca-rers2018/properties/unreach-call-20.prp
+++ b/c/eca-rers2018/properties/unreach-call-20.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(20))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_20())) )

--- a/c/eca-rers2018/properties/unreach-call-21.prp
+++ b/c/eca-rers2018/properties/unreach-call-21.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(21))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_21())) )

--- a/c/eca-rers2018/properties/unreach-call-22.prp
+++ b/c/eca-rers2018/properties/unreach-call-22.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(22))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_22())) )

--- a/c/eca-rers2018/properties/unreach-call-23.prp
+++ b/c/eca-rers2018/properties/unreach-call-23.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(23))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_23())) )

--- a/c/eca-rers2018/properties/unreach-call-24.prp
+++ b/c/eca-rers2018/properties/unreach-call-24.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(24))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_24())) )

--- a/c/eca-rers2018/properties/unreach-call-25.prp
+++ b/c/eca-rers2018/properties/unreach-call-25.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(25))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_25())) )

--- a/c/eca-rers2018/properties/unreach-call-26.prp
+++ b/c/eca-rers2018/properties/unreach-call-26.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(26))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_26())) )

--- a/c/eca-rers2018/properties/unreach-call-27.prp
+++ b/c/eca-rers2018/properties/unreach-call-27.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(27))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_27())) )

--- a/c/eca-rers2018/properties/unreach-call-28.prp
+++ b/c/eca-rers2018/properties/unreach-call-28.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(28))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_28())) )

--- a/c/eca-rers2018/properties/unreach-call-29.prp
+++ b/c/eca-rers2018/properties/unreach-call-29.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(29))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_29())) )

--- a/c/eca-rers2018/properties/unreach-call-3.prp
+++ b/c/eca-rers2018/properties/unreach-call-3.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(3))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_3())) )

--- a/c/eca-rers2018/properties/unreach-call-30.prp
+++ b/c/eca-rers2018/properties/unreach-call-30.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(30))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_30())) )

--- a/c/eca-rers2018/properties/unreach-call-31.prp
+++ b/c/eca-rers2018/properties/unreach-call-31.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(31))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_31())) )

--- a/c/eca-rers2018/properties/unreach-call-32.prp
+++ b/c/eca-rers2018/properties/unreach-call-32.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(32))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_32())) )

--- a/c/eca-rers2018/properties/unreach-call-33.prp
+++ b/c/eca-rers2018/properties/unreach-call-33.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(33))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_33())) )

--- a/c/eca-rers2018/properties/unreach-call-34.prp
+++ b/c/eca-rers2018/properties/unreach-call-34.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(34))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_34())) )

--- a/c/eca-rers2018/properties/unreach-call-35.prp
+++ b/c/eca-rers2018/properties/unreach-call-35.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(35))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_35())) )

--- a/c/eca-rers2018/properties/unreach-call-36.prp
+++ b/c/eca-rers2018/properties/unreach-call-36.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(36))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_36())) )

--- a/c/eca-rers2018/properties/unreach-call-37.prp
+++ b/c/eca-rers2018/properties/unreach-call-37.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(37))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_37())) )

--- a/c/eca-rers2018/properties/unreach-call-38.prp
+++ b/c/eca-rers2018/properties/unreach-call-38.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(38))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_38())) )

--- a/c/eca-rers2018/properties/unreach-call-39.prp
+++ b/c/eca-rers2018/properties/unreach-call-39.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(39))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_39())) )

--- a/c/eca-rers2018/properties/unreach-call-4.prp
+++ b/c/eca-rers2018/properties/unreach-call-4.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(4))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_4())) )

--- a/c/eca-rers2018/properties/unreach-call-40.prp
+++ b/c/eca-rers2018/properties/unreach-call-40.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(40))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_40())) )

--- a/c/eca-rers2018/properties/unreach-call-41.prp
+++ b/c/eca-rers2018/properties/unreach-call-41.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(41))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_41())) )

--- a/c/eca-rers2018/properties/unreach-call-42.prp
+++ b/c/eca-rers2018/properties/unreach-call-42.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(42))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_42())) )

--- a/c/eca-rers2018/properties/unreach-call-43.prp
+++ b/c/eca-rers2018/properties/unreach-call-43.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(43))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_43())) )

--- a/c/eca-rers2018/properties/unreach-call-44.prp
+++ b/c/eca-rers2018/properties/unreach-call-44.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(44))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_44())) )

--- a/c/eca-rers2018/properties/unreach-call-45.prp
+++ b/c/eca-rers2018/properties/unreach-call-45.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(45))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_45())) )

--- a/c/eca-rers2018/properties/unreach-call-46.prp
+++ b/c/eca-rers2018/properties/unreach-call-46.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(46))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_46())) )

--- a/c/eca-rers2018/properties/unreach-call-47.prp
+++ b/c/eca-rers2018/properties/unreach-call-47.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(47))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_47())) )

--- a/c/eca-rers2018/properties/unreach-call-48.prp
+++ b/c/eca-rers2018/properties/unreach-call-48.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(48))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_48())) )

--- a/c/eca-rers2018/properties/unreach-call-49.prp
+++ b/c/eca-rers2018/properties/unreach-call-49.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(49))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_49())) )

--- a/c/eca-rers2018/properties/unreach-call-5.prp
+++ b/c/eca-rers2018/properties/unreach-call-5.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(5))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_5())) )

--- a/c/eca-rers2018/properties/unreach-call-50.prp
+++ b/c/eca-rers2018/properties/unreach-call-50.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(50))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_50())) )

--- a/c/eca-rers2018/properties/unreach-call-51.prp
+++ b/c/eca-rers2018/properties/unreach-call-51.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(51))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_51())) )

--- a/c/eca-rers2018/properties/unreach-call-52.prp
+++ b/c/eca-rers2018/properties/unreach-call-52.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(52))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_52())) )

--- a/c/eca-rers2018/properties/unreach-call-53.prp
+++ b/c/eca-rers2018/properties/unreach-call-53.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(53))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_53())) )

--- a/c/eca-rers2018/properties/unreach-call-54.prp
+++ b/c/eca-rers2018/properties/unreach-call-54.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(54))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_54())) )

--- a/c/eca-rers2018/properties/unreach-call-55.prp
+++ b/c/eca-rers2018/properties/unreach-call-55.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(55))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_55())) )

--- a/c/eca-rers2018/properties/unreach-call-56.prp
+++ b/c/eca-rers2018/properties/unreach-call-56.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(56))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_56())) )

--- a/c/eca-rers2018/properties/unreach-call-57.prp
+++ b/c/eca-rers2018/properties/unreach-call-57.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(57))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_57())) )

--- a/c/eca-rers2018/properties/unreach-call-58.prp
+++ b/c/eca-rers2018/properties/unreach-call-58.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(58))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_58())) )

--- a/c/eca-rers2018/properties/unreach-call-59.prp
+++ b/c/eca-rers2018/properties/unreach-call-59.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(59))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_59())) )

--- a/c/eca-rers2018/properties/unreach-call-6.prp
+++ b/c/eca-rers2018/properties/unreach-call-6.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(6))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_6())) )

--- a/c/eca-rers2018/properties/unreach-call-60.prp
+++ b/c/eca-rers2018/properties/unreach-call-60.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(60))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_60())) )

--- a/c/eca-rers2018/properties/unreach-call-61.prp
+++ b/c/eca-rers2018/properties/unreach-call-61.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(61))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_61())) )

--- a/c/eca-rers2018/properties/unreach-call-62.prp
+++ b/c/eca-rers2018/properties/unreach-call-62.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(62))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_62())) )

--- a/c/eca-rers2018/properties/unreach-call-63.prp
+++ b/c/eca-rers2018/properties/unreach-call-63.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(63))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_63())) )

--- a/c/eca-rers2018/properties/unreach-call-64.prp
+++ b/c/eca-rers2018/properties/unreach-call-64.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(64))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_64())) )

--- a/c/eca-rers2018/properties/unreach-call-65.prp
+++ b/c/eca-rers2018/properties/unreach-call-65.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(65))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_65())) )

--- a/c/eca-rers2018/properties/unreach-call-66.prp
+++ b/c/eca-rers2018/properties/unreach-call-66.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(66))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_66())) )

--- a/c/eca-rers2018/properties/unreach-call-67.prp
+++ b/c/eca-rers2018/properties/unreach-call-67.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(67))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_67())) )

--- a/c/eca-rers2018/properties/unreach-call-68.prp
+++ b/c/eca-rers2018/properties/unreach-call-68.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(68))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_68())) )

--- a/c/eca-rers2018/properties/unreach-call-69.prp
+++ b/c/eca-rers2018/properties/unreach-call-69.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(69))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_69())) )

--- a/c/eca-rers2018/properties/unreach-call-7.prp
+++ b/c/eca-rers2018/properties/unreach-call-7.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(7))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_7())) )

--- a/c/eca-rers2018/properties/unreach-call-70.prp
+++ b/c/eca-rers2018/properties/unreach-call-70.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(70))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_70())) )

--- a/c/eca-rers2018/properties/unreach-call-71.prp
+++ b/c/eca-rers2018/properties/unreach-call-71.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(71))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_71())) )

--- a/c/eca-rers2018/properties/unreach-call-72.prp
+++ b/c/eca-rers2018/properties/unreach-call-72.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(72))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_72())) )

--- a/c/eca-rers2018/properties/unreach-call-73.prp
+++ b/c/eca-rers2018/properties/unreach-call-73.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(73))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_73())) )

--- a/c/eca-rers2018/properties/unreach-call-74.prp
+++ b/c/eca-rers2018/properties/unreach-call-74.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(74))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_74())) )

--- a/c/eca-rers2018/properties/unreach-call-75.prp
+++ b/c/eca-rers2018/properties/unreach-call-75.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(75))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_75())) )

--- a/c/eca-rers2018/properties/unreach-call-76.prp
+++ b/c/eca-rers2018/properties/unreach-call-76.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(76))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_76())) )

--- a/c/eca-rers2018/properties/unreach-call-77.prp
+++ b/c/eca-rers2018/properties/unreach-call-77.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(77))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_77())) )

--- a/c/eca-rers2018/properties/unreach-call-78.prp
+++ b/c/eca-rers2018/properties/unreach-call-78.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(78))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_78())) )

--- a/c/eca-rers2018/properties/unreach-call-79.prp
+++ b/c/eca-rers2018/properties/unreach-call-79.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(79))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_79())) )

--- a/c/eca-rers2018/properties/unreach-call-8.prp
+++ b/c/eca-rers2018/properties/unreach-call-8.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(8))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_8())) )

--- a/c/eca-rers2018/properties/unreach-call-80.prp
+++ b/c/eca-rers2018/properties/unreach-call-80.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(80))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_80())) )

--- a/c/eca-rers2018/properties/unreach-call-81.prp
+++ b/c/eca-rers2018/properties/unreach-call-81.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(81))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_81())) )

--- a/c/eca-rers2018/properties/unreach-call-82.prp
+++ b/c/eca-rers2018/properties/unreach-call-82.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(82))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_82())) )

--- a/c/eca-rers2018/properties/unreach-call-83.prp
+++ b/c/eca-rers2018/properties/unreach-call-83.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(83))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_83())) )

--- a/c/eca-rers2018/properties/unreach-call-84.prp
+++ b/c/eca-rers2018/properties/unreach-call-84.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(84))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_84())) )

--- a/c/eca-rers2018/properties/unreach-call-85.prp
+++ b/c/eca-rers2018/properties/unreach-call-85.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(85))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_85())) )

--- a/c/eca-rers2018/properties/unreach-call-86.prp
+++ b/c/eca-rers2018/properties/unreach-call-86.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(86))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_86())) )

--- a/c/eca-rers2018/properties/unreach-call-87.prp
+++ b/c/eca-rers2018/properties/unreach-call-87.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(87))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_87())) )

--- a/c/eca-rers2018/properties/unreach-call-88.prp
+++ b/c/eca-rers2018/properties/unreach-call-88.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(88))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_88())) )

--- a/c/eca-rers2018/properties/unreach-call-89.prp
+++ b/c/eca-rers2018/properties/unreach-call-89.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(89))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_89())) )

--- a/c/eca-rers2018/properties/unreach-call-9.prp
+++ b/c/eca-rers2018/properties/unreach-call-9.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(9))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_9())) )

--- a/c/eca-rers2018/properties/unreach-call-90.prp
+++ b/c/eca-rers2018/properties/unreach-call-90.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(90))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_90())) )

--- a/c/eca-rers2018/properties/unreach-call-91.prp
+++ b/c/eca-rers2018/properties/unreach-call-91.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(91))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_91())) )

--- a/c/eca-rers2018/properties/unreach-call-92.prp
+++ b/c/eca-rers2018/properties/unreach-call-92.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(92))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_92())) )

--- a/c/eca-rers2018/properties/unreach-call-93.prp
+++ b/c/eca-rers2018/properties/unreach-call-93.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(93))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_93())) )

--- a/c/eca-rers2018/properties/unreach-call-94.prp
+++ b/c/eca-rers2018/properties/unreach-call-94.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(94))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_94())) )

--- a/c/eca-rers2018/properties/unreach-call-95.prp
+++ b/c/eca-rers2018/properties/unreach-call-95.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(95))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_95())) )

--- a/c/eca-rers2018/properties/unreach-call-96.prp
+++ b/c/eca-rers2018/properties/unreach-call-96.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(96))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_96())) )

--- a/c/eca-rers2018/properties/unreach-call-97.prp
+++ b/c/eca-rers2018/properties/unreach-call-97.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(97))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_97())) )

--- a/c/eca-rers2018/properties/unreach-call-98.prp
+++ b/c/eca-rers2018/properties/unreach-call-98.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(98))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_98())) )

--- a/c/eca-rers2018/properties/unreach-call-99.prp
+++ b/c/eca-rers2018/properties/unreach-call-99.prp
@@ -1,1 +1,1 @@
-CHECK( init(main()), LTL(G ! call(__VERIFIER_error(99))) )
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error_99())) )


### PR DESCRIPTION
As discussed on Wednesday, we want to avoid `__VERIFIER_error(int)` due to possible mismatches for the function name. Thus we convert the function parameter into an index for the function name. 