### PR TITLE
Provide script that allows to get all tasks with a certain property

### DIFF
--- a/get_tasks_for_property.sh
+++ b/get_tasks_for_property.sh
@@ -4,6 +4,12 @@
 # Usage: ./get_tasks_for_property <PROPERTY_FILE> [BENCHMARK_DIRECTORY]
 # Execute from directory `sv-benchmarks/c` or provide directory as a second command-line argument.
 
+set -euo pipefail
+IFS=$'\n\t'
+
+# Make recursive globbing work
+shopt -s globstar
+
 property=${1:-}
 directory=${2:-./}
 

--- a/get_tasks_for_property.sh
+++ b/get_tasks_for_property.sh
@@ -22,12 +22,7 @@ if [ -z "$property" ]; then
   exit 1
 fi
 
-property_name=$(basename "$property")
-
-# Only consider task definition files that contain
-# the property name as a string - this makes the script incompatible with linked files,
-# but provides a significant speed-up if only few tasks contain the property.
-for task in $(grep -l "$property_name" "$directory"/**/*.yml); do
+for task in "$directory"/**/*.yml; do
   for prp in $(yq --raw-output "select(.properties != null) | .properties[].property_file" "$task" ); do
     if [ $property -ef "$(dirname "$task")/$prp" ]; then
       echo "$task"

--- a/get_tasks_for_property.sh
+++ b/get_tasks_for_property.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Requires `yq` to be installed.
+# Usage: ./get_tasks_for_property <PROPERTY_FILE> [BENCHMARK_DIRECTORY]
+# Execute from directory `sv-benchmarks/c` or provide directory as a second command-line argument.
+
+property=${1:-}
+directory=${2:-./}
+
+if [ -z "$property" ]; then
+  echo "Usage: $0 <PROPERTY_NAME> [BENCHMARK_DIRECTORY]"
+  exit 1
+fi
+
+property_name=$(basename "$property")
+
+for i in $(grep -l "$property_name" "$directory"/**/*.yml); do
+  task_directory=$(dirname "$i")
+  echo "$task_directory"/$(yq --raw-output '.input_files' $i)
+done

--- a/get_tasks_for_property.sh
+++ b/get_tasks_for_property.sh
@@ -4,6 +4,9 @@
 # Requires `yq` to be installed.
 # Usage: ./get_tasks_for_property <PROPERTY_FILE> [BENCHMARK_DIRECTORY]
 # Execute from directory `sv-benchmarks/c` or provide directory as a second command-line argument.
+# From the returned task definitions, it is possible to get the input files with the following
+# command line:
+# yq --raw-output ".input_files" TASK_DEFINITION
 
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
In case people do not use the benchexec infrastructure,
it is difficult to get the full set of benchmark files
with a certain property.

This script makes that task easier:
It gets a property name and, optionally, the benchmark directory,
and prints all tasks with the given property to stdout.
At the moment, properties must be given without a directory prefix to
reliably work. This way, it is not necessary to look at each single task
definition file separately, but it may be imprecise in case
two different properties with the same basename exist in different
directories.

Example usage:
```
./get_tasks_for_property.sh coverage-branches.prp c/
```