### PR TITLE
loop-acceleration - simple: fix variables initialization

### DIFF
--- a/c/loop-acceleration/simple_2-1.c
+++ b/c/loop-acceleration/simple_2-1.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern unsigned int __VERIFIER_nondet_uint(void);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -8,7 +9,7 @@ void __VERIFIER_assert(int cond) {
 }
 
 int main(void) {
-  unsigned int x;
+  unsigned int x = __VERIFIER_nondet_uint();
 
   while (x < 0x0fffffff) {
     x++;

--- a/c/loop-acceleration/simple_2-2.c
+++ b/c/loop-acceleration/simple_2-2.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern unsigned int __VERIFIER_nondet_uint(void);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -8,7 +9,7 @@ void __VERIFIER_assert(int cond) {
 }
 
 int main(void) {
-  unsigned int x;
+  unsigned int x = __VERIFIER_nondet_uint();
 
   while (x < 0x0fffffff) {
     x++;

--- a/c/loop-acceleration/simple_3-1.c
+++ b/c/loop-acceleration/simple_3-1.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern unsigned short __VERIFIER_nondet_ushort(void);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -9,7 +10,7 @@ void __VERIFIER_assert(int cond) {
 
 int main(void) {
   unsigned int x = 0;
-  unsigned short N;
+  unsigned short N = __VERIFIER_nondet_ushort();
 
   while (x < N) {
     x += 2;

--- a/c/loop-acceleration/simple_3-2.c
+++ b/c/loop-acceleration/simple_3-2.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-extern unsigned int __VERIFIER_nondet_uint();
+extern unsigned short __VERIFIER_nondet_ushort(void);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -10,7 +10,7 @@ void __VERIFIER_assert(int cond) {
 
 int main(void) {
   unsigned int x = 0;
-  unsigned short N = __VERIFIER_nondet_uint();
+  unsigned short N = __VERIFIER_nondet_ushort();
 
   while (x < N) {
     x += 2;


### PR DESCRIPTION
Fix initialization of variables in `simple` benchmark from loop-acceleration.