### PR TITLE
Adding a equivalence-check on the Replace benchmark

### DIFF
--- a/java/ReachSafety.set
+++ b/java/ReachSafety.set
@@ -1,4 +1,5 @@
 jayhorn-recursive/*.yml
 jbmc-regression/*.yml
 jpf-regression/*.yml
+java-ranger-regression/*.yml
 MinePump/*.yml

--- a/java/java-ranger-regression/LICENSE.Apache-2.0.txt
+++ b/java/java-ranger-regression/LICENSE.Apache-2.0.txt
@@ -1,0 +1,1 @@
+../jpf-regression/LICENSE.Apache-2.0.txt

--- a/java/java-ranger-regression/README.txt
+++ b/java/java-ranger-regression/README.txt
@@ -1,0 +1,7 @@
+These are adapted Java Ranger benchmarks. Their original versions can be found here:
+    repo: https://github.com/vaibhavbsharma/java-ranger/tree/default/
+    branch: default
+    root directory: src/examples/veritesting
+The benchmark was taken from the repo: Oct 10, 2019 
+Note: Only benchmarks usable in SV-COMP were taken.
+Note: The changes we made are mostly conversion to SV-COMP format. 

--- a/java/java-ranger-regression/replace5_eqchk.yml
+++ b/java/java-ranger-regression/replace5_eqchk.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - replace5_eqchk/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+

--- a/java/java-ranger-regression/replace5_eqchk/Main.java
+++ b/java/java-ranger-regression/replace5_eqchk/Main.java
@@ -1,0 +1,26 @@
+
+
+public class Main {
+
+    Outputs runReplace(int in0, int in1, int in2, int in3, int in4, int in5,
+                       boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                       char c0, char c1, char c2, char c3, char c4, char c5) {
+        replace t = new replace();
+        char[] ret = t.mainProcess(c0, c1, c2, c3, c4);
+        Outputs outputs = new Outputs(ret);
+        return outputs;
+    }
+
+
+    public static void main(String[] args) {
+        TestVeritestingReplace t = new TestVeritestingReplace();
+        Main s = new Main();
+        t.runTest(s);
+    }
+
+    Outputs testFunction(int in0, int in1, int in2, int in3, int in4, int in5,
+                         boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                         char c0, char c1, char c2, char c3, char c4, char c5) {
+        return runReplace(in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+    }
+}

--- a/java/java-ranger-regression/replace5_eqchk/Outputs.java
+++ b/java/java-ranger-regression/replace5_eqchk/Outputs.java
@@ -1,0 +1,37 @@
+
+public class Outputs {
+    public int[] intOutputs;
+
+    public Outputs(int [] outputs) {
+        intOutputs = new int[outputs.length];
+        for (int i=0; i<outputs.length; i++)
+            intOutputs[i] = outputs[i];
+    }
+
+    public Outputs(char [] outputs) {
+        intOutputs = new int[outputs.length];
+        for (int i=0; i<outputs.length; i++)
+            intOutputs[i] = outputs[i];
+    }
+
+    public Outputs() { intOutputs = new int[0]; }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (Outputs.class.isInstance(obj)) {
+            Outputs o = (Outputs) obj;
+            if (o.intOutputs.length != intOutputs.length) {
+                System.out.println("length mismatch (" + o.intOutputs.length + ", " + intOutputs.length);
+                return false;
+            }
+            for (int i=0; i < intOutputs.length; i++) {
+                if (intOutputs[i] != o.intOutputs[i]) {
+                    System.out.println("entry " + i + " mismatch, " + intOutputs[i] + ", " + o.intOutputs[i]);
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/java/java-ranger-regression/replace5_eqchk/TestVeritestingReplace.java
+++ b/java/java-ranger-regression/replace5_eqchk/TestVeritestingReplace.java
@@ -1,0 +1,71 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class TestVeritestingReplace  {
+
+
+    void testHarness(Main v) {
+        int in0 = Verifier.nondetInt();
+        int in1 = Verifier.nondetInt();
+        int in2 = Verifier.nondetInt();
+        int in3 = Verifier.nondetInt();
+        int in4 = Verifier.nondetInt();
+        int in5 = Verifier.nondetInt();
+        boolean b0 = Verifier.nondetBoolean();
+        boolean b1 = Verifier.nondetBoolean();
+        boolean b2 = Verifier.nondetBoolean();
+        boolean b3 = Verifier.nondetBoolean();
+        boolean b4 = Verifier.nondetBoolean();
+        boolean b5 = Verifier.nondetBoolean();
+        char c0 = Verifier.nondetChar();
+        char c1 = Verifier.nondetChar();
+        char c2 = Verifier.nondetChar();
+        char c3 = Verifier.nondetChar();
+        char c4 = Verifier.nondetChar();
+        char c5 = Verifier.nondetChar();
+        Outputs outSPF = SPFWrapper(v, in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+        // replace.reset(); // not resetting the internal state of replace causes a verification failure
+        Outputs outJR = JRWrapper(v, in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+        checkEquality(v, outSPF, outJR);
+    }
+
+    public void checkEquality(Main v, Outputs outSPF, Outputs outJR) {
+        if (outSPF.equals(outJR)) System.out.println("Match");
+        else {
+            System.out.println("Mismatch");
+            assert(false);
+        }
+//        assert(outSPF == outJR);
+    }
+
+    public Outputs SPFWrapper(Main v, int in0, int in1, int in2, int in3, int in4, int in5,
+                              boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                              char c0, char c1, char c2, char c3, char c4, char c5) {
+        return NoVeritest(v, in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+    }
+
+    // This is a special method. Call this method to prevent Java Ranger from veritesting any regions that appear in any
+    // function or method call higher up in the stack. In the future, this call to SPFWrapperInner can be changed to
+    // be a generic method call if other no-veritesting methods need to be invoked.
+    private Outputs NoVeritest(Main v, int in0, int in1, int in2, int in3, int in4, int in5,
+                               boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                               char c0, char c1, char c2, char c3, char c4, char c5){
+        return SPFWrapperInner(v, in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+    }
+
+    private Outputs SPFWrapperInner(Main v, int in0, int in1, int in2, int in3, int in4, int in5,
+                                    boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                                    char c0, char c1, char c2, char c3, char c4, char c5) {
+        Outputs ret = v.testFunction(in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+        return ret;
+    }
+
+    public Outputs JRWrapper(Main v, int in0, int in1, int in2, int in3, int in4, int in5,
+                             boolean b0, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5,
+                             char c0, char c1, char c2, char c3, char c4, char c5) {
+        return v.testFunction(in0, in1, in2, in3, in4, in5, b0, b1, b2, b3, b4, b5, c0, c1, c2, c3, c4, c5);
+    }
+
+    public void runTest(Main t) {
+        testHarness(t);
+    }
+};

--- a/java/java-ranger-regression/replace5_eqchk/replace.java
+++ b/java/java-ranger-regression/replace5_eqchk/replace.java
@@ -1,0 +1,831 @@
+
+public class replace {
+	
+	public static final int patParaLen = 3;
+	public static int patParaIndex = 0;
+	public static final int patLen = 10;
+	public static int patIndex = 0;
+
+	public static final int subParaLen = 3;
+	public static int subParaIndex = 0;
+	public static final int subLen = 10;
+	public static int subIndex = 0;
+	
+	public static final int strLen = 2;
+	public static int strIndex = 0;
+	public static int tempIndex = 0;
+	//
+//	public static int strIndex = 0;
+	
+	public static final char ENDSTR = '\0';
+	public static final char ESCAPE = '@';
+	public static final char CLOSURE = '*';
+	public static final char BOL = '%';
+	public static final char EOL = '$';
+	public static final char ANY = '?';
+	public static final char CCL = '[';
+	public static final char CCLEND = ']';
+	public static final char NEGATE = '^';
+	public static final char NCCL = '!';
+	public static final char LITCHAR = 'c';
+	public static final char DASH = '-';
+
+	public static final int DITTO = -1;
+	public static final int TAB = 9;
+	public static final int NEWLINE = 10;
+	public static final int CLOSIZE = 1;
+
+	public static final int printBufLen = 50;
+	static int printBufIdx = 0;
+	static char[] printBuf;
+
+	public static void reset() {
+		patParaIndex = 0;
+		patIndex = 0;
+		subParaIndex = 0;
+		subIndex = 0;
+		strIndex = 0;
+		tempIndex = 0;
+		printBufIdx = 0;
+	}
+
+	public static char[] mainProcess(char i0, char i1, char i2, char i3, char i4){
+		printBuf = new char[printBufLen];
+
+
+		//
+		char[] patPara = new char[patParaLen];
+		patPara[0] = i0;
+		patPara[1] = i1;
+//		patPara[2] = i2;
+		patPara[2] = '\0';
+		char[] pat = new char[patLen];
+		int patResult = makepat(patPara, pat);
+		if(patResult <= 0){
+			System.out.println("Challege: illegal pattern!");
+			return new char[]{};
+		}
+		//
+		char[] subPara = new char[subParaLen];
+		subPara[0] = i2;
+		subPara[1] = i3;
+//		subPara[2] = i4;
+//		subPara[3] = i5;
+		subPara[2] = '\0';
+		char[] sub = new char[subLen];
+		int subResult = makesub(subPara, sub);
+		if(subResult <= 0){
+			System.out.println("Challege: illegal sub");
+		}
+		//
+		char[] str = new char[strLen];
+		str[0] = i4;
+		/*
+//		str[1] = i4;
+//		str[2] = i8;
+*/
+		str[1] = '\0';
+		//
+		change(str, pat, sub);
+		for (int i=0; i < printBuf.length; i++) printBuf[i] = '0';
+		char[] retChar = new char[pat.length + sub.length + str.length + printBuf.length];
+		for (int i=0; i < printBuf.length; i++) printBuf[i] = '0';
+		int outIndex = 0;
+		for (int i = 0; i < pat.length; i++)
+			retChar[outIndex++] = pat[i];
+		for (int i = 0; i < sub.length; i++)
+			retChar[outIndex++] = sub[i];
+		for (int i = 0; i < str.length; i++)
+			retChar[outIndex++] = str[i];
+		for (int i = 0; i < printBufLen; i++)
+			retChar[outIndex++] = printBuf[i];
+
+		return retChar;
+	}
+	/*
+	 *
+	 */
+	private static void change(char[] lin, char[] pat, char[] sub) {
+		//
+		int lastm = -1;
+		int i = 0;
+		//		
+		while(lin[i] != ENDSTR){
+			strIndex = i;
+			//
+			//
+			int m = amatch(lin, pat, 0);
+			if(m >= 0){
+				if(lastm != m){
+					//
+					putsub(lin, i, m, sub);
+					lastm = m;
+				}
+			}
+			if(m == -1){
+				//
+				System.out.print(lin[i]);
+				if (printBufIdx < printBuf.length) printBuf[printBufIdx++] = lin[i];
+				i = i + 1;
+			}
+			else if(m == i){
+				//TODO 
+				System.out.print(lin[i]);
+				if (printBufIdx < printBuf.length) printBuf[printBufIdx++] = lin[i];
+				i = i + 1;
+			}
+			else{
+				i = m;
+			}
+		}
+	}
+
+	private static void putsub(char[] lin, int s1, int s2, char[] sub) {
+		int i = 0;
+		while(sub[i] != ENDSTR){
+			char ch = (char)DITTO;
+			if(sub[i] == ch){
+				System.out.print(lin[i]);
+				if (printBufIdx < printBuf.length) printBuf[printBufIdx++] = lin[i];
+			}
+			else{
+				System.out.print(sub[i]);
+				if (printBufIdx < printBuf.length) printBuf[printBufIdx++] = sub[i];
+			}
+			i = i + 1;
+		}
+	}
+
+	/*
+	 * 
+	 */
+	private static int amatch(char[] lin, char[] pat, int j) {
+		int k = -1;
+		boolean done = false;
+		boolean continueIndex = false;
+		if(pat[j] != ENDSTR){
+			continueIndex = true;
+		}
+		while(continueIndex){
+			//
+			if(pat[j] == CLOSURE){
+				int _patsize = patsize(pat, j);
+				j = j + _patsize;
+				tempIndex = strIndex;
+				continueIndex = false;
+				//
+				if(lin[tempIndex] != ENDSTR){
+					continueIndex = true;
+				}
+				//
+				while(continueIndex){
+					boolean result = omatch(lin, pat, j);
+					if(!result){
+						done = true;
+					}
+					continueIndex = false;
+					if(!done){
+						if(lin[tempIndex] != ENDSTR){
+							continueIndex = true;
+						}
+					}
+				}
+				
+				done = false;
+				continueIndex = false;
+				int offset = strIndex;
+				strIndex = tempIndex;
+				if(strIndex >= offset){
+					continueIndex = true;
+				}
+				//
+				while(continueIndex){
+					_patsize = patsize(pat, j);
+					_patsize = _patsize + j;
+					k = amatch(lin, pat, _patsize);
+					if(k >= 0){
+						done = true;
+					}
+					else{
+						strIndex = strIndex -1;
+					}
+					continueIndex = false;
+					if(!done){
+						if(strIndex > offset){
+							continueIndex = true;
+						}
+					}
+				}
+				strIndex = k;
+				done = true;
+			}
+			else{
+				tempIndex = strIndex;
+				boolean result = omatch(lin, pat, j);
+				strIndex = tempIndex;
+				if(!result){
+					strIndex = -1;
+					done = true;
+				}
+				else{
+					int _patsize = patsize(pat, j);
+					j = j + _patsize;
+				}
+			}
+			continueIndex = false;
+			if(!done){
+				if(pat[j] != ENDSTR){
+					continueIndex = true;
+				}
+			}
+		}
+		//
+		return strIndex;
+	}
+
+	/*
+	 * 
+	 * 
+	 */
+	private static boolean omatch(char[] lin, char[] pat, int j) {
+		boolean result = false;
+		//
+		int advance = -1;
+		if(lin[tempIndex] == ENDSTR){
+			//
+			result = false;
+		}
+		else{
+			char tempChar = pat[j];
+			boolean _in_pat_set = in_pat_set(tempChar);
+			if(!_in_pat_set){
+				System.out.println("In omatch: can't happen!");
+			}
+			else{
+				if(pat[j] == LITCHAR){
+					//
+					if(lin[tempIndex] == pat[j+1]){
+						advance = 1;
+					}
+				}
+				//
+				else if(pat[j] == BOL){
+					if(tempIndex == 0){
+						advance = 0;
+					}
+				}
+				else if(pat[j] == ANY){
+					//
+					if(lin[tempIndex] != NEWLINE){
+						advance = 1;
+					}
+				}
+				//
+				else if(pat[j] == EOL){
+					if(lin[tempIndex] == NEWLINE){
+						advance = 0;
+					}
+				}
+				//
+				else if(pat[j] == CCL){
+					int _j = j + 1;
+					//
+					char tempChar1 = lin[tempIndex];
+					boolean _locate = locate(tempChar1, pat, _j);
+					if(_locate){
+						advance = 1;
+					}
+				}
+				else if(pat[j] == NCCL){
+					if(lin[tempIndex] != NEWLINE){
+						int _j = j + 1;
+						char tempChar1 = lin[tempIndex];
+						boolean _locate = locate(tempChar1, pat, _j);
+						if(!_locate){
+							advance = 1;
+						}
+					}
+				}
+				else{
+					CaseError(pat[j]);
+				}
+			}
+		}
+		if(advance >= 0){
+			tempIndex = tempIndex + advance;
+			result = true;
+		}
+		else{
+			result = false;
+		}
+		//
+		return result;
+	}
+
+	/*
+	 * 
+	 */
+	private static boolean locate(char c, char[] pat, int offset) {
+		boolean flag = false;
+		//
+		int i = offset + pat[offset];
+		while(i > offset){
+			if(c == pat[i]){
+				flag = true;
+				i = offset;
+			}
+			else{
+				i = i - 1;
+			}
+		}
+		return flag;
+	}
+
+	/*
+	 * 
+	 */
+	private static int patsize(char[] pat, int n) {
+		char tempChar = pat[n];
+		boolean _in_pat_set = in_pat_set(tempChar);
+		int size = -1;
+		if(!_in_pat_set){
+			System.out.println("In patsize: can't happen");
+		}
+		else{
+			//
+			if(pat[n] == LITCHAR){
+				size = 2;
+			}
+			else if(pat[n] == BOL){
+				size = 1;
+			}
+			else if(pat[n] == EOL){
+				size = 1;
+			}
+			else if(pat[n] == ANY){
+				size = 1;
+			}
+			else if(pat[n] == CCL){
+				size = pat[n+1] + 2;
+			}
+			else if(pat[n] == NCCL){
+				size = pat[n+1] + 2;
+			}
+			else if(pat[n] == CLOSURE){
+				size = CLOSIZE;
+			}
+			else{
+				CaseError(pat[n]);
+			}
+		}
+		return size;
+	}
+
+	private static void CaseError(char c) {
+		System.out.println("Missing case limb!");
+	}
+
+	private static boolean in_pat_set(char ch) {
+		if(ch == LITCHAR){
+			return true;
+		}
+		else if(ch == BOL){
+			return true;
+		}
+		else if(ch == EOL){
+			return true;
+		}
+		else if(ch == ANY){
+			return true;
+		}
+		else if(ch == CCL){
+			return true;
+		}
+		else if(ch == NCCL){
+			return true;
+		}
+		else if(ch == CLOSURE){
+			return true;
+		}
+		else{
+			return false;
+		}
+	}
+	
+	/*
+	 * 
+	 * 
+	 */
+	private static int makesub(char[] arg, char[] sub) {
+		boolean continueIndex = false;
+		if(arg[subParaIndex] != ENDSTR){
+			continueIndex = true;
+		}
+		while(continueIndex){
+			if(arg[subParaIndex] == '&'){
+				//
+				char ch = (char)DITTO;
+				if(subIndex < subLen){
+					sub[subIndex] = ch;
+					subIndex = subIndex + 1;
+				}
+			}
+			else{
+				char escjunk = escSub(arg);
+				if(subIndex < subLen){
+					sub[subIndex] = escjunk;
+					subIndex = subIndex + 1;
+				}
+			}
+			subParaIndex = subParaIndex + 1;
+			continueIndex = false;
+			if(arg[subParaIndex] != ENDSTR){
+				continueIndex = true;
+			}
+		}
+		int result = 0;
+		if(arg[subParaIndex] != ENDSTR){
+			result = 0;
+		}
+		else{
+			if(subIndex < subLen){
+				sub[subIndex] = ENDSTR;
+				result = subParaIndex;
+			}
+			else{
+				result = 0;
+			}
+		}
+		return result;
+	}
+	
+	private static int makepat(char[] arg, char[] pat) {
+		int lastj = 0;
+		boolean done = false;
+		boolean continueIndex = false;
+		if(arg[patParaIndex] != ENDSTR){
+			continueIndex = true;
+		}
+
+		while(continueIndex){
+			int lj = patIndex;
+			//
+			if(arg[patParaIndex] == ANY){
+				if(patIndex < patLen){
+					pat[patIndex] = ANY;
+					patIndex = patIndex + 1;
+				}
+			}
+			else if(arg[patParaIndex] == CCL){
+				//
+				boolean getres = getccl(arg, pat);
+
+				if(!getres){
+					//
+					done = true;
+				}
+				else{
+					done = false;
+				}
+			}
+			else if(arg[patParaIndex] == BOL){
+				if(patParaIndex == 0){
+					if(patIndex < patLen){
+						pat[patIndex] = BOL;
+						patIndex = patIndex + 1;
+					}
+
+				}
+				else{
+					if(patIndex < patLen){
+						pat[patIndex] = LITCHAR;
+						patIndex = patIndex + 1;
+					}
+
+					char escjunk = esc(arg);
+					if(patIndex < patLen){
+						pat[patIndex] = escjunk;
+						patIndex = patIndex + 1;
+					}
+				}
+			}
+			//
+			else if(arg[patParaIndex] == CLOSURE){
+				//
+				if(patParaIndex > 0){
+					lj = lastj;
+					char tempChar = pat[lj];
+					boolean _inset = in_set_2(tempChar);
+					if(_inset){
+						done = true;
+					}
+					else{
+						stclose(pat, lastj);
+					}
+				}
+				else{
+					if(patIndex < patLen){
+						pat[patIndex] = LITCHAR;
+						patIndex = patIndex + 1;
+					}
+
+					char escjunk = esc(arg);
+					if(patIndex < patLen){
+						pat[patIndex] = escjunk;
+						patIndex = patIndex + 1;
+					}
+				}
+			} 
+			else if(arg[patParaIndex] == EOL){
+				if(arg[patParaIndex+1] == ENDSTR){
+					if(patIndex < patLen){
+						pat[patIndex] = EOL;
+						patIndex = patIndex + 1;
+					}
+				}
+				else{
+					if(patIndex < patLen){
+						pat[patIndex] = LITCHAR;
+						patIndex = patIndex + 1;
+					}
+					
+					char escjunk = esc(arg);
+					if(patIndex < patLen){
+						pat[patIndex] = escjunk;
+						patIndex = patIndex + 1;
+					}
+				}
+			}
+			else{
+				//
+				if(patIndex < patLen){
+					pat[patIndex] = LITCHAR;
+					patIndex = patIndex + 1;
+				}
+				
+				char escjunk = esc(arg);
+				if(patIndex < patLen){
+					pat[patIndex] = escjunk;
+					patIndex = patIndex + 1;
+				}
+			}
+			//
+			lastj = lj;
+			//
+			continueIndex = false;
+			if(!done){
+				patParaIndex = patParaIndex + 1;
+				if(arg[patParaIndex] != ENDSTR){
+					continueIndex = true;
+				}
+			}
+		}
+		
+		//
+		int result = 1;
+		if(patIndex < patLen){
+			pat[patIndex] = ENDSTR;
+		}
+		else{
+			result = 0;
+		}
+		if(done){
+			result = 0;
+		}
+		else if(arg[patParaIndex] != ENDSTR){
+			result = 0;
+		}
+		return result;
+	}
+
+	/*
+	 * 
+	 */
+	private static void stclose(char[] pat, int lastj) {
+		for(int jp = patIndex-1; jp >= lastj;){
+			int jt = jp + CLOSIZE;
+			if(jt < patLen){
+				//
+				pat[jt] = pat[jp];
+			}
+			jp = jp - 1;
+		}
+		patIndex = patIndex + CLOSIZE;
+		pat[lastj] = CLOSURE;
+	}
+	private static boolean in_set_2(char ch) {
+		if(ch == BOL){
+			return true;
+		}
+		else if(ch == EOL){
+			return true;
+		}
+		else if(ch == CLOSURE){
+			return true;
+		}
+		else{
+			return false;
+		}
+	}
+	
+	/*
+	 * 
+	 */
+	private static char escSub(char[] s) {
+		char result;
+		if(s[subParaIndex] != ESCAPE){
+			result = s[subParaIndex];
+		}
+		else if(s[subParaIndex+1] == ENDSTR){
+			result = ESCAPE;
+		}
+		else{
+			subParaIndex = subParaIndex + 1;
+			if(s[subParaIndex] == 'n'){
+				result = (char)NEWLINE;
+			}
+			else if(s[subParaIndex] == 't'){
+				result = (char)TAB;
+			}
+			else{
+				result = s[subParaIndex];
+			}
+		}
+		return result;
+	}	
+	
+	/*
+	 * 
+	 */
+	private static char esc(char[] s) {
+		char result;
+		if(s[patParaIndex] != ESCAPE){
+			result = s[patParaIndex];
+		}
+		else if(s[patParaIndex+1] == ENDSTR){
+			result = ESCAPE;
+		}
+		else{
+			patParaIndex = patParaIndex + 1;
+			if(s[patParaIndex] == 'n'){
+				result = (char)NEWLINE;
+			}
+			else if(s[patParaIndex] == 't'){
+				result = (char)TAB;
+			}
+			else{
+				result = s[patParaIndex];
+			}
+		}
+		return result;
+	}
+	/*
+	 * 
+	 * 
+	 */
+	private static boolean getccl(char[] arg, char[] pat) {
+		patParaIndex = patParaIndex + 1;
+		if(arg[patParaIndex] == NEGATE){
+			if(patIndex < patLen){
+				pat[patIndex] = NCCL;
+				patIndex = patIndex + 1;
+			}
+			patParaIndex = patParaIndex + 1;
+		}
+		else{
+			if(patIndex < patLen){
+				pat[patIndex] = CCL;
+				patIndex = patIndex + 1;
+			}
+		}
+		
+		int jstart = patIndex;
+		//
+		if(patIndex < patLen){
+			pat[patIndex] = '\0';
+			patIndex = patIndex + 1;
+		}
+		
+		dodash(CCLEND, arg, pat);
+
+		char _jstart = (char)(patIndex - jstart - 1);
+		//
+		pat[jstart] = _jstart;
+		if(arg[patParaIndex] == CCLEND){
+			return true;
+		}
+		else{
+			return false;
+		}
+	}
+	/*
+	 * 
+	 * 
+	 */
+	private static void dodash(char delim, char[] src, char[] dest) {
+
+		boolean continueIndex = false;
+		if(src[patParaIndex] != delim){
+			if(src[patParaIndex] != ENDSTR){
+				continueIndex = true;
+			}
+		}
+		while(continueIndex){
+			if(src[patParaIndex] != DASH){
+				if(patIndex < patLen){
+					dest[patIndex] = src[patParaIndex];
+					patIndex = patIndex + 1;
+				}
+			}
+			else if(patIndex <= 1){
+				if(patIndex < patLen){
+					dest[patIndex] = DASH;
+					patIndex = patIndex + 1;
+				}
+			}
+			else if(src[patParaIndex + 1] == ENDSTR){
+				if(patIndex < patLen){
+					dest[patIndex] = DASH;
+					patIndex = patIndex + 1;
+				}
+			}
+			else{
+				char tempChar1 = src[patParaIndex-1];
+				boolean _isNum_0 = isalnum(tempChar1);
+				if(_isNum_0){
+					char tempChar2 = src[patParaIndex+1];
+					boolean _isNum_1 = isalnum(tempChar2);
+					if(_isNum_1){
+						if(src[patParaIndex-1] <= src[patParaIndex+1]){
+							//
+							for(int k = src[patParaIndex-1] + 1; k <= src[patParaIndex+1];){
+								char _k = (char)k;
+								if(patIndex < patLen){
+									dest[patIndex] = _k;
+									patIndex = patIndex + 1;
+								}
+								k = k + 1;
+							}
+							//
+							patParaIndex = patParaIndex + 1;
+						}
+						else{
+							if(patIndex < patLen){
+								dest[patIndex] = DASH;
+								patIndex = patIndex + 1;
+							}
+						}
+					}
+					else{
+						if(patIndex < patLen){
+							dest[patIndex] = DASH;
+							patIndex = patIndex + 1;
+						}
+					}
+				}
+				else{
+					if(patIndex < patLen){
+						dest[patIndex] = DASH;
+						patIndex = patIndex + 1;
+					}
+				}
+			}
+			patParaIndex = patParaIndex + 1;
+			//
+			continueIndex = false;
+			if(src[patParaIndex] != delim){
+				if(src[patParaIndex] != ENDSTR){
+					continueIndex = true;
+				}
+			}
+		}
+	}
+	
+	/*
+	 * 
+	 */
+	private static boolean isalnum(char ch) {
+		if(ch >= '0'){
+			if(ch <= '9'){
+				return true;
+			}
+			else if (ch >= 'A'){
+				if(ch <= 'Z'){
+					return true;
+				}
+				else if(ch >= 'a'){
+					if(ch <= 'z'){
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+	
+
+	public static void main(String[] args) {
+		mainProcess('2', '&', 'a', 'a', '0');
+	}
+
+}


### PR DESCRIPTION
The replace program is part of the Siemens suite of programs. This
benchmark performs pattern matching and substitution. One simple
property that should fail on this benchmark is that the outputs of the
benchmark from running it twice should not be equivalent if the starting
states of the benchmark were not equivalent. This is done by not
resetting the benchmark to its starting state. This benchmark was
obtained from Wang et al.
(https://labs.xjtudlc.com/labs/wlaq/hjwang/toolbench.html).

- equivalence-check on the replace benchmark in a folder named replace5_eqchk
- This benchmark wasn't distributed with a license. However, since this benchmark is being contributed by the developers of Java Ranger, we're adding under the same license used to maintain Java Ranger. Since Java Ranger is an extension of SPF, the same license as SPF and JPF also applies to this benchmark.
- contributed by Java Ranger (https://github.com/vaibhavbsharma/java-ranger) but the benchmark was originally distributed by Wang et al. (https://labs.xjtudlc.com/labs/wlaq/hjwang/toolbench.html). 
- replace5_eqchk has been added under java-ranger-regressions which has been added to ReachSafety.set
- assert.prp has been used as the property file
- replace5_eqchk.yml contains the expected answer (false)
