### PR TITLE
Return after free to avoid double-free error

### DIFF
--- a/c/ldv-memsafety-bitfields/test-bitfields-1-1.c
+++ b/c/ldv-memsafety-bitfields/test-bitfields-1-1.c
@@ -16,18 +16,22 @@ int main(void)
 	p->a = 1;
 	if (p->a != 1) {
 		free(p);
+		return 0;
 	}
 	p->b = 2;
 	if (p->b != 2) {
 		free(p);
+		return 0;
 	}
 	p->c = 3;
 	if (p->c != 3) {
 		free(p);
+		return 0;
 	}
 	p->d = 4;
 	if (p->d != 4) {
 		free(p);
+		return 0;
 	}
 
 	free(p);

--- a/c/ldv-memsafety-bitfields/test-bitfields-1-1.i
+++ b/c/ldv-memsafety-bitfields/test-bitfields-1-1.i
@@ -24,18 +24,22 @@ int main(void)
 	p->a = 1;
 	if (p->a != 1) {
 		free(p);
+		return 0;
 	}
 	p->b = 2;
 	if (p->b != 2) {
 		free(p);
+		return 0;
 	}
 	p->c = 3;
 	if (p->c != 3) {
 		free(p);
+		return 0;
 	}
 	p->d = 4;
 	if (p->d != 4) {
 		free(p);
+		return 0;
 	}
 
 	free(p);

--- a/c/ldv-memsafety-bitfields/test-bitfields-1-2.c
+++ b/c/ldv-memsafety-bitfields/test-bitfields-1-2.c
@@ -16,18 +16,22 @@ int main(void)
 	p->a = 1;
 	if (p->a != 1) {
 		free(p);
+		return 0;
 	}
 	p->b = 2;
 	if (p->b != 2) {
 		free(p);
+		return 0;
 	}
 	p->c = 3;
 	if (p->c != 3) {
 		free(p);
+		return 0;
 	}
 	p->d = 4; //ERROR: offsetof(struct A, d) == 3
 	if (p->d != 4) {
 		free(p);
+		return 0;
 	}
 	free(p);
 }

--- a/c/ldv-memsafety-bitfields/test-bitfields-1-2.i
+++ b/c/ldv-memsafety-bitfields/test-bitfields-1-2.i
@@ -25,18 +25,22 @@ int main(void)
 	p->a = 1;
 	if (p->a != 1) {
 		free(p);
+		return 0;
 	}
 	p->b = 2;
 	if (p->b != 2) {
 		free(p);
+		return 0;
 	}
 	p->c = 3;
 	if (p->c != 3) {
 		free(p);
+		return 0;
 	}
 	p->d = 4; //ERROR: offsetof(struct A, d) == 3
 	if (p->d != 4) {
 		free(p);
+		return 0;
 	}
 	free(p);
 }


### PR DESCRIPTION
The rules state: "Agreement: All programs in category 'MemorySafety'
violate at most one (partial) property p (p in {valid-free, valid-deref,
valid-memtrack})." test-bitfields-1-2.{c,i}, however, is known to
violate valid-deref. Thus it must not also violate valid-free.
test-bitfields-1-1.{c,i} isn't actually prone to a double-free error,
but would permit such if any future modification to the benchmark made
one of the conditions to the `if` statements true. Thus apply the same
changes to make it future-proof.
