### PR TITLE
ntdrivers/*: fix memory-safety errors

### DIFF
--- a/c/ntdrivers/cdaudio.i.cil-1.c
+++ b/c/ntdrivers/cdaudio.i.cil-1.c
@@ -7558,7 +7558,9 @@ int main(void)
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
   devobj.DeviceExtension = malloc(sizeof (CD_DEVICE_EXTENSION));
-  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(sizeof (IO_STACK_LOCATION));
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
   irp.AssociatedIrp.SystemBuffer = malloc(sizeof (CDROM_TOC));
   int a;
 

--- a/c/ntdrivers/cdaudio.i.cil-2.c
+++ b/c/ntdrivers/cdaudio.i.cil-2.c
@@ -7558,7 +7558,9 @@ int main(void)
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
   devobj.DeviceExtension = malloc(sizeof (CD_DEVICE_EXTENSION));
-  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(sizeof (IO_STACK_LOCATION));
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
   irp.AssociatedIrp.SystemBuffer = malloc(sizeof (CDROM_TOC));
 
   {

--- a/c/ntdrivers/diskperf.i.cil-1.c
+++ b/c/ntdrivers/diskperf.i.cil-1.c
@@ -3342,7 +3342,9 @@ int main(void)
   struct_4.ListEntry = list_entry_8;
   union __anonunion____missing_field_name_52 union_6;
   union_6.PacketType = __VERIFIER_nondet_long();
-  union_6.CurrentStackLocation = (struct _IO_STACK_LOCATION *)__VERIFIER_nondet_pointer();
+  union_6.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  union_6.CurrentStackLocation += 3;
   struct_4.__annonCompField16 = union_6;
   struct_3.__annonCompField17 = struct_4;
   struct_3.AuxiliaryBuffer = (PCHAR)__VERIFIER_nondet_pointer();

--- a/c/ntdrivers/diskperf.i.cil-2.c
+++ b/c/ntdrivers/diskperf.i.cil-2.c
@@ -2974,7 +2974,7 @@ void DiskPerfLogError(PDEVICE_OBJECT DeviceObject , ULONG UniqueId , NTSTATUS Er
     errorLogEntry->ErrorCode = ErrorCode;
     errorLogEntry->UniqueErrorValue = UniqueId;
     errorLogEntry->FinalStatus = Status;
-    memcpy(& errorLogEntry->DumpData[0], & DeviceObject, sizeof(DEVICE_OBJECT ));
+    memcpy(& errorLogEntry->DumpData[0], DeviceObject, sizeof(DEVICE_OBJECT ));
     errorLogEntry->DumpDataSize = sizeof(DEVICE_OBJECT );
     IoWriteErrorLogEntry(errorLogEntry);
     }
@@ -3218,7 +3218,13 @@ int main(void)
   int __BLAST_NONDET___0 = __VERIFIER_nondet_int() ;
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
+  devobj.DeviceExtension = malloc(sizeof (DEVICE_EXTENSION));
+  ((DEVICE_EXTENSION*)devobj.DeviceExtension)->DiskCounters = malloc(sizeof (struct _DISK_PERFORMANCE));
   KeNumberProcessors = __VERIFIER_nondet_pointer();
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
+  irp.AssociatedIrp.SystemBuffer = malloc(sizeof (struct _DISK_PERFORMANCE));
 
   {
   {

--- a/c/ntdrivers/floppy.i.cil-1.c
+++ b/c/ntdrivers/floppy.i.cil-1.c
@@ -6576,6 +6576,9 @@ NTSTATUS FlFdcDeviceIo(PDEVICE_OBJECT DeviceObject , ULONG Ioctl , PVOID Data )
 
   }
   {
+  irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 1;
   irpStack = irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   irpStack->Parameters.DeviceIoControl.Type3InputBuffer = Data;
   ntStatus = IofCallDriver(DeviceObject, irp);
@@ -7018,8 +7021,13 @@ int main(void)
   int __BLAST_NONDET = __VERIFIER_nondet_int() ;
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
+  devobj.DeviceExtension = malloc(sizeof (DISKETTE_EXTENSION));
+  memset(devobj.DeviceExtension, 0, sizeof (DISKETTE_EXTENSION));
 
   dummy_data.AlternativeArchitecture = __VERIFIER_nondet_int();
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
 
   {
   {

--- a/c/ntdrivers/floppy.i.cil-3.c
+++ b/c/ntdrivers/floppy.i.cil-3.c
@@ -6596,6 +6596,9 @@ NTSTATUS FlFdcDeviceIo(PDEVICE_OBJECT DeviceObject , ULONG Ioctl , PVOID Data )
 
   }
   {
+  irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 1;
   irpStack = irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   irpStack->Parameters.DeviceIoControl.Type3InputBuffer = Data;
   ntStatus = IofCallDriver(DeviceObject, irp);
@@ -7047,8 +7050,13 @@ int main(void)
   int __BLAST_NONDET = __VERIFIER_nondet_int() ;
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
+  devobj.DeviceExtension = malloc(sizeof (DISKETTE_EXTENSION));
+  memset(devobj.DeviceExtension, 0, sizeof (DISKETTE_EXTENSION));
   d.DriverExtension = malloc(sizeof (struct _DRIVER_EXTENSION));
   dummy_data.AlternativeArchitecture = __VERIFIER_nondet_int();
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
 
   {
   {

--- a/c/ntdrivers/parport.i.cil-1.c
+++ b/c/ntdrivers/parport.i.cil-1.c
@@ -9662,6 +9662,9 @@ int main(void)
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
   s = __VERIFIER_nondet_int();
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
 
   {
   {

--- a/c/ntdrivers/parport.i.cil-2.c
+++ b/c/ntdrivers/parport.i.cil-2.c
@@ -9678,6 +9678,9 @@ int main(void)
   int irp_choice = __VERIFIER_nondet_int() ;
   DEVICE_OBJECT devobj ;
   s = __VERIFIER_nondet_int();
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation = malloc(4 * sizeof (IO_STACK_LOCATION));
+  /* ensure a bounded number of subsequent decrements do not result in stack underflow */
+  irp.Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation += 3;
 
   {
   {


### PR DESCRIPTION
1) cdaudio, floppy, parport failed to use CurrentStackLocation in a
memory-safe way: The pointer member CurrentStackLocation is incremented
and decremented in several places and dereferenced thereafter. This may
have been memory safe in the original device driver code in case the
function calls doing increments/decrements were paired correctly. The
partly stubbed device driver that just non-deterministically invokes
individual functions does not guarantee such memory safety. Therefore
make sure CurrentStackLocation is initialized to point to a sufficiently
large memory array and set to a non-zero offset so that all possible
increments/decrements are safe.

2) Initialize the device extensions object as necessary.

3) diskperf.i.cil-2.c took the address of a pointer when using memset.