### PR TITLE
Remove math.h, update README.  Need discussion on integer overflow issue.

### DIFF
--- a/c/nla-digbench/README.md
+++ b/c/nla-digbench/README.md
@@ -4,9 +4,12 @@ Timos Antonopoulos (timos.antonopoulos@yale.edu).
 
 These programs contain nonlinear polynomial properties 
 (mostly equalities) that are challenging for program analysis.
-They were collected from various sources and  have been used in the 
-DIG (Dynamic Invariant Generation) work:
+For example, program `cohendiv.c` has the loop invariants 
+such as `b == y*a` and  `x == q*y + r` where `x,q,y,r,a` are 
+`int` variables.
 
+These programs were collected from various sources and  have been used in the 
+DIG (Dynamic Invariant Generation) work:
 * ThahhVu Nguyen, Timos Antopoulos, Andrew Ruef, and Michael Hicks. A Counterexample-guided Approach to Finding Numerical Invariants. 11th Joint Meeting of the European Software Engineering Conference and the ACM SIGSOFT Symposium on the Foundations of Software Engineering (FSE), pages 605--615. ACM, 2017. 
 * ThanhVu Nguyen, Matthew Dwyer, and William Visser. SymInfer: Inferring Program Invariants using Symbolic States. 32nd IEEE/ACM International Conference on Automated Software Engineering (ASE), pages 804--814. IEEE, 2017.
 * ThanhVu Nguyen, Deepak Kapur, Westley Weimer, and Stephanie Forrest. Using Dynamic Analysis to Discover Polynomial and Array Invariants.  International Conference on Software Engineering (ICSE), pages 683--693. IEEE, 2012. 

--- a/c/nla-digbench/geo2.c
+++ b/c/nla-digbench/geo2.c
@@ -13,7 +13,7 @@ void __VERIFIER_assert(int cond) {
     }
     return;
 }
-//#include <math.h>
+
 
 int main() {
     int z, k;

--- a/c/nla-digbench/knuth.c
+++ b/c/nla-digbench/knuth.c
@@ -11,7 +11,7 @@ void __VERIFIER_assert(int cond) {
     return;
 }
 
-#include <math.h>
+extern double sqrt(double);
 
 int main() {
     int n, a;


### PR DESCRIPTION
<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
