### PR TITLE
Added a simple C nested loop example

### DIFF
--- a/c/ReachSafety-Loops.set
+++ b/c/ReachSafety-Loops.set
@@ -7,6 +7,7 @@ loop-new/*.yml
 loop-industry-pattern/*.yml
 loops-crafted-1/*.yml
 loop-invariants/*.yml
+loop-simple/*.yml
 verifythis/duplets.yml
 verifythis/elimination_max.yml
 verifythis/lcp.yml

--- a/c/loop-simple/LICENSE.txt
+++ b/c/loop-simple/LICENSE.txt
@@ -1,0 +1,1 @@
+../../LICENSE.Apache-2.0.txt

--- a/c/loop-simple/Makefile
+++ b/c/loop-simple/Makefile
@@ -1,0 +1,3 @@
+LEVEL := ../
+
+include $(LEVEL)/Makefile.config

--- a/c/loop-simple/README.txt
+++ b/c/loop-simple/README.txt
@@ -1,0 +1,2 @@
+Simple loop example programs.
+ - deep-nested: Intended to show that execution-based witness violators are not always a good solution. Written by Philipp Berger, RWTH Aachen University.

--- a/c/loop-simple/deep-nested.c
+++ b/c/loop-simple/deep-nested.c
@@ -1,0 +1,24 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+int main() {
+	unsigned a, b, c, d, e;
+
+	unsigned uint32_max;
+	uint32_max = 0xffffffff;
+
+	for (a = 0; a < uint32_max - 1; ++a) {
+		for (b = 0; b < uint32_max - 1; ++b) {
+			for (c = 0; c < uint32_max - 1; ++c) {
+				for (d = 0; d < uint32_max - 1; ++d) {
+					for (e = 0; e < uint32_max - 1; ++e) {
+						if ((a == b) && (b == c) && (c == d) && (d == e) && (e == (uint32_max - 2))) {
+							__VERIFIER_error();
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return 0;
+}

--- a/c/loop-simple/deep-nested.yml
+++ b/c/loop-simple/deep-nested.yml
@@ -1,0 +1,9 @@
+format_version: '1.0'
+
+input_files: 'deep-nested.c'
+
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: false


### PR DESCRIPTION
I want to add an example program for situations where execution-based witness validators are out of their comfort zone.

I hope I chose a correct subdirectory - I would have preferred to add it to an existing one instead of creating a new one, but regarding the attribution style, this seems impractical.

I believe all relevant elements of this checklist are fulfilled, preprocessing was not necessary.

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
