### PR TITLE
Imported a deadlocking configuration of the RTEMS lock model.

### DIFF
--- a/java/properties/no-deadlock.prp
+++ b/java/properties/no-deadlock.prp
@@ -1,0 +1,1 @@
+CHECK( init(Main.main()), LTL(G !deadlock) )

--- a/java/rtems-lock-model/lock-00-01-10.yml
+++ b/java/rtems-lock-model/lock-00-01-10.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - lock-00-01-10
+properties:
+  - property_file: ../properties/no-deadlock.prp
+    expected_verdict: false
+

--- a/java/rtems-lock-model/lock-00-01-10/Main.java
+++ b/java/rtems-lock-model/lock-00-01-10/Main.java
@@ -3,7 +3,7 @@
 
 public class Main {
   public final static void main(String[] args) {
-    harness.Environment.main("00", "01", "10");
+    harness.Environment.main(new String[] {"00", "01", "10"});
     // deadlocks
   }
 }

--- a/java/rtems-lock-model/lock-00-01-10/Main.java
+++ b/java/rtems-lock-model/lock-00-01-10/Main.java
@@ -2,8 +2,8 @@
     lock configuration. */
 
 public class Main {
-    public final static void main(String[] args) {
-	harness.Environment.main("00", "01", "10");
-	// deadlocks
-    }
+  public final static void main(String[] args) {
+    harness.Environment.main("00", "01", "10");
+    // deadlocks
+  }
 }

--- a/java/rtems-lock-model/lock-00-01-10/Main.java
+++ b/java/rtems-lock-model/lock-00-01-10/Main.java
@@ -1,0 +1,9 @@
+/** Main method for running RTEMS example (uniproc version) with fixed
+    lock configuration. */
+
+public class Main {
+    public final static void main(String[] args) {
+	harness.Environment.main("00", "01", "10");
+	// deadlocks
+    }
+}

--- a/java/rtems-lock-model/lock-00-01-10/base/Condition.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/Condition.java
@@ -1,0 +1,4 @@
+package base;
+
+public class Condition {
+}

--- a/java/rtems-lock-model/lock-00-01-10/base/Condition.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/Condition.java
@@ -1,4 +1,3 @@
 package base;
 
-public class Condition {
-}
+public class Condition {}

--- a/java/rtems-lock-model/lock-00-01-10/base/Lock.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/Lock.java
@@ -1,0 +1,28 @@
+package base;
+
+public class Lock {
+  Object owner;
+  int count = 0;
+
+  public Condition newCondition() { // stub
+    return new Condition();
+  }
+
+  public synchronized void lock() {
+    while (count != 0 && owner != Thread.currentThread()) {
+      try {
+	wait();
+      } catch (InterruptedException e) {
+      }
+    }
+    owner = Thread.currentThread();
+    count++;
+  }
+
+  public synchronized void unlock() {
+    if (--count == 0) {
+      owner = null;
+      notifyAll();
+    }
+  }
+}

--- a/java/rtems-lock-model/lock-00-01-10/base/Lock.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/Lock.java
@@ -11,7 +11,7 @@ public class Lock {
   public synchronized void lock() {
     while (count != 0 && owner != Thread.currentThread()) {
       try {
-	wait();
+        wait();
       } catch (InterruptedException e) {
       }
     }

--- a/java/rtems-lock-model/lock-00-01-10/base/PrioLock.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/PrioLock.java
@@ -1,0 +1,54 @@
+package base;
+
+import harness.Environment; // for N_THREADS
+
+public class PrioLock extends Lock {
+  Object owner;
+  int count = 0;
+  int topPrio = Integer.MAX_VALUE; // dummy value
+  int waitCount = 0;
+  Thread waitingThreads[] = new Thread[Environment.N_THREADS];
+
+  public void lock() {
+    Thread thisThread = Thread.currentThread();
+    synchronized(this) {
+      updateTopPrio(thisThread);
+      waitingThreads[waitCount++] = thisThread;
+    }
+    int prio = thisThread.getPriority();
+    synchronized(this) {
+      while (count != 0 && owner != thisThread && prio > topPrio) {
+	// cannot obtain lock; wait for unlock
+	try {
+	  wait();
+	} catch (InterruptedException e) {
+	}
+      }
+      owner = Thread.currentThread();
+      count++;
+      for (int i = 0; i < waitCount; i++) {
+	if (waitingThreads[i] == thisThread) { // remove thread from array
+          waitingThreads[i] = waitingThreads[waitCount - 1];
+	  waitingThreads[waitCount - 1] = null;
+        }
+      }
+      waitCount--;
+    }
+  }
+
+  void updateTopPrio(Thread t) { // smaller priority has precedence
+    int prio = t.getPriority();
+    if (prio < topPrio) {
+      topPrio = prio;
+    }
+  }
+
+  public synchronized void unlock() {
+    super.unlock();
+    // update topPrio of waiting threads
+    topPrio = Integer.MAX_VALUE;
+    for (int i = 0; i < waitCount; i++) {
+      updateTopPrio(waitingThreads[i]);
+    }
+  }
+}

--- a/java/rtems-lock-model/lock-00-01-10/base/PrioLock.java
+++ b/java/rtems-lock-model/lock-00-01-10/base/PrioLock.java
@@ -11,25 +11,25 @@ public class PrioLock extends Lock {
 
   public void lock() {
     Thread thisThread = Thread.currentThread();
-    synchronized(this) {
+    synchronized (this) {
       updateTopPrio(thisThread);
       waitingThreads[waitCount++] = thisThread;
     }
     int prio = thisThread.getPriority();
-    synchronized(this) {
+    synchronized (this) {
       while (count != 0 && owner != thisThread && prio > topPrio) {
-	// cannot obtain lock; wait for unlock
-	try {
-	  wait();
-	} catch (InterruptedException e) {
-	}
+        // cannot obtain lock; wait for unlock
+        try {
+          wait();
+        } catch (InterruptedException e) {
+        }
       }
       owner = Thread.currentThread();
       count++;
       for (int i = 0; i < waitCount; i++) {
-	if (waitingThreads[i] == thisThread) { // remove thread from array
+        if (waitingThreads[i] == thisThread) { // remove thread from array
           waitingThreads[i] = waitingThreads[waitCount - 1];
-	  waitingThreads[waitCount - 1] = null;
+          waitingThreads[waitCount - 1] = null;
         }
       }
       waitCount--;

--- a/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
+++ b/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
@@ -27,7 +27,8 @@ public class Environment {
     int prio3 = 2;
     if (Verifier.nondetBoolean()) {
       if (Verifier.nondetBoolean()) {
-        prio1 = 3; prio3 = 1; // 3, 2, 1: all prios differ
+        prio1 = 3;
+        prio3 = 1; // 3, 2, 1: all prios differ
       } else {
         prio3 = 1; // 2, 2, 1: two prios match, one higher
       }
@@ -39,31 +40,31 @@ public class Environment {
     }
     Mutex.setUpdateMethod(model);
     RTEMSThread t0 =
-      new TestThread(new int[]{(int)(new String(args[0]).charAt(0)) - '0',
-			       (int)(new String(args[0]).charAt(1)) - '0'},
-		     prio1);
+        new TestThread(new int[] {(int)(new String(args[0]).charAt(0)) - '0',
+                                  (int)(new String(args[0]).charAt(1)) - '0'},
+                       prio1);
     t0.start();
-    
-    //Creating thread 1 trying to acquire lock 2, lock 0
+
+    // Creating thread 1 trying to acquire lock 2, lock 0
     RTEMSThread t1 =
-      new TestThread(new int[]{(int)(new String(args[1]).charAt(0)) - '0',
-			       (int)(new String(args[1]).charAt(1)) - '0'},
-		     prio2);
+        new TestThread(new int[] {(int)(new String(args[1]).charAt(0)) - '0',
+                                  (int)(new String(args[1]).charAt(1)) - '0'},
+                       prio2);
     t1.start();
 
-    //creating thread 2 trying to acquire lock1, lock2
+    // creating thread 2 trying to acquire lock1, lock2
     RTEMSThread t2 =
-      new TestThread(new int[]{(int)(new String(args[2]).charAt(0)) - '0',
-			       (int)(new String(args[2]).charAt(1)) - '0'},
-		     prio2);
+        new TestThread(new int[] {(int)(new String(args[2]).charAt(0)) - '0',
+                                  (int)(new String(args[2]).charAt(1)) - '0'},
+                       prio2);
     t2.start();
 
-    try{
+    try {
       t0.join();
       t1.join();
       t2.join();
-      }catch(InterruptedException e){
-        e.printStackTrace();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
   }
 }

--- a/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
+++ b/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
@@ -1,0 +1,69 @@
+package harness;
+
+import base.Lock;
+import rtems.Mutex;
+import rtems.RTEMSThread;
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Environment {
+  public final static int N_THREADS = 3;
+  /*
+  Mutex.REC_UPDATE -  for solution model.
+  Mutex.NONREC_UPDATE -  for RTEMS default model.
+  */
+
+  public final static int model = Mutex.REC_UPDATE;
+  static final Lock[] locks = {createLock(0), createLock(1), createLock(2)};
+
+  static Lock createLock(int id) {
+    // factory method to swap out lock impl. in one place
+    return new /*Prio*/Mutex(id);
+  }
+
+  public final static void main(String[] args) {
+    assert(args.length == N_THREADS);
+    int prio1 = 2;
+    int prio2 = 2;
+    int prio3 = 2;
+    if (Verifier.nondetBoolean()) {
+      if (Verifier.nondetBoolean()) {
+        prio1 = 3; prio3 = 1; // 3, 2, 1: all prios differ
+      } else {
+        prio3 = 1; // 2, 2, 1: two prios match, one higher
+      }
+    } else if (Verifier.nondetBoolean()) {
+        prio3 = 3; // 2, 2, 3: two prios match: one lower
+      }// else {
+        // 3: no need to change the defaults 2, 2, 2: all same
+      //}
+    }
+    Mutex.setUpdateMethod(model);
+    RTEMSThread t0 =
+      new TestThread(new int[]{(int)(new String(args[0]).charAt(0)) - '0',
+			       (int)(new String(args[0]).charAt(1)) - '0'},
+		     prio1);
+    t0.start();
+    
+    //Creating thread 1 trying to acquire lock 2, lock 0
+    RTEMSThread t1 =
+      new TestThread(new int[]{(int)(new String(args[1]).charAt(0)) - '0',
+			       (int)(new String(args[1]).charAt(1)) - '0'},
+		     prio2);
+    t1.start();
+
+    //creating thread 2 trying to acquire lock1, lock2
+    RTEMSThread t2 =
+      new TestThread(new int[]{(int)(new String(args[2]).charAt(0)) - '0',
+			       (int)(new String(args[2]).charAt(1)) - '0'},
+		     prio2);
+    t2.start();
+
+    try{
+      t0.join();
+      t1.join();
+      t2.join();
+      }catch(InterruptedException e){
+        e.printStackTrace();
+    }
+  }
+}

--- a/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
+++ b/java/rtems-lock-model/lock-00-01-10/harness/Environment.java
@@ -17,11 +17,11 @@ public class Environment {
 
   static Lock createLock(int id) {
     // factory method to swap out lock impl. in one place
-    return new /*Prio*/Mutex(id);
+    return new Mutex(id);
   }
 
   public final static void main(String[] args) {
-    assert(args.length == N_THREADS);
+    assert args.length == N_THREADS;
     int prio1 = 2;
     int prio2 = 2;
     int prio3 = 2;
@@ -32,11 +32,8 @@ public class Environment {
       } else {
         prio3 = 1; // 2, 2, 1: two prios match, one higher
       }
-    } else if (Verifier.nondetBoolean()) {
-        prio3 = 3; // 2, 2, 3: two prios match: one lower
-      }// else {
-        // 3: no need to change the defaults 2, 2, 2: all same
-      //}
+    } else {
+      prio3 = 3; // 2, 2, 3: two prios match: one lower
     }
     Mutex.setUpdateMethod(model);
     RTEMSThread t0 =

--- a/java/rtems-lock-model/lock-00-01-10/harness/TestThread.java
+++ b/java/rtems-lock-model/lock-00-01-10/harness/TestThread.java
@@ -21,9 +21,9 @@ public class TestThread extends RTEMSThread {
     for (int i = 0; i < idx.length; i++) {
       locks[i].lock();
     }
-    for (int i = idx.length-1; i>= 0; i--) {
+    for (int i = idx.length - 1; i >= 0; i--) {
       locks[i].unlock();
     }
-    assert currentPriority==realPriority;
+    assert currentPriority == realPriority;
   }
 }

--- a/java/rtems-lock-model/lock-00-01-10/harness/TestThread.java
+++ b/java/rtems-lock-model/lock-00-01-10/harness/TestThread.java
@@ -1,0 +1,29 @@
+package harness;
+
+import base.Lock;
+
+import rtems.RTEMSThread;
+
+public class TestThread extends RTEMSThread {
+  int idx[]; // for simpler diagnosis later (if I get some help on JPF)
+  Lock locks[];
+
+  public TestThread(int lockIdx[], int priority) {
+    super(priority);
+    idx = lockIdx;
+    locks = new Lock[idx.length];
+    for (int i = 0; i < idx.length; i++) {
+      locks[i] = Environment.locks[idx[i]];
+    }
+  }
+
+  public void run() {
+    for (int i = 0; i < idx.length; i++) {
+      locks[i].lock();
+    }
+    for (int i = idx.length-1; i>= 0; i--) {
+      locks[i].unlock();
+    }
+    assert currentPriority==realPriority;
+  }
+}

--- a/java/rtems-lock-model/lock-00-01-10/rtems/Mutex.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/Mutex.java
@@ -1,0 +1,331 @@
+package rtems;
+import base.Lock;
+import base.Condition;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Iterator;
+import gov.nasa.jpf.vm.Verify;
+
+public class Mutex extends Lock {
+	RTEMSThread holder; /*! It is the thread holding this mutex*/
+	int id; /*! It is the ID of this mutex*/
+	int nestCount; /*! It records the nesting count for re-entrant locking*/
+	int priorityBefore=-1; /*! Its value is set to current priority of the
+	 	thread when acquiring this mutex. We need this to ensure proper 
+	 	stepping of the priorities*/
+	MyComparator comparator = new MyComparator(); /*! It places waiting thread
+	 	in priorityQueue based on thread priority*/
+	PriorityQueue<RTEMSThread> waitQueue = 
+		new PriorityQueue<RTEMSThread>(7, comparator); /*! It is the waiting 
+	 	queue for the blocked threads based on priorities of the thread.*/
+	public static final int REC_UPDATE = 1; /*! This model solves the problem
+	 	of priority inversion*/
+  	public static final int NONREC_UPDATE = 0; /*! This model reproduces RTEMS 
+  		problem of priority inversion for priority inheritance discipline*/
+	public static int USE_MODEL=NONREC_UPDATE; /*! Indicates the current model
+	 	of execution of process*/
+
+	public Mutex(int idx){
+
+		this.id = idx;
+		this.nestCount = 0;
+		this.priorityBefore = -1;
+		this.holder=null;
+	}
+
+	/**
+	* Brief It selects the model for execution of program.
+	*
+	* @param[in] method We update the priorities based on method.
+	* For now there are only 3 methods Recursive and Non-Recursive. 
+	* Recursive model addresses the problem of priority inversion and
+	* Non-Recursive model is the default RTEMS model to show that there
+	* exists priority inversion problem.
+	*/
+	public static void setUpdateMethod(int method)
+	{
+		USE_MODEL = method;
+	}
+
+	/**
+	* Brief It is the routine to acquire mutex.
+	*
+	* Executing thread calls this routine to acquire the mutex. If mutex is 
+	* available then it is handed over to thread and the mutex object is 
+	* pushed to the thread's mutexOrderList. Current priority of the
+	* thread is stored in priorityBefore of the mutex to ensure proper step-
+	* down of the priority at the time of release of the mutex. If the mutex is 
+	* already blocked then the thread is pushed to waiting Queue of this mutex.
+	*
+	*/
+	public void lock() {
+		synchronized(this)
+		{
+			RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+
+			while((holder!=null) && (holder!=thisThread))
+			{
+					
+					try{
+							Verify.beginAtomic();
+								assert (thisThread.currentPriority == thisThread.getPriority());
+								thisThread.state = Thread.State.WAITING;
+								updatePriority(thisThread.currentPriority);
+								if(waitQueue.contains(thisThread)==false){
+									System.out.println("Adding thread :" + thisThread.getId() + " in waitQ of mutex: "+id);
+									waitQueue.offer(thisThread);
+								}
+								thisThread.wait = waitQueue;
+								thisThread.trylock = this;
+							Verify.endAtomic();
+						wait();
+
+						}catch (InterruptedException e) 
+					{}
+				
+			}
+			assert thisThread.getState() != Thread.State.WAITING;
+			if(holder==null)
+			{
+				
+				holder = thisThread;
+				holder.pushMutex(this);
+				assert nestCount==0;
+				
+			}
+			nestCount++;
+			thisThread.resourceCount++;
+		}
+	}
+
+	/**
+	* Brief This routine releases mutex.
+	* 
+	* On release of mutex, we properly set the current priority of thread
+	* releasing the mutex. If there are more thread waiting, then top
+	* waiting priority thread is set as the new holder of the mutex and is
+	* notified.
+	*
+	*/
+	public void unlock() {
+		Mutex topMutex=null;
+		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+		RTEMSThread candidateThr;
+		int stepdownPri;
+		synchronized(this)            //trylock
+		{
+
+
+			assert nestCount>0;
+			assert thisThread.resourceCount>0;
+			nestCount--;
+			thisThread.resourceCount--;
+			if(nestCount==0)
+			{
+				Verify.beginAtomic();
+				topMutex = thisThread.mutexOrderList.get(0);
+				assert this==topMutex;		
+				topMutex = thisThread.mutexOrderList.remove(0);
+				thisThread.setPriority(priorityBefore);
+				thisThread.currentPriority = priorityBefore;	
+			
+				assert holder!=null;
+				assert holder.wait==null;
+				assert holder.trylock==null;
+				holder = waitQueue.poll();			
+				Verify.endAtomic();
+
+				if(holder != null)
+				{
+					assert holder.state==Thread.State.WAITING;
+					holder.state = Thread.State.RUNNABLE;
+					holder.wait = null;
+					holder.trylock = null;
+					holder.pushMutex(this);	
+				
+					notifyAll();							
+				
+				}
+				else
+				{
+					holder = null;
+				}
+			
+			}
+			validator();
+		}
+					
+	}
+
+	/**
+	* Brief It validates whether there exists priority inversion in system.
+	*
+	* This is routine is coupled with unlock to ensure that on release of
+	* mutex there is proper stepping of priority of releasing thread. 
+	* If there exists priority inversion then program will stop with
+	* giving assertion error.
+	*/
+	public void validator(){
+		RTEMSThread chkThr;
+		Mutex chkMtx;
+		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+		synchronized(this)
+		{
+			Iterator<Mutex> mItr = thisThread.mutexOrderList.iterator();
+			while (mItr.hasNext()){
+				chkMtx = mItr.next();
+				synchronized(chkMtx)
+				{
+					System.out.println("--->Mutex: "+chkMtx.id);
+					chkThr = chkMtx.waitQueue.peek();	
+					
+						if(chkThr!=null)
+						{
+							System.out.println("------>Thread-id: "+ chkThr.getId()+" priority: "+ chkThr.getPriority());
+							assert (thisThread.getPriority()<=chkThr.getPriority());	
+						}
+				}
+				
+				
+			}
+		}
+	}
+
+	/**
+	* Brief It updates the priority of holder thread if required.
+	* 
+	* It calls specific update procefure based on the set method
+	* (recursive or non-recursive).
+	*/
+	public void updatePriority(int priority)
+	{
+
+		RTEMSThread trylockHolder;
+		int preUpdateHolderPriority = holder.currentPriority;
+		int postUdateHolderPriority = -1;
+		boolean success=false;
+		if(USE_MODEL==REC_UPDATE)
+		{
+			updateRecPriority(priority);
+		}
+		else
+		{
+			updateNonRecPriority(priority);
+		}
+		postUdateHolderPriority = holder.currentPriority;
+		/*
+		We cand avoid idempotent operations when holder.currentPriority did not got changed 
+		by the current executing thread when holder is waiting. As current priority of holder remains same then
+		what is the point in stepping below code flow because holder while acquring its trylock would have 
+		already gone through updateRecPriority procedure.
+		*/
+
+		if((holder.wait!=null) &&(preUpdateHolderPriority!=postUdateHolderPriority)){ 
+			
+			assert holder.trylock!=null;
+			trylockHolder = holder.trylock.holder;
+
+			success = reEnqueue();
+			if(success)
+			{
+				//if not success then holder has been selected as new candidate thread by holder.trylock.holder
+				holder.trylock.updatePriority(holder.currentPriority);
+			}
+			
+		}
+
+	}
+
+	/**
+	* Brief It just updates current priority of holder thread.
+	* 
+	* It updates current priority of the holder thread if it is
+    * less than executing thread trying to acquire this mutex.
+	*/
+	public void updateNonRecPriority(int priority)
+	{
+		if(holder.currentPriority > priority){
+		holder.currentPriority = priority;
+		holder.setPriority(priority);
+		}
+
+	}
+
+	/**
+	* Brief It updates priority recursively.
+	* 
+	* It goes through the list of acquired mutex by the holder thread,
+	* from the current mutex index to the topmost mutex in the list and
+	* checks whether there is need to change the priorityBefore of the 
+	* acquired mutex by the holder thread.
+	*/
+	public void updateRecPriority(int priority)
+	{
+		int i;
+		Mutex candidate;
+		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+		int mutexIdx = this.holder.getMutexIndex(this);
+		int stopflag = 0;
+		assert this.holder!=null;	
+		assert this.holder!= thisThread;	
+		//Assertion check
+		//assert mutexIdx!=-1;
+		if(!(mutexIdx==-1))
+		{
+			//This case will happen when thread calls unlock and pops the mutex but didn't got the chance to reassign the 
+			//newholder
+			for(i=mutexIdx-1;i>=0;i--)
+			{
+				candidate = holder.mutexOrderList.get(i);
+				if(candidate.priorityBefore < priority){
+					stopflag = 1;
+					break;
+				}
+				candidate.priorityBefore = priority;	
+				
+			}
+			if(stopflag==0)
+			{
+				if(holder.currentPriority > priority)
+				{
+					holder.currentPriority = priority;
+					holder.setPriority(priority);	
+				}	
+					
+			}
+		}
+		
+				
+	}
+	
+	/**
+	* Brief This routine is re-enqueue's the holder thread waiting 
+	* on any mutex.
+	*
+	* If executing thread promotes current priority of the holder thread
+	* and if holder thread is waiting on someother mutex then we update the 
+	* position of holder thread in waitqueue based on new current priority.
+	*/
+	public boolean reEnqueue()
+	{
+		PriorityQueue<RTEMSThread> pqueue;
+		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+		pqueue = holder.wait;
+		if(pqueue.contains(holder)==true)
+		{
+			pqueue.remove(holder);
+			pqueue.offer(holder);	
+			return true;
+		}
+		return false;
+	}
+}
+
+class MyComparator implements Comparator<RTEMSThread>
+{
+	@Override
+	public int compare(RTEMSThread t1, RTEMSThread t2)
+	{
+		return t1.getPriority() - t2.getPriority();
+	}
+}

--- a/java/rtems-lock-model/lock-00-01-10/rtems/Mutex.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/Mutex.java
@@ -7,325 +7,291 @@ import java.util.Iterator;
 import gov.nasa.jpf.vm.Verify;
 
 public class Mutex extends Lock {
-	RTEMSThread holder; /*! It is the thread holding this mutex*/
-	int id; /*! It is the ID of this mutex*/
-	int nestCount; /*! It records the nesting count for re-entrant locking*/
-	int priorityBefore=-1; /*! Its value is set to current priority of the
-	 	thread when acquiring this mutex. We need this to ensure proper 
-	 	stepping of the priorities*/
-	MyComparator comparator = new MyComparator(); /*! It places waiting thread
-	 	in priorityQueue based on thread priority*/
-	PriorityQueue<RTEMSThread> waitQueue = 
-		new PriorityQueue<RTEMSThread>(7, comparator); /*! It is the waiting 
-	 	queue for the blocked threads based on priorities of the thread.*/
-	public static final int REC_UPDATE = 1; /*! This model solves the problem
-	 	of priority inversion*/
-  	public static final int NONREC_UPDATE = 0; /*! This model reproduces RTEMS 
-  		problem of priority inversion for priority inheritance discipline*/
-	public static int USE_MODEL=NONREC_UPDATE; /*! Indicates the current model
-	 	of execution of process*/
+  RTEMSThread holder; /*! It is the thread holding this mutex*/
+  int id;             /*! It is the ID of this mutex*/
+  int nestCount;      /*! It records the nesting count for re-entrant locking*/
+  int priorityBefore = -1; /*! Its value is set to current priority of the
+            thread when acquiring this mutex. We need this to ensure proper
+            stepping of the priorities*/
+  MyComparator comparator = new MyComparator(); /*! It places waiting thread
+          in priorityQueue based on thread priority*/
+  PriorityQueue<RTEMSThread> waitQueue =
+      new PriorityQueue<RTEMSThread>(7, comparator); /*! It is the waiting
+      queue for the blocked threads based on priorities of the thread.*/
+  public static final int REC_UPDATE = 1;      /*! This model solves the problem
+               of priority inversion*/
+  public static final int NONREC_UPDATE = 0;   /*! This model reproduces RTEMS
+            problem of priority inversion for priority inheritance discipline*/
+  public static int USE_MODEL = NONREC_UPDATE; /*! Indicates the current model
+            of execution of process*/
 
-	public Mutex(int idx){
+  public Mutex(int idx) {
 
-		this.id = idx;
-		this.nestCount = 0;
-		this.priorityBefore = -1;
-		this.holder=null;
-	}
+    this.id = idx;
+    this.nestCount = 0;
+    this.priorityBefore = -1;
+    this.holder = null;
+  }
 
-	/**
-	* Brief It selects the model for execution of program.
-	*
-	* @param[in] method We update the priorities based on method.
-	* For now there are only 3 methods Recursive and Non-Recursive. 
-	* Recursive model addresses the problem of priority inversion and
-	* Non-Recursive model is the default RTEMS model to show that there
-	* exists priority inversion problem.
-	*/
-	public static void setUpdateMethod(int method)
-	{
-		USE_MODEL = method;
-	}
+  /**
+  * Brief It selects the model for execution of program.
+  *
+  * @param[in] method We update the priorities based on method.
+  * For now there are only 3 methods Recursive and Non-Recursive.
+  * Recursive model addresses the problem of priority inversion and
+  * Non-Recursive model is the default RTEMS model to show that there
+  * exists priority inversion problem.
+  */
+  public static void setUpdateMethod(int method) { USE_MODEL = method; }
 
-	/**
-	* Brief It is the routine to acquire mutex.
-	*
-	* Executing thread calls this routine to acquire the mutex. If mutex is 
-	* available then it is handed over to thread and the mutex object is 
-	* pushed to the thread's mutexOrderList. Current priority of the
-	* thread is stored in priorityBefore of the mutex to ensure proper step-
-	* down of the priority at the time of release of the mutex. If the mutex is 
-	* already blocked then the thread is pushed to waiting Queue of this mutex.
-	*
-	*/
-	public void lock() {
-		synchronized(this)
-		{
-			RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+  /**
+  * Brief It is the routine to acquire mutex.
+  *
+  * Executing thread calls this routine to acquire the mutex. If mutex is
+  * available then it is handed over to thread and the mutex object is
+  * pushed to the thread's mutexOrderList. Current priority of the
+  * thread is stored in priorityBefore of the mutex to ensure proper step-
+  * down of the priority at the time of release of the mutex. If the mutex is
+  * already blocked then the thread is pushed to waiting Queue of this mutex.
+  *
+  */
+  public void lock() {
+    synchronized (this) {
+      RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
 
-			while((holder!=null) && (holder!=thisThread))
-			{
-					
-					try{
-							Verify.beginAtomic();
-								assert (thisThread.currentPriority == thisThread.getPriority());
-								thisThread.state = Thread.State.WAITING;
-								updatePriority(thisThread.currentPriority);
-								if(waitQueue.contains(thisThread)==false){
-									System.out.println("Adding thread :" + thisThread.getId() + " in waitQ of mutex: "+id);
-									waitQueue.offer(thisThread);
-								}
-								thisThread.wait = waitQueue;
-								thisThread.trylock = this;
-							Verify.endAtomic();
-						wait();
+      while ((holder != null) && (holder != thisThread)) {
 
-						}catch (InterruptedException e) 
-					{}
-				
-			}
-			assert thisThread.getState() != Thread.State.WAITING;
-			if(holder==null)
-			{
-				
-				holder = thisThread;
-				holder.pushMutex(this);
-				assert nestCount==0;
-				
-			}
-			nestCount++;
-			thisThread.resourceCount++;
-		}
-	}
+        try {
+          Verify.beginAtomic();
+          assert(thisThread.currentPriority == thisThread.getPriority());
+          thisThread.state = Thread.State.WAITING;
+          updatePriority(thisThread.currentPriority);
+          if (waitQueue.contains(thisThread) == false) {
+            System.out.println("Adding thread :" + thisThread.getId() +
+                               " in waitQ of mutex: " + id);
+            waitQueue.offer(thisThread);
+          }
+          thisThread.wait = waitQueue;
+          thisThread.trylock = this;
+          Verify.endAtomic();
+          wait();
 
-	/**
-	* Brief This routine releases mutex.
-	* 
-	* On release of mutex, we properly set the current priority of thread
-	* releasing the mutex. If there are more thread waiting, then top
-	* waiting priority thread is set as the new holder of the mutex and is
-	* notified.
-	*
-	*/
-	public void unlock() {
-		Mutex topMutex=null;
-		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
-		RTEMSThread candidateThr;
-		int stepdownPri;
-		synchronized(this)            //trylock
-		{
+        } catch (InterruptedException e) {
+        }
+      }
+      assert thisThread.getState() != Thread.State.WAITING;
+      if (holder == null) {
 
+        holder = thisThread;
+        holder.pushMutex(this);
+        assert nestCount == 0;
+      }
+      nestCount++;
+      thisThread.resourceCount++;
+    }
+  }
 
-			assert nestCount>0;
-			assert thisThread.resourceCount>0;
-			nestCount--;
-			thisThread.resourceCount--;
-			if(nestCount==0)
-			{
-				Verify.beginAtomic();
-				topMutex = thisThread.mutexOrderList.get(0);
-				assert this==topMutex;		
-				topMutex = thisThread.mutexOrderList.remove(0);
-				thisThread.setPriority(priorityBefore);
-				thisThread.currentPriority = priorityBefore;	
-			
-				assert holder!=null;
-				assert holder.wait==null;
-				assert holder.trylock==null;
-				holder = waitQueue.poll();			
-				Verify.endAtomic();
+  /**
+  * Brief This routine releases mutex.
+  *
+  * On release of mutex, we properly set the current priority of thread
+  * releasing the mutex. If there are more thread waiting, then top
+  * waiting priority thread is set as the new holder of the mutex and is
+  * notified.
+  *
+  */
+  public void unlock() {
+    Mutex topMutex = null;
+    RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+    RTEMSThread candidateThr;
+    int stepdownPri;
+    synchronized (this) // trylock
+    {
 
-				if(holder != null)
-				{
-					assert holder.state==Thread.State.WAITING;
-					holder.state = Thread.State.RUNNABLE;
-					holder.wait = null;
-					holder.trylock = null;
-					holder.pushMutex(this);	
-				
-					notifyAll();							
-				
-				}
-				else
-				{
-					holder = null;
-				}
-			
-			}
-			validator();
-		}
-					
-	}
+      assert nestCount > 0;
+      assert thisThread.resourceCount > 0;
+      nestCount--;
+      thisThread.resourceCount--;
+      if (nestCount == 0) {
+        Verify.beginAtomic();
+        topMutex = thisThread.mutexOrderList.get(0);
+        assert this == topMutex;
+        topMutex = thisThread.mutexOrderList.remove(0);
+        thisThread.setPriority(priorityBefore);
+        thisThread.currentPriority = priorityBefore;
 
-	/**
-	* Brief It validates whether there exists priority inversion in system.
-	*
-	* This is routine is coupled with unlock to ensure that on release of
-	* mutex there is proper stepping of priority of releasing thread. 
-	* If there exists priority inversion then program will stop with
-	* giving assertion error.
-	*/
-	public void validator(){
-		RTEMSThread chkThr;
-		Mutex chkMtx;
-		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
-		synchronized(this)
-		{
-			Iterator<Mutex> mItr = thisThread.mutexOrderList.iterator();
-			while (mItr.hasNext()){
-				chkMtx = mItr.next();
-				synchronized(chkMtx)
-				{
-					System.out.println("--->Mutex: "+chkMtx.id);
-					chkThr = chkMtx.waitQueue.peek();	
-					
-						if(chkThr!=null)
-						{
-							System.out.println("------>Thread-id: "+ chkThr.getId()+" priority: "+ chkThr.getPriority());
-							assert (thisThread.getPriority()<=chkThr.getPriority());	
-						}
-				}
-				
-				
-			}
-		}
-	}
+        assert holder != null;
+        assert holder.wait == null;
+        assert holder.trylock == null;
+        holder = waitQueue.poll();
+        Verify.endAtomic();
 
-	/**
-	* Brief It updates the priority of holder thread if required.
-	* 
-	* It calls specific update procefure based on the set method
-	* (recursive or non-recursive).
-	*/
-	public void updatePriority(int priority)
-	{
+        if (holder != null) {
+          assert holder.state == Thread.State.WAITING;
+          holder.state = Thread.State.RUNNABLE;
+          holder.wait = null;
+          holder.trylock = null;
+          holder.pushMutex(this);
 
-		RTEMSThread trylockHolder;
-		int preUpdateHolderPriority = holder.currentPriority;
-		int postUdateHolderPriority = -1;
-		boolean success=false;
-		if(USE_MODEL==REC_UPDATE)
-		{
-			updateRecPriority(priority);
-		}
-		else
-		{
-			updateNonRecPriority(priority);
-		}
-		postUdateHolderPriority = holder.currentPriority;
-		/*
-		We cand avoid idempotent operations when holder.currentPriority did not got changed 
-		by the current executing thread when holder is waiting. As current priority of holder remains same then
-		what is the point in stepping below code flow because holder while acquring its trylock would have 
-		already gone through updateRecPriority procedure.
-		*/
+          notifyAll();
 
-		if((holder.wait!=null) &&(preUpdateHolderPriority!=postUdateHolderPriority)){ 
-			
-			assert holder.trylock!=null;
-			trylockHolder = holder.trylock.holder;
+        } else {
+          holder = null;
+        }
+      }
+      validator();
+    }
+  }
 
-			success = reEnqueue();
-			if(success)
-			{
-				//if not success then holder has been selected as new candidate thread by holder.trylock.holder
-				holder.trylock.updatePriority(holder.currentPriority);
-			}
-			
-		}
+  /**
+  * Brief It validates whether there exists priority inversion in system.
+  *
+  * This is routine is coupled with unlock to ensure that on release of
+  * mutex there is proper stepping of priority of releasing thread.
+  * If there exists priority inversion then program will stop with
+  * giving assertion error.
+  */
+  public void validator() {
+    RTEMSThread chkThr;
+    Mutex chkMtx;
+    RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+    synchronized (this) {
+      Iterator<Mutex> mItr = thisThread.mutexOrderList.iterator();
+      while (mItr.hasNext()) {
+        chkMtx = mItr.next();
+        synchronized (chkMtx) {
+          System.out.println("--->Mutex: " + chkMtx.id);
+          chkThr = chkMtx.waitQueue.peek();
 
-	}
+          if (chkThr != null) {
+            System.out.println("------>Thread-id: " + chkThr.getId() +
+                               " priority: " + chkThr.getPriority());
+            assert(thisThread.getPriority() <= chkThr.getPriority());
+          }
+        }
+      }
+    }
+  }
 
-	/**
-	* Brief It just updates current priority of holder thread.
-	* 
-	* It updates current priority of the holder thread if it is
-    * less than executing thread trying to acquire this mutex.
-	*/
-	public void updateNonRecPriority(int priority)
-	{
-		if(holder.currentPriority > priority){
-		holder.currentPriority = priority;
-		holder.setPriority(priority);
-		}
+  /**
+  * Brief It updates the priority of holder thread if required.
+  *
+  * It calls specific update procefure based on the set method
+  * (recursive or non-recursive).
+  */
+  public void updatePriority(int priority) {
 
-	}
+    RTEMSThread trylockHolder;
+    int preUpdateHolderPriority = holder.currentPriority;
+    int postUdateHolderPriority = -1;
+    boolean success = false;
+    if (USE_MODEL == REC_UPDATE) {
+      updateRecPriority(priority);
+    } else {
+      updateNonRecPriority(priority);
+    }
+    postUdateHolderPriority = holder.currentPriority;
+    /*
+    We cand avoid idempotent operations when holder.currentPriority did not got
+    changed
+    by the current executing thread when holder is waiting. As current priority
+    of holder remains same then
+    what is the point in stepping below code flow because holder while acquring
+    its trylock would have
+    already gone through updateRecPriority procedure.
+    */
 
-	/**
-	* Brief It updates priority recursively.
-	* 
-	* It goes through the list of acquired mutex by the holder thread,
-	* from the current mutex index to the topmost mutex in the list and
-	* checks whether there is need to change the priorityBefore of the 
-	* acquired mutex by the holder thread.
-	*/
-	public void updateRecPriority(int priority)
-	{
-		int i;
-		Mutex candidate;
-		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
-		int mutexIdx = this.holder.getMutexIndex(this);
-		int stopflag = 0;
-		assert this.holder!=null;	
-		assert this.holder!= thisThread;	
-		//Assertion check
-		//assert mutexIdx!=-1;
-		if(!(mutexIdx==-1))
-		{
-			//This case will happen when thread calls unlock and pops the mutex but didn't got the chance to reassign the 
-			//newholder
-			for(i=mutexIdx-1;i>=0;i--)
-			{
-				candidate = holder.mutexOrderList.get(i);
-				if(candidate.priorityBefore < priority){
-					stopflag = 1;
-					break;
-				}
-				candidate.priorityBefore = priority;	
-				
-			}
-			if(stopflag==0)
-			{
-				if(holder.currentPriority > priority)
-				{
-					holder.currentPriority = priority;
-					holder.setPriority(priority);	
-				}	
-					
-			}
-		}
-		
-				
-	}
-	
-	/**
-	* Brief This routine is re-enqueue's the holder thread waiting 
-	* on any mutex.
-	*
-	* If executing thread promotes current priority of the holder thread
-	* and if holder thread is waiting on someother mutex then we update the 
-	* position of holder thread in waitqueue based on new current priority.
-	*/
-	public boolean reEnqueue()
-	{
-		PriorityQueue<RTEMSThread> pqueue;
-		RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
-		pqueue = holder.wait;
-		if(pqueue.contains(holder)==true)
-		{
-			pqueue.remove(holder);
-			pqueue.offer(holder);	
-			return true;
-		}
-		return false;
-	}
+    if ((holder.wait != null) &&
+        (preUpdateHolderPriority != postUdateHolderPriority)) {
+
+      assert holder.trylock != null;
+      trylockHolder = holder.trylock.holder;
+
+      success = reEnqueue();
+      if (success) {
+        // if not success then holder has been selected as new candidate thread
+        // by holder.trylock.holder
+        holder.trylock.updatePriority(holder.currentPriority);
+      }
+    }
+  }
+
+  /**
+  * Brief It just updates current priority of holder thread.
+  *
+  * It updates current priority of the holder thread if it is
+* less than executing thread trying to acquire this mutex.
+  */
+  public void updateNonRecPriority(int priority) {
+    if (holder.currentPriority > priority) {
+      holder.currentPriority = priority;
+      holder.setPriority(priority);
+    }
+  }
+
+  /**
+  * Brief It updates priority recursively.
+  *
+  * It goes through the list of acquired mutex by the holder thread,
+  * from the current mutex index to the topmost mutex in the list and
+  * checks whether there is need to change the priorityBefore of the
+  * acquired mutex by the holder thread.
+  */
+  public void updateRecPriority(int priority) {
+    int i;
+    Mutex candidate;
+    RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+    int mutexIdx = this.holder.getMutexIndex(this);
+    int stopflag = 0;
+    assert this.holder != null;
+    assert this.holder != thisThread;
+    // Assertion check
+    // assert mutexIdx!=-1;
+    if (!(mutexIdx == -1)) {
+      // This case will happen when thread calls unlock and pops the mutex but
+      // didn't got the chance to reassign the
+      // newholder
+      for (i = mutexIdx - 1; i >= 0; i--) {
+        candidate = holder.mutexOrderList.get(i);
+        if (candidate.priorityBefore < priority) {
+          stopflag = 1;
+          break;
+        }
+        candidate.priorityBefore = priority;
+      }
+      if (stopflag == 0) {
+        if (holder.currentPriority > priority) {
+          holder.currentPriority = priority;
+          holder.setPriority(priority);
+        }
+      }
+    }
+  }
+
+  /**
+  * Brief This routine is re-enqueue's the holder thread waiting
+  * on any mutex.
+  *
+  * If executing thread promotes current priority of the holder thread
+  * and if holder thread is waiting on someother mutex then we update the
+  * position of holder thread in waitqueue based on new current priority.
+  */
+  public boolean reEnqueue() {
+    PriorityQueue<RTEMSThread> pqueue;
+    RTEMSThread thisThread = (RTEMSThread)Thread.currentThread();
+    pqueue = holder.wait;
+    if (pqueue.contains(holder) == true) {
+      pqueue.remove(holder);
+      pqueue.offer(holder);
+      return true;
+    }
+    return false;
+  }
 }
 
-class MyComparator implements Comparator<RTEMSThread>
-{
-	@Override
-	public int compare(RTEMSThread t1, RTEMSThread t2)
-	{
-		return t1.getPriority() - t2.getPriority();
-	}
+class MyComparator implements Comparator<RTEMSThread> {
+  @Override
+  public int compare(RTEMSThread t1, RTEMSThread t2) {
+    return t1.getPriority() - t2.getPriority();
+  }
 }

--- a/java/rtems-lock-model/lock-00-01-10/rtems/OrderList.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/OrderList.java
@@ -1,0 +1,7 @@
+package rtems;
+
+public class OrderList{
+	//This class is not functional yet. This OrderList was created for
+	//implementing a list of mutex per thread object. or current implementation
+	//we simply use in-built java's array list to store the mutex objects.
+}

--- a/java/rtems-lock-model/lock-00-01-10/rtems/OrderList.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/OrderList.java
@@ -1,7 +1,7 @@
 package rtems;
 
-public class OrderList{
-	//This class is not functional yet. This OrderList was created for
-	//implementing a list of mutex per thread object. or current implementation
-	//we simply use in-built java's array list to store the mutex objects.
+public class OrderList {
+  // This class is not functional yet. This OrderList was created for
+  // implementing a list of mutex per thread object. or current implementation
+  // we simply use in-built java's array list to store the mutex objects.
 }

--- a/java/rtems-lock-model/lock-00-01-10/rtems/RTEMSThread.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/RTEMSThread.java
@@ -6,91 +6,85 @@ import java.util.PriorityQueue;
 
 public class RTEMSThread extends Thread {
   // TODO: add extra priority field etc.
-	public PriorityQueue<RTEMSThread> wait; /*! It points to waitqueue of 
-	 	mutex on which this thread is blocked.*/
-	public int resourceCount; /*! It is the count of resources held 
-	 	by this thread. For now just acquired mutex count*/
-	public Thread.State state; /*! Reflects the state of the thread
-		based on standard Thread implementation*/
-	public int currentPriority; /*! It is the current priority of the thread*/
-	public int realPriority; /*! It is the priority of thread at its creation
-		time*/
-	public List<Mutex> mutexOrderList; /*! List of acquired 
-		mutex by the thread by the course of time*/
-	public Mutex trylock; /*! References to mutex on which this thread is
-		blocked*/
+  public PriorityQueue<RTEMSThread> wait; /*! It points to waitqueue of
+          mutex on which this thread is blocked.*/
+  public int resourceCount;               /*! It is the count of resources held
+                        by this thread. For now just acquired mutex count*/
+  public Thread.State state;              /*! Reflects the state of the thread
+                       based on standard Thread implementation*/
+  public int currentPriority; /*! It is the current priority of the thread*/
+  public int realPriority;    /*! It is the priority of thread at its creation
+             time*/
+  public List<Mutex> mutexOrderList; /*! List of acquired
+          mutex by the thread by the course of time*/
+  public Mutex trylock; /*! References to mutex on which this thread is
+          blocked*/
 
+  /**
+  * @brief Initializes thread object.
+  *
+  * Constructor sets the priority of the thread and initializes the
+  * list of mutex for this thread.
+  *
+  * @param[in] priority We set the currentpriority of this thread.
+  *
+  */
+  public RTEMSThread(int priority) {
+    this.mutexOrderList = new ArrayList<Mutex>();
+    this.state = this.getState();
+    this.setPriority(priority);
+    this.currentPriority = this.realPriority = this.getPriority();
+    // System.out.println("setting priority = "+getPriority() + " for thread:
+    // "+getId());
+    this.trylock = null;
+  }
 
-	/**
-	* @brief Initializes thread object.
-	* 
-	* Constructor sets the priority of the thread and initializes the 
-	* list of mutex for this thread.
-	*
-	* @param[in] priority We set the currentpriority of this thread.
-	*  
-	*/
-	public RTEMSThread(int priority) {
-		this.mutexOrderList = new ArrayList<Mutex>();
-		this.state = this.getState();
-		this.setPriority(priority);
-		this.currentPriority = this.realPriority = this.getPriority();
-		//System.out.println("setting priority = "+getPriority() + " for thread: "+getId());
-		this.trylock = null;
-	}
+  /**
+  * @brief Sets the current priority of the thread.
+  *
+  *
+  * @param[in] priority We set the currentpriority of this thread.
+  *
+  */
+  public void setCurrentPriority(int priority) { currentPriority = priority; }
 
-	/**
-	* @brief Sets the current priority of the thread.
-	* 
-	*
-	* @param[in] priority We set the currentpriority of this thread.
-	*  
-	*/
-	public void setCurrentPriority(int priority){
-		currentPriority = priority;
-	}
+  /**
+  * @brief Sets the current priority of the thread.
+  *
+  *
+  * @param[in] priority We set the real priority of this thread.
+  *
+  */
+  public void setRealPriority(int priority) { realPriority = priority; }
 
-	/**
-	* @brief Sets the current priority of the thread.
-	* 
-	*
-	* @param[in] priority We set the real priority of this thread.
-	*  
-	*/
-	public void setRealPriority(int priority){
-		realPriority = priority;
-	}
+  /**
+  * @brief Records the acquired mutex in mutexOrderList.
+  *
+  * This function is called when a thread successfully acquires a mutex.
+  * Like RTEMS model it saves this mutex in chain fashion to ensure proper
+  * behavior of RTEMS mutex implementation.
+  *
+  * @param[in] obj<Mutex> It is the mutex that the thread successfully
+  * acquired
+  */
+  public void pushMutex(Mutex obj) {
+    assert !(mutexOrderList.contains(this));
+    obj.priorityBefore = currentPriority;
+    mutexOrderList.add(0, obj);
+    assert wait == null;
+    assert trylock == null;
+  }
 
-	/**
-	* @brief Records the acquired mutex in mutexOrderList.
-	*
-	* This function is called when a thread successfully acquires a mutex.
-	* Like RTEMS model it saves this mutex in chain fashion to ensure proper
-	* behavior of RTEMS mutex implementation.
-	* 
-	* @param[in] obj<Mutex> It is the mutex that the thread successfully
-	* acquired
-	*/
-	public void pushMutex(Mutex obj){
-		assert !(mutexOrderList.contains(this));
-		obj.priorityBefore = currentPriority;
-		mutexOrderList.add(0, obj);
-		assert wait == null;
-		assert trylock == null;	
-	}
-
-	/**
-	* @brief Gets the index of stored mutex.
-	*
-	* If present, it returns the index of mutex obj stored in the 
-	* thread's mutexOrderList
-	* 
-	* @param[in] obj<Mutex> 
-	* @param[out] Returns position index of mutex object passed to function
-	* if it is present in the mutexOrderList of this thread or else return -1
-	*  
-	*/
-	public int getMutexIndex(Mutex obj){
-		return mutexOrderList.indexOf(obj);	
-	}
+  /**
+  * @brief Gets the index of stored mutex.
+  *
+  * If present, it returns the index of mutex obj stored in the
+  * thread's mutexOrderList
+  *
+  * @param[in] obj<Mutex>
+  * @param[out] Returns position index of mutex object passed to function
+  * if it is present in the mutexOrderList of this thread or else return -1
+  *
+  */
+  public int getMutexIndex(Mutex obj) { return mutexOrderList.indexOf(obj); }
 }

--- a/java/rtems-lock-model/lock-00-01-10/rtems/RTEMSThread.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/RTEMSThread.java
@@ -1,0 +1,96 @@
+package rtems;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class RTEMSThread extends Thread {
+  // TODO: add extra priority field etc.
+	public PriorityQueue<RTEMSThread> wait; /*! It points to waitqueue of 
+	 	mutex on which this thread is blocked.*/
+	public int resourceCount; /*! It is the count of resources held 
+	 	by this thread. For now just acquired mutex count*/
+	public Thread.State state; /*! Reflects the state of the thread
+		based on standard Thread implementation*/
+	public int currentPriority; /*! It is the current priority of the thread*/
+	public int realPriority; /*! It is the priority of thread at its creation
+		time*/
+	public List<Mutex> mutexOrderList; /*! List of acquired 
+		mutex by the thread by the course of time*/
+	public Mutex trylock; /*! References to mutex on which this thread is
+		blocked*/
+
+
+	/**
+	* @brief Initializes thread object.
+	* 
+	* Constructor sets the priority of the thread and initializes the 
+	* list of mutex for this thread.
+	*
+	* @param[in] priority We set the currentpriority of this thread.
+	*  
+	*/
+	public RTEMSThread(int priority) {
+		this.mutexOrderList = new ArrayList<Mutex>();
+		this.state = this.getState();
+		this.setPriority(priority);
+		this.currentPriority = this.realPriority = this.getPriority();
+		//System.out.println("setting priority = "+getPriority() + " for thread: "+getId());
+		this.trylock = null;
+	}
+
+	/**
+	* @brief Sets the current priority of the thread.
+	* 
+	*
+	* @param[in] priority We set the currentpriority of this thread.
+	*  
+	*/
+	public void setCurrentPriority(int priority){
+		currentPriority = priority;
+	}
+
+	/**
+	* @brief Sets the current priority of the thread.
+	* 
+	*
+	* @param[in] priority We set the real priority of this thread.
+	*  
+	*/
+	public void setRealPriority(int priority){
+		realPriority = priority;
+	}
+
+	/**
+	* @brief Records the acquired mutex in mutexOrderList.
+	*
+	* This function is called when a thread successfully acquires a mutex.
+	* Like RTEMS model it saves this mutex in chain fashion to ensure proper
+	* behavior of RTEMS mutex implementation.
+	* 
+	* @param[in] obj<Mutex> It is the mutex that the thread successfully
+	* acquired
+	*/
+	public void pushMutex(Mutex obj){
+		assert !(mutexOrderList.contains(this));
+		obj.priorityBefore = currentPriority;
+		mutexOrderList.add(0, obj);
+		assert wait == null;
+		assert trylock == null;	
+	}
+
+	/**
+	* @brief Gets the index of stored mutex.
+	*
+	* If present, it returns the index of mutex obj stored in the 
+	* thread's mutexOrderList
+	* 
+	* @param[in] obj<Mutex> 
+	* @param[out] Returns position index of mutex object passed to function
+	* if it is present in the mutexOrderList of this thread or else return -1
+	*  
+	*/
+	public int getMutexIndex(Mutex obj){
+		return mutexOrderList.indexOf(obj);	
+	}
+}

--- a/java/rtems-lock-model/lock-00-01-10/rtems/WaitQueue.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/WaitQueue.java
@@ -1,5 +1,5 @@
 public class WaitQueue {
-	//This class is not functional now. We can use it for future enhancement
-	//in mutex's waitqueue. Currently we just have priority based waitqueue
-	//embeded in mutex class itself.
+  // This class is not functional now. We can use it for future enhancement
+  // in mutex's waitqueue. Currently we just have priority based waitqueue
+  // embeded in mutex class itself.
 }

--- a/java/rtems-lock-model/lock-00-01-10/rtems/WaitQueue.java
+++ b/java/rtems-lock-model/lock-00-01-10/rtems/WaitQueue.java
@@ -1,0 +1,5 @@
+public class WaitQueue {
+	//This class is not functional now. We can use it for future enhancement
+	//in mutex's waitqueue. Currently we just have priority based waitqueue
+	//embeded in mutex class itself.
+}


### PR DESCRIPTION
This is work in progress. A license, more descriptions, and more variants of this example, will be added later. (The original repo git@github.com:saurabhgadia4/lock-model.git has a BSD 2-clause license.)

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
