### PR TITLE
Don't require memcleanup, small fix and variants of the elimination_max

### DIFF
--- a/c/ReachSafety-Recursive.set
+++ b/c/ReachSafety-Recursive.set
@@ -3,3 +3,5 @@ recursive-simple/*.yml
 verifythis/prefixsum_rec.yml
 verifythis/tree_del_rec.yml
 verifythis/tree_max.yml
+verifythis/elimination_max_rec.yml
+verifythis/elimination_max_rec_onepoint.yml

--- a/c/verifythis/duplets.yml
+++ b/c/verifythis/duplets.yml
@@ -5,7 +5,5 @@ input_files: 'duplets.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/elimination_max.c
+++ b/c/verifythis/elimination_max.c
@@ -15,7 +15,7 @@ int main() {
     int x = 0;
     int y = n - 1;
 
-    while(x != y) {
+    while(x < y) {
         /* Possible formulation of the invariant:
          *
          * Claude Marche, Jean-Christophe Filliatre

--- a/c/verifythis/elimination_max.yml
+++ b/c/verifythis/elimination_max.yml
@@ -5,7 +5,5 @@ input_files: 'elimination_max.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/elimination_max_rec.c
+++ b/c/verifythis/elimination_max_rec.c
@@ -1,0 +1,40 @@
+extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+        if(!cond) __VERIFIER_error();
+}
+
+int check(int x, int y, int *a, int n) {
+    if(x >= y) return x;
+
+    /* This should be taken as the precondition */
+    __VERIFIER_assert(0 <= x && y < n);
+
+    int x0 = x;
+    int y0 = y;
+
+    if(a[x] <= a[y]) x++;
+    else y--;
+
+    int x1 = check(x, y, a, n);
+
+
+    /* This should be taken as the postcondition */
+    int i = __VERIFIER_nondet_int();
+    __VERIFIER_assume(x0 <= i && i <= y0);
+    int ai = a[i];
+    int ax = a[x1];
+    __VERIFIER_assert(ai <= ax);
+
+    return x1;
+}
+
+int main() {
+    int n = __VERIFIER_nondet_int();
+    __VERIFIER_assume(n >= 0);
+    int *a = calloc(n, sizeof(int));
+    int x = check(0, n-1, a, n);
+    return x;
+}
+

--- a/c/verifythis/elimination_max_rec.c
+++ b/c/verifythis/elimination_max_rec.c
@@ -5,6 +5,8 @@ void __VERIFIER_assert(int cond) {
         if(!cond) __VERIFIER_error();
 }
 
+extern int __VERIFIER_nondet_int(void);
+
 int check(int x, int y, int *a, int n) {
     if(x >= y) return x;
 

--- a/c/verifythis/elimination_max_rec.yml
+++ b/c/verifythis/elimination_max_rec.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'tree_max.c'
+input_files: 'elimination_max_rec.c'
 
 properties:
   - property_file: ../properties/valid-memsafety.prp

--- a/c/verifythis/elimination_max_rec_onepoint.c
+++ b/c/verifythis/elimination_max_rec_onepoint.c
@@ -5,6 +5,8 @@ void __VERIFIER_assert(int cond) {
         if(!cond) __VERIFIER_error();
 }
 
+extern int __VERIFIER_nondet_int(void);
+
 int check(int x, int y, int *a, int i, int n) {
     if(x >= y) return x;
 

--- a/c/verifythis/elimination_max_rec_onepoint.c
+++ b/c/verifythis/elimination_max_rec_onepoint.c
@@ -1,0 +1,44 @@
+extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+        if(!cond) __VERIFIER_error();
+}
+
+int check(int x, int y, int *a, int i, int n) {
+    if(x >= y) return x;
+
+    /* This should be taken as the precondition */
+    __VERIFIER_assert(0 <= x && y < n);
+    __VERIFIER_assume(0 <= i && i < n);
+
+    int x0 = x;
+    int y0 = y;
+
+    if(a[x] <= a[y]) x++;
+    else y--;
+
+    int x1 = check(x, y, a, i, n);
+
+
+    /* This should be taken as the postcondition */
+    int ai = a[i];
+    int ax = a[x1];
+    __VERIFIER_assert(ai <= ax);
+
+    return x1;
+}
+
+int main() {
+    int n = __VERIFIER_nondet_int();
+    __VERIFIER_assume(n >= 0);
+    int i = __VERIFIER_nondet_int();
+    __VERIFIER_assume(0 <= i && i < n);
+    int *a = calloc(n, sizeof(int));
+    int x = check(0, n-1, a, i, n);
+    int ai = a[i];
+    int ax = a[x];
+    __VERIFIER_assert(ai <= ax);
+    return x;
+}
+

--- a/c/verifythis/elimination_max_rec_onepoint.yml
+++ b/c/verifythis/elimination_max_rec_onepoint.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'tree_max.c'
+input_files: 'elimination_max_rec_onepoint.c'
 
 properties:
   - property_file: ../properties/valid-memsafety.prp

--- a/c/verifythis/lcp.yml
+++ b/c/verifythis/lcp.yml
@@ -5,7 +5,5 @@ input_files: 'lcp.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/prefixsum_iter.yml
+++ b/c/verifythis/prefixsum_iter.yml
@@ -5,7 +5,5 @@ input_files: 'prefixsum_iter.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/prefixsum_rec.yml
+++ b/c/verifythis/prefixsum_rec.yml
@@ -5,7 +5,5 @@ input_files: 'prefixsum_rec.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/tree_del_iter.yml
+++ b/c/verifythis/tree_del_iter.yml
@@ -5,7 +5,5 @@ input_files: 'tree_del_iter.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true

--- a/c/verifythis/tree_del_rec.yml
+++ b/c/verifythis/tree_del_rec.yml
@@ -5,7 +5,5 @@ input_files: 'tree_del_rec.c'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true


### PR DESCRIPTION
This fixes some issues and contributes variants of benchmarks.

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
