### PR TITLE
Fix openbsd_cmemrchr-alloca*

### DIFF
--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.c
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.c
@@ -50,6 +50,8 @@ cmemrchr(const void *s, int c, size_t n)
 	return(NULL);
 }
 
+const int MAX = 100000;
+
 int main() {
   int length = __VERIFIER_nondet_int();
   int n = __VERIFIER_nondet_int();
@@ -57,7 +59,7 @@ int main() {
   if (length < 1) {
       length = 1;
   }
-  if (n < 1) {
+  if (n < 1 || n > MAX) {
       n = 1;
   }
   char* nondetArea = (char*) alloca(n * sizeof(char));

--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.c
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.c
@@ -64,7 +64,7 @@ int main() {
   }
   char* nondetArea = (char*) alloca(n * sizeof(char));
 	
-	for(int i = 0; i < length; i++)
+	for(int i = 0; i < n; i++)
 	{
 	  nondetArea[i] = __VERIFIER_nondet_char();
 	}

--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.i
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.i
@@ -536,7 +536,7 @@ int main() {
   }
   char* nondetArea = (char*) __builtin_alloca (n * sizeof(char));
 	
-	for(int i = 0; i < length; i++)
+	for(int i = 0; i < n; i++)
 	{
 	  nondetArea[i] = __VERIFIER_nondet_char();
 	}

--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.i
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.i
@@ -523,6 +523,7 @@ cmemrchr(const void *s, int c, size_t n)
  }
  return(((void *)0));
 }
+const int MAX = 100000;
 int main() {
   int length = __VERIFIER_nondet_int();
   int n = __VERIFIER_nondet_int();
@@ -530,7 +531,7 @@ int main() {
   if (length < 1) {
       length = 1;
   }
-  if (n < 1) {
+  if (n < 1 || n > MAX) {
       n = 1;
   }
   char* nondetArea = (char*) __builtin_alloca (n * sizeof(char));

--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.yml
@@ -4,7 +4,5 @@ format_version: '1.0'
 input_files: 'openbsd_cmemrchr-alloca-2.i'
 
 properties:
-  - property_file: ../properties/termination.prp
-    expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true

--- a/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.c
+++ b/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.c
@@ -50,6 +50,8 @@ cmemrchr(const void *s, int c, size_t n)
 	return(NULL);
 }
 
+const int MAX = 100000;
+
 int main() {
   int length = __VERIFIER_nondet_int();
   int n = __VERIFIER_nondet_int();
@@ -57,7 +59,7 @@ int main() {
   if (length < 1) {
       length = 1;
   }
-  if (n < 1) {
+  if (n < 1 || n > MAX) {
       n = 1;
   }
   char* nondetArea = (char*) alloca(n * sizeof(char));

--- a/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.i
+++ b/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.i
@@ -557,6 +557,7 @@ cmemrchr(const void *s, int c, size_t n)
  }
  return(((void *)0));
 }
+const int MAX = 100000;
 int main() {
   int length = __VERIFIER_nondet_int();
   int n = __VERIFIER_nondet_int();
@@ -564,7 +565,7 @@ int main() {
   if (length < 1) {
       length = 1;
   }
-  if (n < 1) {
+  if (n < 1 || n > MAX) {
       n = 1;
   }
   char* nondetArea = (char*) __builtin_alloca (n * sizeof(char));


### PR DESCRIPTION
Fixes three problems with openbsd_cmemrchr-alloca*:
- Unbounded stack allocation (see #550, #561, #791).
- Use of a 32-bit preprocessed file in a 64-bit category.
- Memory safety violation introduced in a recent "bugfix" (#776).
