### PR TITLE
Adding new benchmarks for reachsafety - arrays and loops.

### DIFF
--- a/c/ReachSafety-Arrays.set
+++ b/c/ReachSafety-Arrays.set
@@ -6,3 +6,5 @@ array-programs/*.yml
 array-crafted/*.yml
 array-multidimensional/*.yml
 array-patterns/*.yml
+array-cav19/*.yml
+array-lopstr16/*.yml

--- a/c/array-cav19/LICENSE
+++ b/c/array-cav19/LICENSE
@@ -1,0 +1,1 @@
+../../LICENSE.Apache-2.0.txt

--- a/c/array-cav19/Makefile
+++ b/c/array-cav19/Makefile
@@ -1,0 +1,3 @@
+LEVEL := ../
+
+include $(LEVEL)/Makefile.config

--- a/c/array-cav19/README.txt
+++ b/c/array-cav19/README.txt
@@ -1,0 +1,1 @@
+Benchmarks submitted by VeriAbs team, TCS Innovation labs, Pune.

--- a/c/array-cav19/array_doub_access_init_const.c
+++ b/c/array-cav19/array_doub_access_init_const.c
@@ -14,6 +14,5 @@ int main()
 
   for(i=0;i<=2*N;i++)
     __VERIFIER_assert(a[i]>=0);
+  return 0;
 }
-
-    

--- a/c/array-cav19/array_doub_access_init_const.c
+++ b/c/array-cav19/array_doub_access_init_const.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int N=100000;
+  int a[2*N+2];
+
+  for(i=0;i<=N;i++) {
+    a[2*i]=0;
+    a[2*i+1]=0;
+  }
+
+  for(i=0;i<=2*N;i++)
+    __VERIFIER_assert(a[i]>=0);
+}
+
+    

--- a/c/array-cav19/array_doub_access_init_const.yml
+++ b/c/array-cav19/array_doub_access_init_const.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_doub_access_init_const.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_both_ends_multiple_sum.c
+++ b/c/array-cav19/array_init_both_ends_multiple_sum.c
@@ -9,8 +9,6 @@ int main()
   int i;
   int sum=0;
   
-  //  __VERIFIER_assume(N>0 && N<10000);
-
   for (i=0;i<N;i++) {
     a[i] = i;
   }
@@ -24,4 +22,5 @@ int main()
   }
 
   __VERIFIER_assert(sum == 0);
+  return 0;
 }

--- a/c/array-cav19/array_init_both_ends_multiple_sum.c
+++ b/c/array-cav19/array_init_both_ends_multiple_sum.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-#define N 100000 
+int N = 100000;
 int main()
 {
   int a[N];

--- a/c/array-cav19/array_init_both_ends_multiple_sum.c
+++ b/c/array-cav19/array_init_both_ends_multiple_sum.c
@@ -1,9 +1,9 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define N 100000 
 int main()
 {
-  int N;
   int a[N];
   int b[N];
   int i;

--- a/c/array-cav19/array_init_both_ends_multiple_sum.c
+++ b/c/array-cav19/array_init_both_ends_multiple_sum.c
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int N;
+  int a[N];
+  int b[N];
+  int i;
+  int sum=0;
+  
+  //  __VERIFIER_assume(N>0 && N<10000);
+
+  for (i=0;i<N;i++) {
+    a[i] = i;
+  }
+
+  for (i=0;i<N;i++) {
+    b[N-i-1]=i;
+  }
+
+  for (i=0;i<N;i++) {
+    sum=sum+(a[i]-b[N-i-1]);
+  }
+
+  __VERIFIER_assert(sum == 0);
+}

--- a/c/array-cav19/array_init_both_ends_multiple_sum.yml
+++ b/c/array-cav19/array_init_both_ends_multiple_sum.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_both_ends_multiple_sum.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_nondet_vars.c
+++ b/c/array-cav19/array_init_nondet_vars.c
@@ -19,6 +19,7 @@ int main()
 
   for(i=1;i<n;i++)
     __VERIFIER_assert(a[i]>=(i+2));
+  return 0;
 }
 
     

--- a/c/array-cav19/array_init_nondet_vars.c
+++ b/c/array-cav19/array_init_nondet_vars.c
@@ -1,18 +1,19 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
   int i;
-  int j;
-  int n;
+  int j=__VERIFIER_nondet_int();
+  int n=__VERIFIER_nondet_int();
+  __VERIFIER_assume(n < 100000);
   int a[n];
 
   __VERIFIER_assume(j>0 && j < 10000);
-  __VERIFIER_assume(n < 100000);
  
   for(i=1;i<n;i++) {
-    int k;
+    int k=__VERIFIER_nondet_int();
     __VERIFIER_assume(k>0 && k < 10000);
     a[i]=i+j+k;
   }
@@ -20,6 +21,4 @@ int main()
   for(i=1;i<n;i++)
     __VERIFIER_assert(a[i]>=(i+2));
   return 0;
-}
-
-    
+}  

--- a/c/array-cav19/array_init_nondet_vars.c
+++ b/c/array-cav19/array_init_nondet_vars.c
@@ -1,0 +1,24 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int j;
+  int n;
+  int a[n];
+
+  __VERIFIER_assume(j>0 && j < 10000);
+  __VERIFIER_assume(n < 100000);
+ 
+  for(i=1;i<n;i++) {
+    int k;
+    __VERIFIER_assume(k>0 && k < 10000);
+    a[i]=i+j+k;
+  }
+
+  for(i=1;i<n;i++)
+    __VERIFIER_assert(a[i]>=(i+2));
+}
+
+    

--- a/c/array-cav19/array_init_nondet_vars.yml
+++ b/c/array-cav19/array_init_nondet_vars.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_nondet_vars.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_pair_sum_const.c
+++ b/c/array-cav19/array_init_pair_sum_const.c
@@ -1,0 +1,25 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int N=100000;
+  int a[N];
+  int b[N];
+  int c[N];
+
+  for(i=0;i<N;i++) {
+    a[i]=1;
+    b[i]=2;
+  }
+
+  for(i=0;i<N;i++){
+    c[i]=a[i]+b[i];
+  }
+
+  for(i=1;i<N;i++)
+    __VERIFIER_assert(c[i] >= 3);
+}
+
+

--- a/c/array-cav19/array_init_pair_sum_const.c
+++ b/c/array-cav19/array_init_pair_sum_const.c
@@ -20,6 +20,7 @@ int main()
 
   for(i=1;i<N;i++)
     __VERIFIER_assert(c[i] >= 3);
+  return 0;
 }
 
 

--- a/c/array-cav19/array_init_pair_sum_const.yml
+++ b/c/array-cav19/array_init_pair_sum_const.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_pair_sum_const.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_pair_symmetr.c
+++ b/c/array-cav19/array_init_pair_symmetr.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
-#define N 100000
+int N = 100000;
 int main()
 {
   int i;

--- a/c/array-cav19/array_init_pair_symmetr.c
+++ b/c/array-cav19/array_init_pair_symmetr.c
@@ -1,16 +1,17 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define N 100000
 int main()
 {
   int i;
-  int N;
   int a[N];
   int b[N];
   int c[N];
 
   for(i=0;i<N;i++) {
-    int x;
+    int x=__VERIFIER_nondet_int();
     __VERIFIER_assume(x > -100000 && x < 100000);
     a[i]=x;
     b[i]=-x;
@@ -24,5 +25,3 @@ int main()
     __VERIFIER_assert(c[i] == 0);
   return 0;
 }
-
-

--- a/c/array-cav19/array_init_pair_symmetr.c
+++ b/c/array-cav19/array_init_pair_symmetr.c
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int N;
+  int a[N];
+  int b[N];
+  int c[N];
+
+  for(i=0;i<N;i++) {
+    int x;
+    __VERIFIER_assume(x > -100000 && x < 100000);
+    a[i]=x;
+    b[i]=-x;
+  }
+
+  for(i=0;i<N;i++){
+    c[i]=a[i]+b[i];
+  }
+
+  for(i=1;i<N;i++)
+    __VERIFIER_assert(c[i] == 0);
+}
+
+

--- a/c/array-cav19/array_init_pair_symmetr.c
+++ b/c/array-cav19/array_init_pair_symmetr.c
@@ -22,6 +22,7 @@ int main()
 
   for(i=1;i<N;i++)
     __VERIFIER_assert(c[i] == 0);
+  return 0;
 }
 
 

--- a/c/array-cav19/array_init_pair_symmetr.yml
+++ b/c/array-cav19/array_init_pair_symmetr.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_pair_symmetr.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_pair_symmetr2.c
+++ b/c/array-cav19/array_init_pair_symmetr2.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
-#define N 100000
+int N = 100000;
 int main()
 {
   int i;

--- a/c/array-cav19/array_init_pair_symmetr2.c
+++ b/c/array-cav19/array_init_pair_symmetr2.c
@@ -1,17 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define N 100000
 int main()
 {
   int i;
-  int N;
   int a[N];
   int b[N];
   int c[N];
 
   for(i=0;i<N;i++) {
-    int x;
-    int y;
+    int x=__VERIFIER_nondet_int();
+    int y=__VERIFIER_nondet_int();
     __VERIFIER_assume(y<100000 && y > -100000);
     __VERIFIER_assume(x<100000 && x > -100000);
     __VERIFIER_assume(x>y);

--- a/c/array-cav19/array_init_pair_symmetr2.c
+++ b/c/array-cav19/array_init_pair_symmetr2.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int N;
+  int a[N];
+  int b[N];
+  int c[N];
+
+  for(i=0;i<N;i++) {
+    int x;
+    int y;
+    __VERIFIER_assume(y<100000 && y > -100000);
+    __VERIFIER_assume(x<100000 && x > -100000);
+    __VERIFIER_assume(x>y);
+    a[i]=x;
+    b[i]=y;
+  }
+
+  for(i=0;i<N;i++){
+    c[i]=a[i]-b[i];
+  }
+
+  for(i=1;i<N;i++)
+    __VERIFIER_assert(c[i] > 0);
+}

--- a/c/array-cav19/array_init_pair_symmetr2.c
+++ b/c/array-cav19/array_init_pair_symmetr2.c
@@ -25,4 +25,5 @@ int main()
 
   for(i=1;i<N;i++)
     __VERIFIER_assert(c[i] > 0);
+  return 0;
 }

--- a/c/array-cav19/array_init_pair_symmetr2.yml
+++ b/c/array-cav19/array_init_pair_symmetr2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_pair_symmetr2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_var_plus_ind.c
+++ b/c/array-cav19/array_init_var_plus_ind.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
-#define N 100000
+int N = 100000;
 int main()
 {
   int i;

--- a/c/array-cav19/array_init_var_plus_ind.c
+++ b/c/array-cav19/array_init_var_plus_ind.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int j=0;
+  int N;
+  int a[N];
+
+  for(i=0;i<N;i++){
+    int x;
+    if(x) break;
+    a[i]=j;
+    j=j+i;
+  }
+
+  for(int k=1;k<i;k++)
+    __VERIFIER_assert(a[k]>=0);
+}
+

--- a/c/array-cav19/array_init_var_plus_ind.c
+++ b/c/array-cav19/array_init_var_plus_ind.c
@@ -17,5 +17,6 @@ int main()
 
   for(int k=1;k<i;k++)
     __VERIFIER_assert(a[k]>=0);
+  return 0;
 }
 

--- a/c/array-cav19/array_init_var_plus_ind.c
+++ b/c/array-cav19/array_init_var_plus_ind.c
@@ -1,15 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define N 100000
 int main()
 {
   int i;
   int j=0;
-  int N;
   int a[N];
 
   for(i=0;i<N;i++){
-    int x;
+    int x=__VERIFIER_nondet_int();
     if(x) break;
     a[i]=j;
     j=j+i;

--- a/c/array-cav19/array_init_var_plus_ind.yml
+++ b/c/array-cav19/array_init_var_plus_ind.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_var_plus_ind.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_var_plus_ind2.c
+++ b/c/array-cav19/array_init_var_plus_ind2.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
-#define N 100000
+int N = 100000;
 int main()
 {
   int i;

--- a/c/array-cav19/array_init_var_plus_ind2.c
+++ b/c/array-cav19/array_init_var_plus_ind2.c
@@ -19,5 +19,6 @@ int main()
 
   for(int l=1;l<i;l++)
     __VERIFIER_assert(a[l]>=k);
+  return 0;
 }
 

--- a/c/array-cav19/array_init_var_plus_ind2.c
+++ b/c/array-cav19/array_init_var_plus_ind2.c
@@ -1,0 +1,23 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int j=0;
+  int k=0;
+  int N;
+  int a[N];
+
+  for(i=0;i<N;i++){
+    int x;
+    if(x) break;
+    a[i]=j;
+    j=j+i;
+    k=k-i;
+  }
+
+  for(int l=1;l<i;l++)
+    __VERIFIER_assert(a[l]>=k);
+}
+

--- a/c/array-cav19/array_init_var_plus_ind2.c
+++ b/c/array-cav19/array_init_var_plus_ind2.c
@@ -1,16 +1,17 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define N 100000
 int main()
 {
   int i;
   int j=0;
   int k=0;
-  int N;
   int a[N];
 
   for(i=0;i<N;i++){
-    int x;
+    int x=__VERIFIER_nondet_int();
     if(x) break;
     a[i]=j;
     j=j+i;

--- a/c/array-cav19/array_init_var_plus_ind2.yml
+++ b/c/array-cav19/array_init_var_plus_ind2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_var_plus_ind2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_init_var_plus_ind3.c
+++ b/c/array-cav19/array_init_var_plus_ind3.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
-#define N 100000
+int N = 100000;
 int main()
 {
   int i;

--- a/c/array-cav19/array_init_var_plus_ind3.c
+++ b/c/array-cav19/array_init_var_plus_ind3.c
@@ -1,15 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define N 100000
 int main()
 {
   int i;
   int j=0;
-  int N;
   int a[N];
 
   for(i=0;i<N;i++){
-    int x;
+    int x=__VERIFIER_nondet_int();
     if(x) break;
     a[i]=j;
     j=j-i;

--- a/c/array-cav19/array_init_var_plus_ind3.c
+++ b/c/array-cav19/array_init_var_plus_ind3.c
@@ -17,5 +17,6 @@ int main()
 
   for(int k=4;k<i;k++)
     __VERIFIER_assert(a[k] <= 0);
+  return 0;
 }
 

--- a/c/array-cav19/array_init_var_plus_ind3.c
+++ b/c/array-cav19/array_init_var_plus_ind3.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int j=0;
+  int N;
+  int a[N];
+
+  for(i=0;i<N;i++){
+    int x;
+    if(x) break;
+    a[i]=j;
+    j=j-i;
+  }
+
+  for(int k=4;k<i;k++)
+    __VERIFIER_assert(a[k] <= 0);
+}
+

--- a/c/array-cav19/array_init_var_plus_ind3.yml
+++ b/c/array-cav19/array_init_var_plus_ind3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_init_var_plus_ind3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_min_and_copy_shift_sum_add.c
+++ b/c/array-cav19/array_min_and_copy_shift_sum_add.c
@@ -1,18 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
   int i;
-  int j;
+  int j=__VERIFIER_nondet_int();
+  __VERIFIER_assume(j < 10000 && j > -10000);
   int k = 0;
-  int N;
+  int N=__VERIFIER_nondet_int();
+  __VERIFIER_assume(N < 10000 && N > -10000);
   int a[N+1];
   int b[N];
 
-  __VERIFIER_assume(N < 10000 && N > -10000);
-  __VERIFIER_assume(j < 10000 && j > -10000);
-  
   for(i=0;i<N;i++) {
     __VERIFIER_assume(a[i] < 10000 && a[i] > -10000);
     if (j > a[i])

--- a/c/array-cav19/array_min_and_copy_shift_sum_add.c
+++ b/c/array-cav19/array_min_and_copy_shift_sum_add.c
@@ -28,4 +28,5 @@ int main()
   }
       
   __VERIFIER_assert(k >= 0);
+  return 0;
 }

--- a/c/array-cav19/array_min_and_copy_shift_sum_add.c
+++ b/c/array-cav19/array_min_and_copy_shift_sum_add.c
@@ -1,0 +1,31 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int j;
+  int k = 0;
+  int N;
+  int a[N+1];
+  int b[N];
+
+  __VERIFIER_assume(N < 10000 && N > -10000);
+  __VERIFIER_assume(j < 10000 && j > -10000);
+  
+  for(i=0;i<N;i++) {
+    __VERIFIER_assume(a[i] < 10000 && a[i] > -10000);
+    if (j > a[i])
+      j = a[i];
+  }
+
+  for(i=0;i<N;i++) {
+    b[i] = a[i]-j;
+  }
+
+  for(i=0;i<N;i++) {
+    k = k+b[i]+i;
+  }
+      
+  __VERIFIER_assert(k >= 0);
+}

--- a/c/array-cav19/array_min_and_copy_shift_sum_add.yml
+++ b/c/array-cav19/array_min_and_copy_shift_sum_add.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_min_and_copy_shift_sum_add.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_tiling_poly6.c
+++ b/c/array-cav19/array_tiling_poly6.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int S;
+  int i;
+  int a[S];
+
+  __VERIFIER_assume(S>1);
+  
+  for(i=0;i<S;i++)
+    a[i]=((i-1)*(i+1));
+
+  for(i=0;i<S;i++)
+    a[i]=a[i]-(i*i);
+
+  for(i=0;i<S;i++)
+    __VERIFIER_assert(a[i]==-1);
+}
+

--- a/c/array-cav19/array_tiling_poly6.c
+++ b/c/array-cav19/array_tiling_poly6.c
@@ -17,5 +17,6 @@ int main()
 
   for(i=0;i<S;i++)
     __VERIFIER_assert(a[i]==-1);
+  return 0;
 }
 

--- a/c/array-cav19/array_tiling_poly6.c
+++ b/c/array-cav19/array_tiling_poly6.c
@@ -1,14 +1,14 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
-  int S;
+  int S=__VERIFIER_nondet_int();
+  __VERIFIER_assume(S>1);
   int i;
   int a[S];
 
-  __VERIFIER_assume(S>1);
-  
   for(i=0;i<S;i++)
     a[i]=((i-1)*(i+1));
 

--- a/c/array-cav19/array_tiling_poly6.yml
+++ b/c/array-cav19/array_tiling_poly6.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_tiling_poly6.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_tiling_tcpy.c
+++ b/c/array-cav19/array_tiling_tcpy.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int S;
+  int i;
+  int a[2*S];
+  int acopy[2*S];
+
+  __VERIFIER_assume(S>1);
+  
+  for(i=0;i < S;i++) {
+    acopy[2*S - (i+1)] = a[2*S - (i+1)];
+    acopy[i] = a[i];
+  }
+
+  for(i=0;i<2*S;i++)
+    __VERIFIER_assert(acopy[i] == a[i]);
+}
+

--- a/c/array-cav19/array_tiling_tcpy.c
+++ b/c/array-cav19/array_tiling_tcpy.c
@@ -17,5 +17,6 @@ int main()
 
   for(i=0;i<2*S;i++)
     __VERIFIER_assert(acopy[i] == a[i]);
+  return 0;
 }
 

--- a/c/array-cav19/array_tiling_tcpy.c
+++ b/c/array-cav19/array_tiling_tcpy.c
@@ -1,14 +1,15 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
-  int S;
+  int S=__VERIFIER_nondet_int();
+  __VERIFIER_assume(S>1);
   int i;
   int a[2*S];
   int acopy[2*S];
 
-  __VERIFIER_assume(S>1);
   
   for(i=0;i < S;i++) {
     acopy[2*S - (i+1)] = a[2*S - (i+1)];

--- a/c/array-cav19/array_tiling_tcpy.yml
+++ b/c/array-cav19/array_tiling_tcpy.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_tiling_tcpy.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-cav19/array_tripl_access_init_const.c
+++ b/c/array-cav19/array_tripl_access_init_const.c
@@ -15,5 +15,6 @@ int main()
 
   for(i=0;i<=3*N;i++)
     __VERIFIER_assert(a[i] >= 0);
+  return 0;
 }
 

--- a/c/array-cav19/array_tripl_access_init_const.c
+++ b/c/array-cav19/array_tripl_access_init_const.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main()
+{
+  int i;
+  int N=100000;
+  int a[3*N+1];
+
+  for(i=0; i<= N; i++) {
+    a[3*i] =0;
+    a[3*i+1]=0;
+    a[3*i+2]=0;
+  }
+
+  for(i=0;i<=3*N;i++)
+    __VERIFIER_assert(a[i] >= 0);
+}
+

--- a/c/array-cav19/array_tripl_access_init_const.yml
+++ b/c/array-cav19/array_tripl_access_init_const.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'array_tripl_access_init_const.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/LICENSE
+++ b/c/array-lopstr16/LICENSE
@@ -1,0 +1,1 @@
+../../LICENSE.Apache-2.0.txt

--- a/c/array-lopstr16/Makefile
+++ b/c/array-lopstr16/Makefile
@@ -1,0 +1,3 @@
+LEVEL := ../
+
+include $(LEVEL)/Makefile.config

--- a/c/array-lopstr16/README.txt
+++ b/c/array-lopstr16/README.txt
@@ -1,0 +1,1 @@
+Benchmarks submitted by VeriAbs team, TCS Innovation labs, Pune.

--- a/c/array-lopstr16/base_case.c
+++ b/c/array-lopstr16/base_case.c
@@ -1,6 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
+void *malloc(unsigned int size);
 #define SIZE 1000000
 #define NULL '\0'
 struct S

--- a/c/array-lopstr16/base_case.c
+++ b/c/array-lopstr16/base_case.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
 void *malloc(unsigned int size);
 #define SIZE 1000000
-#define NULL '\0'
+#define NULL 0
 struct S
 {
 	int n;

--- a/c/array-lopstr16/base_case.c
+++ b/c/array-lopstr16/base_case.c
@@ -1,0 +1,45 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define SIZE 1000000
+#define NULL '\0'
+struct S
+{
+	int n;
+	int *p;
+};
+struct S *a[SIZE];
+
+int main()
+{
+
+	int i;
+
+	for (i = 0; i < SIZE; i++)
+	{
+		struct S *s1 = (struct S *) malloc(sizeof(struct S));
+		s1->n = __VERIFIER_nondet_int();
+
+		if (s1->n == 0)
+		{
+			s1->p = (int *) malloc(sizeof(int));
+		}
+		else
+		{
+			s1->p = NULL;
+		}
+
+		a[i] = s1;
+	}
+
+	for (i = 0; i < SIZE; i++)
+	{
+		struct S *s2 = a[i];
+		if (s2->n == 0)
+		{
+			__VERIFIER_assert(s2->p != NULL);
+		}
+	}
+
+	return 0;
+}

--- a/c/array-lopstr16/base_case.i
+++ b/c/array-lopstr16/base_case.i
@@ -1,0 +1,37 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+void *malloc(unsigned int size);
+struct S
+{
+ int n;
+ int *p;
+};
+struct S *a[1000000];
+int main()
+{
+ int i;
+ for (i = 0; i < 1000000; i++)
+ {
+  struct S *s1 = (struct S *) malloc(sizeof(struct S));
+  s1->n = __VERIFIER_nondet_int();
+  if (s1->n == 0)
+  {
+   s1->p = (int *) malloc(sizeof(int));
+  }
+  else
+  {
+   s1->p = 0;
+  }
+  a[i] = s1;
+ }
+ for (i = 0; i < 1000000; i++)
+ {
+  struct S *s2 = a[i];
+  if (s2->n == 0)
+  {
+   __VERIFIER_assert(s2->p != 0);
+  }
+ }
+ return 0;
+}

--- a/c/array-lopstr16/base_case.yml
+++ b/c/array-lopstr16/base_case.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'base_case.c'
+input_files: 'base_case.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/base_case.yml
+++ b/c/array-lopstr16/base_case.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'base_case.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/break-1.c
+++ b/c/array-lopstr16/break-1.c
@@ -1,0 +1,31 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 1000000
+#define NULL '\0'
+struct S
+{
+	int *n;
+};
+
+struct S s[SIZE];
+
+int main()
+{
+	int i;
+	int c;
+	for(i = 0; i < SIZE; i++)
+	{
+		if(c > 5)
+			break;
+
+		s[i].n = malloc(sizeof(int));
+	}
+
+	for(i = 0; i < SIZE; i++)
+	{
+		if(c <= 5)
+			__VERIFIER_assert(s[i].n != NULL);
+	}
+
+	return 0;
+}

--- a/c/array-lopstr16/break-1.c
+++ b/c/array-lopstr16/break-1.c
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 void *malloc(unsigned int size);
+extern int __VERIFIER_nondet_int(void);
 #define SIZE 1000000
-#define NULL '\0'
+#define NULL 0
 struct S
 {
 	int *n;
@@ -13,7 +14,7 @@ struct S s[SIZE];
 int main()
 {
 	int i;
-	int c;
+	int c=__VERIFIER_nondet_int();
 	for(i = 0; i < SIZE; i++)
 	{
 		if(c > 5)

--- a/c/array-lopstr16/break-1.c
+++ b/c/array-lopstr16/break-1.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
 #define SIZE 1000000
 #define NULL '\0'
 struct S

--- a/c/array-lopstr16/break-1.i
+++ b/c/array-lopstr16/break-1.i
@@ -1,0 +1,26 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
+extern int __VERIFIER_nondet_int(void);
+struct S
+{
+ int *n;
+};
+struct S s[1000000];
+int main()
+{
+ int i;
+ int c=__VERIFIER_nondet_int();
+ for(i = 0; i < 1000000; i++)
+ {
+  if(c > 5)
+   break;
+  s[i].n = malloc(sizeof(int));
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  if(c <= 5)
+   __VERIFIER_assert(s[i].n != 0);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/break-1.yml
+++ b/c/array-lopstr16/break-1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'break-1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/break-1.yml
+++ b/c/array-lopstr16/break-1.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'break-1.c'
+input_files: 'break-1.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/break-2.c
+++ b/c/array-lopstr16/break-2.c
@@ -1,0 +1,30 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 1000000
+struct S
+{
+	int n;
+};
+
+struct S s[SIZE];
+
+int main()
+{
+	int i;
+
+	for(i = 0; i < SIZE; i++)
+	{
+		if(i > SIZE / 2)
+			break;
+
+		s[i].n = 10;
+	}
+
+	for(i = 0; i < SIZE; i++)
+	{
+		if(i <= SIZE /2 )
+			__VERIFIER_assert(s[i].n == 10);
+	}
+
+	return 0;
+}

--- a/c/array-lopstr16/break-2.i
+++ b/c/array-lopstr16/break-2.i
@@ -1,0 +1,23 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+struct S
+{
+ int n;
+};
+struct S s[1000000];
+int main()
+{
+ int i;
+ for(i = 0; i < 1000000; i++)
+ {
+  if(i > 1000000 / 2)
+   break;
+  s[i].n = 10;
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  if(i <= 1000000 /2 )
+   __VERIFIER_assert(s[i].n == 10);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/break-2.yml
+++ b/c/array-lopstr16/break-2.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'break-2.c'
+input_files: 'break-2.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/break-2.yml
+++ b/c/array-lopstr16/break-2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'break-2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/flag_loopdep.c
+++ b/c/array-lopstr16/flag_loopdep.c
@@ -1,0 +1,46 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 1000000
+#define NULL '\0'
+typedef struct
+{
+	int *n;
+}S;
+int nondet_pointer();
+
+void init(S a[], int size)
+{
+	int i;
+	for(i = 0; i < size; i++)
+	{
+		a[i].n = (int *) malloc(sizeof(int));
+	}
+}
+
+int main()
+{
+	S a[SIZE];
+	int i;
+	int flag;
+	flag = 0;
+
+	init(a, SIZE);
+
+	for(i = 0; i < SIZE; i++)
+	{
+		if(a[i].n != NULL)
+		{
+			flag = 1;
+		}
+	}
+
+	
+	for(i = 0; i < SIZE; i++)
+	{
+		if (flag == 0)
+		__VERIFIER_assert(a[i].n == NULL);
+	}
+	
+	
+	return 0;
+}	

--- a/c/array-lopstr16/flag_loopdep.c
+++ b/c/array-lopstr16/flag_loopdep.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
 #define SIZE 1000000
 #define NULL '\0'
 typedef struct

--- a/c/array-lopstr16/flag_loopdep.i
+++ b/c/array-lopstr16/flag_loopdep.i
@@ -1,0 +1,37 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
+typedef struct
+{
+ int *n;
+}S;
+int nondet_pointer();
+void init(S a[], int size)
+{
+ int i;
+ for(i = 0; i < size; i++)
+ {
+  a[i].n = (int *) malloc(sizeof(int));
+ }
+}
+int main()
+{
+ S a[1000000];
+ int i;
+ int flag;
+ flag = 0;
+ init(a, 1000000);
+ for(i = 0; i < 1000000; i++)
+ {
+  if(a[i].n != '\0')
+  {
+   flag = 1;
+  }
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  if (flag == 0)
+  __VERIFIER_assert(a[i].n == '\0');
+ }
+ return 0;
+}

--- a/c/array-lopstr16/flag_loopdep.yml
+++ b/c/array-lopstr16/flag_loopdep.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'flag_loopdep.c'
+input_files: 'flag_loopdep.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/flag_loopdep.yml
+++ b/c/array-lopstr16/flag_loopdep.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'flag_loopdep.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/flag_loopdep_simple.c
+++ b/c/array-lopstr16/flag_loopdep_simple.c
@@ -1,0 +1,45 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define SIZE 1000000
+typedef struct
+{
+	int n;
+}S;
+
+void init(S a[], int size)
+{
+	int i;
+	for(i = 0; i < size; i++)
+	{
+		a[i].n = __VERIFIER_nondet_int();
+	}
+}
+
+int main()
+{
+	S a[SIZE];
+	int i;
+	int flag;
+	flag = 0;
+
+	init(a, SIZE);
+
+	for(i = 0; i < SIZE; i++)
+	{
+		if(a[i].n != 0)
+		{
+			flag = 1;
+		}
+	}
+
+	
+	for(i = 0; i < SIZE; i++)
+	{
+		if (flag == 0)
+		__VERIFIER_assert(a[i].n == 0 );
+	}
+	
+	
+	return 0;
+}	

--- a/c/array-lopstr16/flag_loopdep_simple.i
+++ b/c/array-lopstr16/flag_loopdep_simple.i
@@ -1,0 +1,36 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+typedef struct
+{
+ int n;
+}S;
+void init(S a[], int size)
+{
+ int i;
+ for(i = 0; i < size; i++)
+ {
+  a[i].n = __VERIFIER_nondet_int();
+ }
+}
+int main()
+{
+ S a[1000000];
+ int i;
+ int flag;
+ flag = 0;
+ init(a, 1000000);
+ for(i = 0; i < 1000000; i++)
+ {
+  if(a[i].n != 0)
+  {
+   flag = 1;
+  }
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  if (flag == 0)
+  __VERIFIER_assert(a[i].n == 0 );
+ }
+ return 0;
+}

--- a/c/array-lopstr16/flag_loopdep_simple.yml
+++ b/c/array-lopstr16/flag_loopdep_simple.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'flag_loopdep_simple.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/flag_loopdep_simple.yml
+++ b/c/array-lopstr16/flag_loopdep_simple.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'flag_loopdep_simple.c'
+input_files: 'flag_loopdep_simple.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/motivex.c
+++ b/c/array-lopstr16/motivex.c
@@ -20,7 +20,7 @@ int main()
 
 	for (i = 0; i < SIZE; i++)
 	{
-		if ( nondet_short())
+		if (__VERIFIER_nondet_short() )
 		{
 			k = __VERIFIER_nondet_short();
 			a[i].p = k;

--- a/c/array-lopstr16/motivex.c
+++ b/c/array-lopstr16/motivex.c
@@ -1,0 +1,38 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+#define SIZE 1000000
+struct S {
+	unsigned short p;		  
+	unsigned short q;		 		  
+} a[10000];
+
+int main()
+{
+	unsigned char k;
+	
+	int i;
+	for (i  = 0; i < SIZE ; i++)
+	{
+		a[i].p = i; 
+		a[i].q = i ;
+	}
+
+	for (i = 0; i < SIZE; i++)
+	{
+		if ( nondet_short())
+		{
+			k = __VERIFIER_nondet_short();
+			a[i].p = k;
+			a[i].q = k * k ;
+		}
+	}
+
+	for (i = 0; i < SIZE; i++)
+	{
+		__VERIFIER_assert(a[i].p == a[i].q || a[i].q == a[i].p * a[i].p);
+	}
+
+	return 0;
+}
+

--- a/c/array-lopstr16/motivex.i
+++ b/c/array-lopstr16/motivex.i
@@ -1,0 +1,31 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+struct S {
+ unsigned short p;
+ unsigned short q;
+} a[10000];
+int main()
+{
+ unsigned char k;
+ int i;
+ for (i = 0; i < 1000000 ; i++)
+ {
+  a[i].p = i;
+  a[i].q = i ;
+ }
+ for (i = 0; i < 1000000; i++)
+ {
+  if (__VERIFIER_nondet_short() )
+  {
+   k = __VERIFIER_nondet_short();
+   a[i].p = k;
+   a[i].q = k * k ;
+  }
+ }
+ for (i = 0; i < 1000000; i++)
+ {
+  __VERIFIER_assert(a[i].p == a[i].q || a[i].q == a[i].p * a[i].p);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/motivex.yml
+++ b/c/array-lopstr16/motivex.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'motivex.c'
+input_files: 'motivex.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/motivex.yml
+++ b/c/array-lopstr16/motivex.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'motivex.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/partial_lesser_bound-1.c
+++ b/c/array-lopstr16/partial_lesser_bound-1.c
@@ -1,0 +1,32 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 10000000
+int a[SIZE];
+int i;
+main ()
+{
+	for(i=0;i<SIZE;i++)
+	{
+	a[i] = 0 ;
+	}
+
+	for(i=0;i<SIZE/2;i++)
+	{
+	a[i] = 10 ;
+	}
+
+
+	for(i=0;i<SIZE/2;i++)
+	{
+		__VERIFIER_assert(a[i]==10);
+	}
+	
+
+}	
+
+

--- a/c/array-lopstr16/partial_lesser_bound-1.c
+++ b/c/array-lopstr16/partial_lesser_bound-1.c
@@ -8,7 +8,7 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 10000000
 int a[SIZE];
 int i;
-main ()
+int main()
 {
 	for(i=0;i<SIZE;i++)
 	{
@@ -26,7 +26,7 @@ main ()
 		__VERIFIER_assert(a[i]==10);
 	}
 	
-
+	return 0;
 }	
 
 

--- a/c/array-lopstr16/partial_lesser_bound-1.i
+++ b/c/array-lopstr16/partial_lesser_bound-1.i
@@ -1,0 +1,25 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int a[10000000];
+int i;
+int main()
+{
+ for(i=0;i<10000000;i++)
+ {
+ a[i] = 0 ;
+ }
+ for(i=0;i<10000000/2;i++)
+ {
+ a[i] = 10 ;
+ }
+ for(i=0;i<10000000/2;i++)
+ {
+  __VERIFIER_assert(a[i]==10);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/partial_lesser_bound-1.yml
+++ b/c/array-lopstr16/partial_lesser_bound-1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_lesser_bound-1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/partial_lesser_bound-1.yml
+++ b/c/array-lopstr16/partial_lesser_bound-1.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'partial_lesser_bound-1.c'
+input_files: 'partial_lesser_bound-1.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/partial_lesser_bound.c
+++ b/c/array-lopstr16/partial_lesser_bound.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
 #define SIZE 1000000
 #define NULL '\0'
 int *a[SIZE];

--- a/c/array-lopstr16/partial_lesser_bound.c
+++ b/c/array-lopstr16/partial_lesser_bound.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 void *malloc(unsigned int size);
 #define SIZE 1000000
-#define NULL '\0'
+#define NULL 0
 int *a[SIZE];
 int i;
 int main()

--- a/c/array-lopstr16/partial_lesser_bound.c
+++ b/c/array-lopstr16/partial_lesser_bound.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 1000000
+#define NULL '\0'
+int *a[SIZE];
+int i;
+main ()
+{
+	for(i = 0; i < SIZE; i++)
+	{
+		a[i] = NULL;
+	}
+
+	for(i = 0; i < SIZE / 2; i++)
+	{
+		a[i] = malloc(sizeof(int)) ;
+	}
+
+
+	for(i = 0; i < SIZE / 2; i++)
+	{
+		__VERIFIER_assert(a[i] != NULL);
+	}
+
+
+}	
+
+

--- a/c/array-lopstr16/partial_lesser_bound.c
+++ b/c/array-lopstr16/partial_lesser_bound.c
@@ -4,7 +4,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 #define NULL '\0'
 int *a[SIZE];
 int i;
-main ()
+int main()
 {
 	for(i = 0; i < SIZE; i++)
 	{
@@ -21,8 +21,6 @@ main ()
 	{
 		__VERIFIER_assert(a[i] != NULL);
 	}
-
-
+	return 0;
 }	
-
 

--- a/c/array-lopstr16/partial_lesser_bound.i
+++ b/c/array-lopstr16/partial_lesser_bound.i
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+void *malloc(unsigned int size);
+int *a[1000000];
+int i;
+int main()
+{
+ for(i = 0; i < 1000000; i++)
+ {
+  a[i] = 0;
+ }
+ for(i = 0; i < 1000000 / 2; i++)
+ {
+  a[i] = malloc(sizeof(int)) ;
+ }
+ for(i = 0; i < 1000000 / 2; i++)
+ {
+  __VERIFIER_assert(a[i] != 0);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/partial_lesser_bound.yml
+++ b/c/array-lopstr16/partial_lesser_bound.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'partial_lesser_bound.c'
+input_files: 'partial_lesser_bound.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/partial_lesser_bound.yml
+++ b/c/array-lopstr16/partial_lesser_bound.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_lesser_bound.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/scalar_loopdep.c
+++ b/c/array-lopstr16/scalar_loopdep.c
@@ -1,0 +1,34 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define SIZE 100000
+struct _S
+{
+	int n;
+};
+typedef struct _S S;
+
+S a[SIZE];
+
+int main()
+{
+	int i,x;
+	int y = 100;
+	for(i = 0; i < SIZE; i++)
+	{
+		x = y;
+		a[i].n = y;
+		y++;
+	}
+
+
+	for(i = 0; i < SIZE; i++)
+	{
+		__VERIFIER_assert(a[i].n >= 100);
+		
+	}
+
+	return 0;
+}
+
+

--- a/c/array-lopstr16/scalar_loopdep.i
+++ b/c/array-lopstr16/scalar_loopdep.i
@@ -1,0 +1,24 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+struct _S
+{
+ int n;
+};
+typedef struct _S S;
+S a[100000];
+int main()
+{
+ int i,x;
+ int y = 100;
+ for(i = 0; i < 100000; i++)
+ {
+  x = y;
+  a[i].n = y;
+  y++;
+ }
+ for(i = 0; i < 100000; i++)
+ {
+  __VERIFIER_assert(a[i].n >= 100);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/scalar_loopdep.yml
+++ b/c/array-lopstr16/scalar_loopdep.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'scalar_loopdep.c'
+input_files: 'scalar_loopdep.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/scalar_loopdep.yml
+++ b/c/array-lopstr16/scalar_loopdep.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'scalar_loopdep.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/single_elem_safe.c
+++ b/c/array-lopstr16/single_elem_safe.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
 void *malloc(unsigned int size);
 #define SIZE 1000000
-#define NULL '\0'
+#define NULL (void *)0
 struct S
 {
 	int *p;

--- a/c/array-lopstr16/single_elem_safe.c
+++ b/c/array-lopstr16/single_elem_safe.c
@@ -1,6 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern int __VERIFIER_nondet_int();
+void *malloc(unsigned int size);
 #define SIZE 1000000
 #define NULL '\0'
 struct S

--- a/c/array-lopstr16/single_elem_safe.c
+++ b/c/array-lopstr16/single_elem_safe.c
@@ -1,0 +1,55 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define SIZE 1000000
+#define NULL '\0'
+struct S
+{
+	int *p;
+	int n;
+};
+
+struct S *a[SIZE];
+
+int main()
+{
+
+	int i;
+
+	for (i = 0; i < SIZE; i++)
+	{
+		int q = __VERIFIER_nondet_int();
+		struct S *s = NULL;
+		if (q == 0)
+		{
+			s = (struct S*) malloc(sizeof(struct S));
+			s->n = q % 2;
+		}
+		if (s != 0)
+		{
+			if (s->n == 0)
+			{
+				s->p = (int *) malloc(sizeof(int));
+			}
+			else
+			{
+				s->p = NULL;
+			}
+		}
+
+		a[i] = s;
+	}
+
+	a[3] = (struct S*) malloc(sizeof(struct S));
+
+	for (i = 0; i < SIZE; i++)
+	{
+		struct S *s1 = a[i];
+		if (i != 3 && s1 != NULL && s1->n == 0)
+		{
+			__VERIFIER_assert(s1->p != NULL); 
+		}
+	}
+	return 0;
+}
+

--- a/c/array-lopstr16/single_elem_safe.i
+++ b/c/array-lopstr16/single_elem_safe.i
@@ -1,0 +1,46 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+void *malloc(unsigned int size);
+struct S
+{
+ int *p;
+ int n;
+};
+struct S *a[1000000];
+int main()
+{
+ int i;
+ for (i = 0; i < 1000000; i++)
+ {
+  int q = __VERIFIER_nondet_int();
+  struct S *s = (void *)0;
+  if (q == 0)
+  {
+   s = (struct S*) malloc(sizeof(struct S));
+   s->n = q % 2;
+  }
+  if (s != 0)
+  {
+   if (s->n == 0)
+   {
+    s->p = (int *) malloc(sizeof(int));
+   }
+   else
+   {
+    s->p = (void *)0;
+   }
+  }
+  a[i] = s;
+ }
+ a[3] = (struct S*) malloc(sizeof(struct S));
+ for (i = 0; i < 1000000; i++)
+ {
+  struct S *s1 = a[i];
+  if (i != 3 && s1 != (void *)0 && s1->n == 0)
+  {
+   __VERIFIER_assert(s1->p != (void *)0);
+  }
+ }
+ return 0;
+}

--- a/c/array-lopstr16/single_elem_safe.yml
+++ b/c/array-lopstr16/single_elem_safe.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'single_elem_safe.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/single_elem_safe.yml
+++ b/c/array-lopstr16/single_elem_safe.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'single_elem_safe.c'
+input_files: 'single_elem_safe.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-lopstr16/sum_multi_array.c
+++ b/c/array-lopstr16/sum_multi_array.c
@@ -1,0 +1,41 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+#define SIZE 1000000
+struct _S
+{
+	int n;
+};
+typedef struct _S S;
+
+S a[SIZE];
+S b[SIZE];
+S c[SIZE];
+
+int main()
+{
+	
+	int i;
+
+	for(i = 0; i < SIZE; i++)
+	{
+		int v;
+	        v = __VERIFIER_nondet_int();
+		a[i].n= v;
+		v = __VERIFIER_nondet_int();
+		b[i].n = v;
+	}
+	
+	for(i = 0; i < SIZE; i++)
+	{
+		c[i].n = a[i].n + b[i].n;
+	}
+
+	for(i = 0; i < SIZE; i++)
+	{
+		__VERIFIER_assert(c[i].n == a[i].n + b[i].n);
+	}
+
+	return 0;
+}
+

--- a/c/array-lopstr16/sum_multi_array.i
+++ b/c/array-lopstr16/sum_multi_array.i
@@ -1,0 +1,32 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
+struct _S
+{
+ int n;
+};
+typedef struct _S S;
+S a[1000000];
+S b[1000000];
+S c[1000000];
+int main()
+{
+ int i;
+ for(i = 0; i < 1000000; i++)
+ {
+  int v;
+         v = __VERIFIER_nondet_int();
+  a[i].n= v;
+  v = __VERIFIER_nondet_int();
+  b[i].n = v;
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  c[i].n = a[i].n + b[i].n;
+ }
+ for(i = 0; i < 1000000; i++)
+ {
+  __VERIFIER_assert(c[i].n == a[i].n + b[i].n);
+ }
+ return 0;
+}

--- a/c/array-lopstr16/sum_multi_array.yml
+++ b/c/array-lopstr16/sum_multi_array.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sum_multi_array.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-lopstr16/sum_multi_array.yml
+++ b/c/array-lopstr16/sum_multi_array.yml
@@ -1,6 +1,6 @@
 format_version: '1.0'
 
-input_files: 'sum_multi_array.c'
+input_files: 'sum_multi_array.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp

--- a/c/array-programs/copysome1-1.c
+++ b/c/array-programs/copysome1-1.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-int N = 200000;
+#define N 200000
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome1-1.c
+++ b/c/array-programs/copysome1-1.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-#define N 200000
+int N = 200000;
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome1-2.c
+++ b/c/array-programs/copysome1-2.c
@@ -9,7 +9,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-#define N 200000
+int N = 200000;
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome1-2.c
+++ b/c/array-programs/copysome1-2.c
@@ -9,7 +9,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-int N = 200000;
+#define N 200000
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome2-1.c
+++ b/c/array-programs/copysome2-1.c
@@ -8,7 +8,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-#define N 200000
+int N = 200000;
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome2-1.c
+++ b/c/array-programs/copysome2-1.c
@@ -8,7 +8,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-int N = 200000;
+#define N 200000
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome2-2.c
+++ b/c/array-programs/copysome2-2.c
@@ -8,7 +8,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-#define N 200000
+int N = 200000;
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/copysome2-2.c
+++ b/c/array-programs/copysome2-2.c
@@ -8,7 +8,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int __VERIFIER_nondet_int();
 
-int N = 200000;
+#define N 200000
 
 int main( ) {
   int a1[N];

--- a/c/array-programs/partial_mod_count_1.c
+++ b/c/array-programs/partial_mod_count_1.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
 int main(){
-int i,j=0,k=0,a[N];
+int i,j=0,a[N];
   unsigned int R=1;
   for(i=0;i<N;i++){
     a[i]=i+1;

--- a/c/array-programs/partial_mod_count_1.c
+++ b/c/array-programs/partial_mod_count_1.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,a[N];
   unsigned int R=1;

--- a/c/array-programs/partial_mod_count_1.c
+++ b/c/array-programs/partial_mod_count_1.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R=1;
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2)
+       a[i]=i%R;
+    //if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < N/2);
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_1.c
+++ b/c/array-programs/partial_mod_count_1.c
@@ -2,18 +2,18 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=1;
   for(i=0;i<N;i++){
     a[i]=i+1;
     if(i>N/2)
        a[i]=i%R;
-    //if(a[i]==0) k++;
   }
   for(i=0;i<N;i++){
     if (a[i]==0) j++;
      __VERIFIER_assert(j < N/2);
   }
-} // assume R > 0
+  return 0;
+} 
 

--- a/c/array-programs/partial_mod_count_1.yml
+++ b/c/array-programs/partial_mod_count_1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_2.c
+++ b/c/array-programs/partial_mod_count_2.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,a[N];
   unsigned int R=2;

--- a/c/array-programs/partial_mod_count_2.c
+++ b/c/array-programs/partial_mod_count_2.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=2;
 
@@ -10,11 +10,11 @@ int i,j=0,k=0,a[N];
     a[i]=i+1;
     if(i>N/2)
        a[i]=i%R;
-    //if(a[i]==0) k++;
   }
   for(i=0;i<N;i++){
     if (a[i]==0) j++;
      __VERIFIER_assert(j < (N/4));
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_2.c
+++ b/c/array-programs/partial_mod_count_2.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
 int main(){
-int i,j=0,k=0,a[N];
+int i,j=0,a[N];
   unsigned int R=2;
 
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_2.c
+++ b/c/array-programs/partial_mod_count_2.c
@@ -1,0 +1,20 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R=2;
+
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2)
+       a[i]=i%R;
+    //if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < (N/4));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_2.yml
+++ b/c/array-programs/partial_mod_count_2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_3.c
+++ b/c/array-programs/partial_mod_count_3.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,a[N];
   unsigned int R=3;

--- a/c/array-programs/partial_mod_count_3.c
+++ b/c/array-programs/partial_mod_count_3.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R=3;
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2)
+       a[i]=i%R;
+    //if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < (N/6)+2);
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_3.c
+++ b/c/array-programs/partial_mod_count_3.c
@@ -2,18 +2,18 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=3;
   for(i=0;i<N;i++){
     a[i]=i+1;
     if(i>N/2)
        a[i]=i%R;
-    //if(a[i]==0) k++;
   }
   for(i=0;i<N;i++){
     if (a[i]==0) j++;
      __VERIFIER_assert(j < (N/6)+2);
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_3.c
+++ b/c/array-programs/partial_mod_count_3.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
 int main(){
-int i,j=0,k=0,a[N];
+int i,j=0,a[N];
   unsigned int R=3;
   for(i=0;i<N;i++){
     a[i]=i+1;

--- a/c/array-programs/partial_mod_count_3.yml
+++ b/c/array-programs/partial_mod_count_3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_4.c
+++ b/c/array-programs/partial_mod_count_4.c
@@ -2,18 +2,17 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=4;
   for(i=0;i<N;i++){
     a[i]=i+1;
     if(i>N/2)
        a[i]=i%R;
-    //if(a[i]==0) k++;
   }
   for(i=0;i<N;i++){
     if (a[i]==0) j++;
      __VERIFIER_assert(j < (N/8));
   }
-} // assume R > 0
-
+  return 0;
+}

--- a/c/array-programs/partial_mod_count_4.c
+++ b/c/array-programs/partial_mod_count_4.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R=4;
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2)
+       a[i]=i%R;
+    //if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < (N/8));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_4.c
+++ b/c/array-programs/partial_mod_count_4.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,a[N];
   unsigned int R=4;

--- a/c/array-programs/partial_mod_count_4.c
+++ b/c/array-programs/partial_mod_count_4.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
 int main(){
-int i,j=0,k=0,a[N];
+int i,j=0,a[N];
   unsigned int R=4;
   for(i=0;i<N;i++){
     a[i]=i+1;

--- a/c/array-programs/partial_mod_count_4.yml
+++ b/c/array-programs/partial_mod_count_4.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_4.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_5.c
+++ b/c/array-programs/partial_mod_count_5.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,a[N];
   unsigned int R=5;

--- a/c/array-programs/partial_mod_count_5.c
+++ b/c/array-programs/partial_mod_count_5.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
 int main(){
-int i,j=0,k=0,a[N];
+int i,j=0,a[N];
   unsigned int R=5;
   for(i=0;i<N;i++){
     a[i]=i+1;

--- a/c/array-programs/partial_mod_count_5.c
+++ b/c/array-programs/partial_mod_count_5.c
@@ -1,0 +1,19 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R=5;
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2)
+       a[i]=i%R;
+    //if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < (N/10));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_5.c
+++ b/c/array-programs/partial_mod_count_5.c
@@ -2,18 +2,18 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=5;
   for(i=0;i<N;i++){
     a[i]=i+1;
     if(i>N/2)
        a[i]=i%R;
-    //if(a[i]==0) k++;
   }
   for(i=0;i<N;i++){
     if (a[i]==0) j++;
      __VERIFIER_assert(j < (N/10));
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_5.yml
+++ b/c/array-programs/partial_mod_count_5.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_5.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_1.c
+++ b/c/array-programs/partial_mod_count_limited_1.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_1.c
+++ b/c/array-programs/partial_mod_count_limited_1.c
@@ -1,10 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 #define N 1000000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
+int lim=__VERIFIER_nondet_int();
  unsigned int R=1;
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_1.c
+++ b/c/array-programs/partial_mod_count_limited_1.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R=1;
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < N/R);
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_1.c
+++ b/c/array-programs/partial_mod_count_limited_1.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-
+extern void __VERIFIER_assume(int);
 #define N 1000000
 int main(){
 int i,j=0,k=0,a[N];

--- a/c/array-programs/partial_mod_count_limited_1.c
+++ b/c/array-programs/partial_mod_count_limited_1.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R=1;
@@ -17,5 +17,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j < N/R);
   }
-} // assume R > 0
+  return 0;
+} 
 

--- a/c/array-programs/partial_mod_count_limited_1.yml
+++ b/c/array-programs/partial_mod_count_limited_1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_2.c
+++ b/c/array-programs/partial_mod_count_limited_2.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R=2;
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2 && k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < N/(2*R));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_2.c
+++ b/c/array-programs/partial_mod_count_limited_2.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000
+int N = 1000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_2.c
+++ b/c/array-programs/partial_mod_count_limited_2.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_2.c
+++ b/c/array-programs/partial_mod_count_limited_2.c
@@ -1,11 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern int __VERIFIER_nondet_int(void);
 #define N 1000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
+int lim=__VERIFIER_nondet_int();
  unsigned int R=2;
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_2.c
+++ b/c/array-programs/partial_mod_count_limited_2.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R=2;
@@ -17,5 +17,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j < N/(2*R));
   }
-} // assume R > 0
+  return 0;
+} 
 

--- a/c/array-programs/partial_mod_count_limited_2.yml
+++ b/c/array-programs/partial_mod_count_limited_2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_3.c
+++ b/c/array-programs/partial_mod_count_limited_3.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000
+int N = 1000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_3.c
+++ b/c/array-programs/partial_mod_count_limited_3.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_3.c
+++ b/c/array-programs/partial_mod_count_limited_3.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R=3;
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2 && k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < (N/(2*R))+2);
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_3.c
+++ b/c/array-programs/partial_mod_count_limited_3.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R=3;
@@ -17,5 +17,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j < (N/(2*R))+2);
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_limited_3.c
+++ b/c/array-programs/partial_mod_count_limited_3.c
@@ -1,11 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern int __VERIFIER_nondet_int(void);
 #define N 1000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
+int lim=__VERIFIER_nondet_int();
  unsigned int R=3;
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_3.yml
+++ b/c/array-programs/partial_mod_count_limited_3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_4.c
+++ b/c/array-programs/partial_mod_count_limited_4.c
@@ -1,11 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern int __VERIFIER_nondet_int(void);
 #define N 1000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
+int lim=__VERIFIER_nondet_int();
  unsigned int R=4;
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_4.c
+++ b/c/array-programs/partial_mod_count_limited_4.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R=4;
@@ -17,5 +17,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j < N/(2*R));
   }
-} // assume R > 0
+  return 0;
+} 
 

--- a/c/array-programs/partial_mod_count_limited_4.c
+++ b/c/array-programs/partial_mod_count_limited_4.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000
+int N = 1000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_4.c
+++ b/c/array-programs/partial_mod_count_limited_4.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_4.c
+++ b/c/array-programs/partial_mod_count_limited_4.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R=4;
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2 && k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < N/(2*R));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_4.yml
+++ b/c/array-programs/partial_mod_count_limited_4.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_4.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_5.c
+++ b/c/array-programs/partial_mod_count_limited_5.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R=5;
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2 && k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < N/(2*R));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_5.c
+++ b/c/array-programs/partial_mod_count_limited_5.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000
+int N = 1000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_5.c
+++ b/c/array-programs/partial_mod_count_limited_5.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_5.c
+++ b/c/array-programs/partial_mod_count_limited_5.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R=5;
@@ -17,5 +17,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j < N/(2*R));
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_limited_5.c
+++ b/c/array-programs/partial_mod_count_limited_5.c
@@ -1,11 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern int __VERIFIER_nondet_int(void);
 #define N 1000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
+int lim=__VERIFIER_nondet_int();
  unsigned int R=5;
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_5.yml
+++ b/c/array-programs/partial_mod_count_limited_5.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_5.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_base.c
+++ b/c/array-programs/partial_mod_count_limited_base.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000000
+int N = 1000000;
 int main(){
 int i,j=0,k=0,a[N];
   unsigned int R=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_base.c
+++ b/c/array-programs/partial_mod_count_limited_base.c
@@ -1,11 +1,11 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern int __VERIFIER_nondet_int(void);
 #define N 1000000
 int main(){
 int i,j=0,k=0,a[N];
-  unsigned int R;
+  unsigned int R=__VERIFIER_nondet_int();
  __VERIFIER_assume(R>0);
   for(i=0;i<N;i++){
     a[i]=i+1;

--- a/c/array-programs/partial_mod_count_limited_base.c
+++ b/c/array-programs/partial_mod_count_limited_base.c
@@ -1,0 +1,20 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000000
+void main(){
+int i,j=0,k=0,a[N];
+  unsigned int R;
+ __VERIFIER_assume(R>0);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/2 && k<1)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j < 2);
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_base.c
+++ b/c/array-programs/partial_mod_count_limited_base.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_base.c
+++ b/c/array-programs/partial_mod_count_limited_base.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
   unsigned int R;
  __VERIFIER_assume(R>0);
@@ -16,5 +16,6 @@ int i,j=0,k=0,a[N];
     if (a[i]==0) j++;
      __VERIFIER_assert(j < 2);
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_limited_base.yml
+++ b/c/array-programs/partial_mod_count_limited_base.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_base.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/array-programs/partial_mod_count_limited_gen.c
+++ b/c/array-programs/partial_mod_count_limited_gen.c
@@ -2,7 +2,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 1000
-void main(){
+int main(){
 int i,j=0,k=0,a[N];
 int lim;
  unsigned int R;
@@ -18,5 +18,6 @@ __VERIFIER_assume(0 < lim && lim < N/R);
     if (a[i]==0) j++;
      __VERIFIER_assert(j <= ((N*(R-1))/(R*R)));
   }
-} // assume R > 0
+  return 0;
+}
 

--- a/c/array-programs/partial_mod_count_limited_gen.c
+++ b/c/array-programs/partial_mod_count_limited_gen.c
@@ -3,7 +3,7 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
 extern unsigned int __VERIFIER_nondet_uint(void);
 extern int __VERIFIER_nondet_int(void);
-#define N 1000
+int N = 1000;
 int main(){
 int i,j=0,k=0,a[N];
 int lim=__VERIFIER_nondet_int();

--- a/c/array-programs/partial_mod_count_limited_gen.c
+++ b/c/array-programs/partial_mod_count_limited_gen.c
@@ -1,0 +1,22 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+#define N 1000
+void main(){
+int i,j=0,k=0,a[N];
+int lim;
+ unsigned int R;
+ __VERIFIER_assume(R>1 && R<6);
+__VERIFIER_assume(0 < lim && lim < N/R);
+  for(i=0;i<N;i++){
+    a[i]=i+1;
+    if(i>N/R && k<lim)
+       a[i]=i%R;
+    if(a[i]==0) k++;
+  }
+  for(i=0;i<N;i++){
+    if (a[i]==0) j++;
+     __VERIFIER_assert(j <= ((N*(R-1))/(R*R)));
+  }
+} // assume R > 0
+

--- a/c/array-programs/partial_mod_count_limited_gen.c
+++ b/c/array-programs/partial_mod_count_limited_gen.c
@@ -1,12 +1,13 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 extern void __VERIFIER_assume(int);
-
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern int __VERIFIER_nondet_int(void);
 #define N 1000
 int main(){
 int i,j=0,k=0,a[N];
-int lim;
- unsigned int R;
+int lim=__VERIFIER_nondet_int();
+ unsigned int R=__VERIFIER_nondet_uint();
  __VERIFIER_assume(R>1 && R<6);
 __VERIFIER_assume(0 < lim && lim < N/R);
   for(i=0;i<N;i++){

--- a/c/array-programs/partial_mod_count_limited_gen.c
+++ b/c/array-programs/partial_mod_count_limited_gen.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern void __VERIFIER_assume(int);
 
 #define N 1000
 int main(){

--- a/c/array-programs/partial_mod_count_limited_gen.yml
+++ b/c/array-programs/partial_mod_count_limited_gen.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'partial_mod_count_limited_gen.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/discover_list.c
+++ b/c/loops-crafted-1/discover_list.c
@@ -498,4 +498,5 @@ struct opts_t opts;
 unsigned char * resp;
 int j = __VERIFIER_nondet_int ();
 int ret = do_discover_list( & tobj, _VERIFIER_nondet_int (), j,  sizeof (resp),  & opts);
+return 0;
 }

--- a/c/loops-crafted-1/discover_list.c
+++ b/c/loops-crafted-1/discover_list.c
@@ -1,4 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void *malloc(unsigned int size);
+extern int __VERIFIER_nondet_int(void);
 struct _IO_FILE;
 struct _IO_marker;
 struct option;
@@ -116,7 +118,6 @@ static struct option long_options [19] = {{"adn", 0, 0, 'A'}, {"brief", 0, 0, 'b
 
 
 int __tmpTR__int_1;
-struct _IO_FILE;
 struct _IO_marker;
 struct smp_val_name;
 struct smp_func_def_rrlen;
@@ -129,12 +130,6 @@ struct smp_val_name{
 int  value;
 char * name;
 } ;
-typedef long long  __quad_t;
-typedef __quad_t __off64_t;
-typedef void  _IO_lock_t;
-typedef long  __off_t;
-typedef struct _IO_FILE FILE;
-typedef unsigned long  size_t;
 extern int  sprintf(char * __restrict __s, char  const* __restrict __format, ...);
 extern int  sscanf(char  const* __restrict __s, char  const* __restrict __format, ...);
 extern void * memset(void * __s, int  __c, size_t __n);
@@ -496,7 +491,7 @@ int main(){
 struct smp_target_obj tobj;
 struct opts_t opts;
 unsigned char * resp;
-int j = __VERIFIER_nondet_int ();
-int ret = do_discover_list( & tobj, _VERIFIER_nondet_int (), j,  sizeof (resp),  & opts);
+resp= (unsigned char *) malloc (sizeof (unsigned char));
+int ret = do_discover_list( & tobj, __VERIFIER_nondet_int() , resp,  sizeof (resp),  & opts);
 return 0;
 }

--- a/c/loops-crafted-1/discover_list.c
+++ b/c/loops-crafted-1/discover_list.c
@@ -1,0 +1,501 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+struct _IO_FILE;
+struct _IO_marker;
+struct option;
+struct smp_target_obj;
+struct smp_req_resp;
+struct opts_t;
+struct smp_req_resp{
+int  request_len;
+unsigned char * request;
+int  max_response_len;
+unsigned char * response;
+int  act_response_len;
+int  transport_err;
+} ;
+struct smp_target_obj{
+char  device_name [256];
+int  subvalue;
+unsigned char  sas_addr [8];
+int  interface_selector;
+int  opened;
+int  fd;
+} ;
+struct option{
+char  const* name;
+int  has_arg;
+int * flag;
+int  val;
+} ;
+struct _IO_marker{
+struct _IO_marker* _next;
+struct _IO_FILE* _sbuf;
+int  _pos;
+} ;
+typedef long long  __quad_t;
+typedef __quad_t __off64_t;
+typedef void  _IO_lock_t;
+typedef long  __off_t;
+typedef struct _IO_FILE FILE;
+struct opts_t{
+int  do_adn;
+int  do_brief;
+int  desc_type;
+int  desc_type_given;
+int  filter;
+int  do_hex;
+int  ign_zp;
+int  do_num;
+int  num_given;
+int  do_1line;
+int  phy_id;
+int  phy_id_given;
+int  do_raw;
+int  do_summary;
+int  verbose;
+int  sa_given;
+unsigned long long  sa;
+char  const* zpi_fn;
+FILE* zpi_filep;
+} ;
+typedef unsigned long  size_t;
+struct _IO_FILE{
+int  _flags;
+char * _IO_read_ptr;
+char * _IO_read_end;
+char * _IO_read_base;
+char * _IO_write_base;
+char * _IO_write_ptr;
+char * _IO_write_end;
+char * _IO_buf_base;
+char * _IO_buf_end;
+char * _IO_save_base;
+char * _IO_backup_base;
+char * _IO_save_end;
+struct _IO_marker* _markers;
+struct _IO_FILE* _chain;
+int  _fileno;
+int  _flags2;
+__off_t _old_offset;
+unsigned short  _cur_column;
+signed char  _vtable_offset;
+char  _shortbuf [1];
+_IO_lock_t* _lock;
+__off64_t _offset;
+void * __pad1;
+void * __pad2;
+void * __pad3;
+void * __pad4;
+size_t __pad5;
+int  _mode;
+char  _unused2 [40];
+} ;
+extern FILE* fopen(char  const* __restrict __filename, char  const* __restrict __modes);
+extern int  sscanf(char  const* __restrict __s, char  const* __restrict __format, ...);
+extern char * getenv(char  const* __name);
+extern void * memset(void * __s, int  __c, size_t __n);
+extern int  strcmp(char  const* __s1, char  const* __s2);
+extern char * strchr(char  const* __s, int  __c);
+extern size_t strlen(char  const* __s);
+extern int  getopt_long(int  ___argc, char * const* ___argv, char  const* __shortopts, struct option const* __longopts, int * __longind);
+extern int  smp_initiator_open(char  const* device_name, int  subvalue, char  const* i_params, unsigned long long  sa, struct smp_target_obj* tobj, int  verbose);
+extern int  smp_send_req(struct smp_target_obj const* tobj, struct smp_req_resp* rresp, int  verbose);
+extern int  smp_get_func_def_resp_len(int  func_code);
+extern int  smp_is_naa5(unsigned long long  addr);
+extern void  dStrHex(char  const* str, int  len, int  no_ascii);
+extern int  smp_get_num(char  const* buf);
+extern long long  smp_get_llnum(char  const* buf);
+static int  do_discover_list(struct smp_target_obj* top, int  sphy_id, unsigned char * resp, int  max_resp_len, struct opts_t* op);
+int  main6(int  argc, char ** argv);
+extern char * optarg;
+extern int  optind;
+extern char * optarg;
+extern int  optind;
+static struct option long_options [19] = {{"adn", 0, 0, 'A'}, {"brief", 0, 0, 'b'}, {"descriptor", 1, 0, 'd'}, {"filter", 1, 0, 'f'}, {"help", 0, 0, 'h'}, {"hex", 0, 0, 'H'}, {"ignore", 0, 0, 'i'}, {"interface", 1, 0, 'I'}, {"list", 0, 0, 'l'}, {"num", 1, 0, 'n'}, {"one", 0, 0, 'o'}, {"phy", 1, 0, 'p'}, {"sa", 1, 0, 's'}, {"summary", 0, 0, 'S'}, {"raw", 0, 0, 'r'}, {"verbose", 0, 0, 'v'}, {"version", 0, 0, 'V'}, {"zpi", 1, 0, 'Z'}, {0, 0, 0, 0}};
+
+
+
+int __tmpTR__int_1;
+struct _IO_FILE;
+struct _IO_marker;
+struct smp_val_name;
+struct smp_func_def_rrlen;
+struct smp_func_def_rrlen{
+int  func;
+int  def_req_len;
+int  def_resp_len;
+} ;
+struct smp_val_name{
+int  value;
+char * name;
+} ;
+typedef long long  __quad_t;
+typedef __quad_t __off64_t;
+typedef void  _IO_lock_t;
+typedef long  __off_t;
+typedef struct _IO_FILE FILE;
+typedef unsigned long  size_t;
+extern int  sprintf(char * __restrict __s, char  const* __restrict __format, ...);
+extern int  sscanf(char  const* __restrict __s, char  const* __restrict __format, ...);
+extern void * memset(void * __s, int  __c, size_t __n);
+extern char * strchr(char  const* __s, int  __c);
+extern size_t strlen(char  const* __s);
+extern int  toupper(int  __c);
+extern int  smp_get_func_def_resp_len(int  func_code);
+int  smp_get_func_def_resp_len(int  func_code);
+extern int  smp_is_naa5(unsigned long long  addr);
+int  smp_is_naa5(unsigned long long  addr);
+extern void  dStrHex(char  const* str, int  len, int  no_ascii);
+void  dStrHex(char  const* str, int  len, int  no_ascii);
+extern int  smp_get_num(char  const* buf);
+int  smp_get_num(char  const* buf);
+extern long long  smp_get_llnum(char  const* buf);
+long long  smp_get_llnum(char  const* buf);
+struct smp_func_def_rrlen smp_def_rrlen_arr [32] = {{0x0, 0, 6}, {0x1, 0, 14}, {0x2, -3, -3}, {0x3, -2, -2}, {0x4, -2, -2}, {0x5, -2, -2}, {0x6, -2, -2}, {0x7, -3, -3}, {0x10, 2, 0xc}, {0x11, 2, 6}, {0x12, 2, 13}, {0x13, 2, 9}, {0x14, -2, -2}, {0x20, -2, -2}, {0x21, -2, -2}, {0x22, -2, -2}, {0x80, 3, 0}, {0x81, -2, 0}, {0x82, -3, -3}, {0x83, -3, -3}, {0x85, -2, 0}, {0x86, -2, -2}, {0x87, -2, 0}, {0x88, -2, 0}, {0x89, -2, 0}, {0x8a, -2, 0}, {0x8b, -2, 0}, {0x90, 9, 0}, {0x91, 9, 0}, {0x92, 9, 0}, {0x93, -2, 0}, {-1, -1, -1}};
+
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int  smp_get_func_def_resp_len(int  func_code)
+{
+struct smp_func_def_rrlen* drlp;
+for(drlp = smp_def_rrlen_arr ; drlp->func >= 0 ;  ++drlp)
+{
+if(func_code == drlp->func)
+return drlp->def_resp_len;
+}
+return -1;
+}
+int  smp_is_naa5(unsigned long long  addr)
+{
+return (0x5 == ((addr >> 60) & 0xf));
+}
+void  dStrHex(char  const* str, int  len, int  no_ascii)
+{
+char  const* p = str;
+unsigned char  c;
+char  buff [82];
+int  a = 0;
+int  const bpstart = 5;
+int  const cpstart = 60;
+int  cpos = cpstart;
+int  bpos = bpstart;
+int  i;
+int  k;
+if(len <= 0)
+return ;
+memset(buff, ' ', 80);
+buff[80] = '\0';
+if(no_ascii < 0)
+{
+return ;
+}
+k = sprintf(buff + 1, "%.2x", a);
+((( "1_1_247_8589935493" /*Grp 1*/, __VERIFIER_assert(k+1>=0 && k+1< 82))) , buff[k+1]=' ');
+for(i = 0 ; i < len ; i++ )
+{
+c =  * p++ ;
+bpos += 3;
+if(bpos == (bpstart + (9 * 3)))
+bpos++ ;
+((( "1_1_254_8589935534" /*Grp 1*/, __VERIFIER_assert(bpos>=0 && bpos< 82)) , (__tmpTR__int_1 = sprintf( & buff[bpos], "%.2x", (int )(unsigned char )c))) , __tmpTR__int_1);
+((( "1_1_255_8589935545" /*Grp 1*/, __VERIFIER_assert(bpos+2>=0 && bpos+2< 82))) , buff[bpos+2]=' ');
+if(no_ascii)
+((__tmpTR__int_1 = cpos , cpos = __tmpTR__int_1+1 , ( "1_1_257_8589935554" /*Grp 1*/, __VERIFIER_assert(__tmpTR__int_1>=0 && __tmpTR__int_1< 82))) , buff[__tmpTR__int_1]=' ');
+else
+{
+if((c < ' ') || (c >= 0x7f))
+c = '.';
+buff[cpos++ ] = c;
+}
+if(cpos > (cpstart + 15))
+{
+bpos = bpstart;
+cpos = cpstart;
+a += 16;
+memset(buff, ' ', 80);
+k = sprintf(buff + 1, "%.2x", a);
+((( "1_1_270_8589935626" /*Grp 1*/, __VERIFIER_assert(k+1>=0 && k+1< 82))) , buff[k+1]=' ');
+}
+}
+
+}
+int  smp_get_num(char  const* buf)
+{
+int  res;
+int  num;
+int  n;
+int  len;
+unsigned int  unum;
+char * cp;
+char  c = 'c';
+char  c2;
+char  c3;
+if(((( void * ) 0) == buf) || ('\0' == buf[0]))
+return -1;
+len = strlen(buf);
+if(('0' == buf[0]) && (('x' == buf[1]) || ('X' == buf[1])))
+{
+res = sscanf(buf + 2, "%x",  & unum);
+num = unum;
+}
+else
+if('H' == toupper(buf[len - 1]))
+{
+res = sscanf(buf, "%x",  & unum);
+num = unum;
+}
+else
+res = sscanf(buf, "%d%c%c%c",  & num,  & c,  & c2,  & c3);
+if(res < 1)
+return -1LL;
+else
+if(1 == res)
+return num;
+else
+{
+if(res > 2)
+c2 = toupper(c2);
+if(res > 3)
+c3 = toupper(c3);
+switch(toupper(c))
+{
+case ',': 
+;
+case 'C': 
+return num;
+case 'W': 
+return num * 2;
+case 'B': 
+return num * 512;
+case 'K': 
+if(2 == res)
+return num * 1024;
+if(('B' == c2) || ('D' == c2))
+return num * 1000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1024;
+return -1;
+case 'M': 
+if(2 == res)
+return num * 1048576;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1048576;
+return -1;
+case 'G': 
+if(2 == res)
+return num * 1073741824;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1073741824;
+return -1;
+case 'X': 
+cp = strchr(buf, 'x');
+if((( void * ) 0) == cp)
+cp = strchr(buf, 'X');
+if(cp)
+{
+n = smp_get_num(cp + 1);
+if(-1 != n)
+return num * n;
+}
+return -1;
+default: ;
+return -1;
+}
+}
+}
+long long  smp_get_llnum(char  const* buf)
+{
+int  res;
+int  len;
+long long  num;
+long long  ll;
+unsigned long long  unum;
+char * cp;
+char  c = 'c';
+char  c2;
+char  c3;
+if(((( void * ) 0) == buf) || ('\0' == buf[0]))
+return -1LL;
+len = strlen(buf);
+if(('0' == buf[0]) && (('x' == buf[1]) || ('X' == buf[1])))
+{
+res = sscanf(buf + 2, "%llx",  & unum);
+num = unum;
+}
+else
+if('H' == toupper(buf[len - 1]))
+{
+res = sscanf(buf, "%llx",  & unum);
+num = unum;
+}
+else
+res = sscanf(buf, "%lld%c%c%c",  & num,  & c,  & c2,  & c3);
+if(res < 1)
+return -1LL;
+else
+if(1 == res)
+return num;
+else
+{
+if(res > 2)
+c2 = toupper(c2);
+if(res > 3)
+c3 = toupper(c3);
+switch(toupper(c))
+{
+case 'C': 
+return num;
+case 'W': 
+return num * 2;
+case 'B': 
+return num * 512;
+case 'K': 
+if(2 == res)
+return num * 1024;
+if(('B' == c2) || ('D' == c2))
+return num * 1000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1024;
+return -1LL;
+case 'M': 
+if(2 == res)
+return num * 1048576;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1048576;
+return -1LL;
+case 'G': 
+if(2 == res)
+return num * 1073741824;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1073741824;
+return -1LL;
+case 'T': 
+if(2 == res)
+return num * 1099511627776LL;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000000000LL;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1099511627776LL;
+return -1LL;
+case 'P': 
+if(2 == res)
+return num * 1099511627776LL * 1024;
+if(('B' == c2) || ('D' == c2))
+return num * 1000000000000LL * 1000;
+if(('I' == c2) && (4 == res) && ('B' == c3))
+return num * 1099511627776LL * 1024;
+return -1LL;
+case 'X': 
+cp = strchr(buf, 'x');
+if((( void * ) 0) == cp)
+cp = strchr(buf, 'X');
+if(cp)
+{
+ll = smp_get_llnum(cp + 1);
+if(-1LL != ll)
+return num * ll;
+}
+return -1LL;
+default: ;
+return -1LL;
+}
+}
+}
+
+static int  do_discover_list(struct smp_target_obj* top, int  sphy_id, unsigned char * resp, int  max_resp_len, struct opts_t* op)
+{
+unsigned char  smp_req [32] = {0x40, 0x20, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+struct smp_req_resp smp_rr;
+int  len;
+int  res;
+int  dword_resp_len;
+int  mnum_desc;
+dword_resp_len = (max_resp_len - 8) / 4;
+smp_req[2] = (dword_resp_len < 0x100) ? dword_resp_len : 0xff;
+smp_req[8] = sphy_id;
+mnum_desc = op->do_num;
+if((0 == op->desc_type) && (mnum_desc > 8))
+mnum_desc = 8;
+if((1 == op->desc_type) && (mnum_desc > 40))
+mnum_desc = 40;
+smp_req[9] = mnum_desc;
+smp_req[10] = op->filter & 0xf;
+if(op->ign_zp)
+smp_req[10] |= 0x80;
+smp_req[11] = op->desc_type & 0xf;
+memset( & smp_rr, 0,  sizeof (smp_rr));
+res = smp_send_req(top,  & smp_rr, op->verbose);
+if(res)
+{
+return -1;
+}
+if(smp_rr.transport_err)
+{
+return -1;
+}
+if((smp_rr.act_response_len >= 0) && (smp_rr.act_response_len < 4))
+{
+return 97;
+}
+len = resp[3];
+if((0 == len) && (0 == resp[2]))
+{
+len = smp_get_func_def_resp_len(resp[1]);
+if(len < 0)
+{
+len = 0;
+
+}
+}
+len = 4 + (len * 4);
+if(op->do_hex || op->do_raw)
+{
+if(op->do_hex)
+dStrHex(( char  const* ) resp, len, 1);
+else
+;
+if(0x41 != resp[0])
+return 97;
+if(resp[1] != smp_req[1])
+return 97;
+if(resp[2])
+{
+return resp[2];
+}
+return 0;
+}
+if(0x41 != resp[0])
+{
+return 97;
+}
+if(resp[1] != smp_req[1])
+{
+return 97;
+}
+if(resp[2])
+{
+return resp[2];
+}
+return 0;
+}
+
+int main(){
+struct smp_target_obj tobj;
+struct opts_t opts;
+unsigned char * resp;
+int j = __VERIFIER_nondet_int ();
+int ret = do_discover_list( & tobj, _VERIFIER_nondet_int (), j,  sizeof (resp),  & opts);
+}

--- a/c/loops-crafted-1/discover_list.c
+++ b/c/loops-crafted-1/discover_list.c
@@ -60,7 +60,7 @@ unsigned long long  sa;
 char  const* zpi_fn;
 FILE* zpi_filep;
 } ;
-typedef unsigned long  size_t;
+typedef unsigned int  size_t;
 struct _IO_FILE{
 int  _flags;
 char * _IO_read_ptr;

--- a/c/loops-crafted-1/discover_list.c
+++ b/c/loops-crafted-1/discover_list.c
@@ -113,7 +113,6 @@ extern char * optarg;
 extern int  optind;
 extern char * optarg;
 extern int  optind;
-static struct option long_options [19] = {{"adn", 0, 0, 'A'}, {"brief", 0, 0, 'b'}, {"descriptor", 1, 0, 'd'}, {"filter", 1, 0, 'f'}, {"help", 0, 0, 'h'}, {"hex", 0, 0, 'H'}, {"ignore", 0, 0, 'i'}, {"interface", 1, 0, 'I'}, {"list", 0, 0, 'l'}, {"num", 1, 0, 'n'}, {"one", 0, 0, 'o'}, {"phy", 1, 0, 'p'}, {"sa", 1, 0, 's'}, {"summary", 0, 0, 'S'}, {"raw", 0, 0, 'r'}, {"verbose", 0, 0, 'v'}, {"version", 0, 0, 'V'}, {"zpi", 1, 0, 'Z'}, {0, 0, 0, 0}};
 
 
 

--- a/c/loops-crafted-1/discover_list.yml
+++ b/c/loops-crafted-1/discover_list.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'discover_list.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/iftelse.c
+++ b/c/loops-crafted-1/iftelse.c
@@ -1,0 +1,28 @@
+
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k,j;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = j = k = 0;
+  while( i < n ) {
+    i = i + 3;
+    if(i%2)
+	    j = j+3;
+    else
+	    k = k+3;
+    if(n>0)
+	  __VERIFIER_assert( (i/2<=j) );
+  }
+  return 0;
+}
+

--- a/c/loops-crafted-1/iftelse.c
+++ b/c/loops-crafted-1/iftelse.c
@@ -7,7 +7,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,k,j;

--- a/c/loops-crafted-1/iftelse.yml
+++ b/c/loops-crafted-1/iftelse.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'iftelse.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de20.c
+++ b/c/loops-crafted-1/in-de20.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de20.c
+++ b/c/loops-crafted-1/in-de20.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  __VERIFIER_assert(x==n);
+}

--- a/c/loops-crafted-1/in-de20.c
+++ b/c/loops-crafted-1/in-de20.c
@@ -25,4 +25,5 @@ int main()
   }
 
   __VERIFIER_assert(x==n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de20.yml
+++ b/c/loops-crafted-1/in-de20.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de20.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de31.c
+++ b/c/loops-crafted-1/in-de31.c
@@ -31,4 +31,5 @@ int main()
   }
 
   __VERIFIER_assert(z==n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de31.c
+++ b/c/loops-crafted-1/in-de31.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de31.c
+++ b/c/loops-crafted-1/in-de31.c
@@ -1,0 +1,34 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  __VERIFIER_assert(z==n);
+}

--- a/c/loops-crafted-1/in-de31.yml
+++ b/c/loops-crafted-1/in-de31.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de31.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de32.c
+++ b/c/loops-crafted-1/in-de32.c
@@ -1,0 +1,34 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    x--;
+    y--;
+  }
+
+  __VERIFIER_assert(x==0);
+}

--- a/c/loops-crafted-1/in-de32.c
+++ b/c/loops-crafted-1/in-de32.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de32.c
+++ b/c/loops-crafted-1/in-de32.c
@@ -31,4 +31,5 @@ int main()
   }
 
   __VERIFIER_assert(x==0);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de32.yml
+++ b/c/loops-crafted-1/in-de32.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de32.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de41.c
+++ b/c/loops-crafted-1/in-de41.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de41.c
+++ b/c/loops-crafted-1/in-de41.c
@@ -37,4 +37,5 @@ int main()
   }
 
   __VERIFIER_assert(y==n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de41.c
+++ b/c/loops-crafted-1/in-de41.c
@@ -1,0 +1,40 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  __VERIFIER_assert(y==n);
+}

--- a/c/loops-crafted-1/in-de41.yml
+++ b/c/loops-crafted-1/in-de41.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de41.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de42.c
+++ b/c/loops-crafted-1/in-de42.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de42.c
+++ b/c/loops-crafted-1/in-de42.c
@@ -1,0 +1,40 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    z++;
+  }
+
+  __VERIFIER_assert(z==2*n);
+}

--- a/c/loops-crafted-1/in-de42.c
+++ b/c/loops-crafted-1/in-de42.c
@@ -37,4 +37,5 @@ int main()
   }
 
   __VERIFIER_assert(z==2*n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de42.yml
+++ b/c/loops-crafted-1/in-de42.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de42.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de51.c
+++ b/c/loops-crafted-1/in-de51.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de51.c
+++ b/c/loops-crafted-1/in-de51.c
@@ -1,0 +1,46 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  __VERIFIER_assert(x==n);
+}

--- a/c/loops-crafted-1/in-de51.c
+++ b/c/loops-crafted-1/in-de51.c
@@ -43,4 +43,5 @@ int main()
   }
 
   __VERIFIER_assert(x==n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de51.yml
+++ b/c/loops-crafted-1/in-de51.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de51.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de52.c
+++ b/c/loops-crafted-1/in-de52.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de52.c
+++ b/c/loops-crafted-1/in-de52.c
@@ -1,0 +1,46 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  while(z>0)
+  {
+    y--;
+    z--;
+  }
+
+  __VERIFIER_assert(y==0);
+}

--- a/c/loops-crafted-1/in-de52.c
+++ b/c/loops-crafted-1/in-de52.c
@@ -43,4 +43,5 @@ int main()
   }
 
   __VERIFIER_assert(y==0);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de52.yml
+++ b/c/loops-crafted-1/in-de52.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de52.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de61.c
+++ b/c/loops-crafted-1/in-de61.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de61.c
+++ b/c/loops-crafted-1/in-de61.c
@@ -49,4 +49,5 @@ int main()
   }
 
   __VERIFIER_assert(z==n);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de61.c
+++ b/c/loops-crafted-1/in-de61.c
@@ -1,0 +1,52 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  __VERIFIER_assert(z==n);
+}

--- a/c/loops-crafted-1/in-de61.yml
+++ b/c/loops-crafted-1/in-de61.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de61.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/in-de62.c
+++ b/c/loops-crafted-1/in-de62.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();

--- a/c/loops-crafted-1/in-de62.c
+++ b/c/loops-crafted-1/in-de62.c
@@ -1,0 +1,52 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main()
+{
+  unsigned int n = __VERIFIER_nondet_uint();
+  unsigned int x=n, y=0, z;
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  z = y;
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    z++;
+  }
+
+  while(x>0)
+  {
+    x--;
+    y++;
+  }
+
+  while(z>0)
+  {
+    x++;
+    z--;
+  }
+
+  while(y>0)
+  {
+    y--;
+    x--;
+  }
+
+  __VERIFIER_assert(x==0);
+}

--- a/c/loops-crafted-1/in-de62.c
+++ b/c/loops-crafted-1/in-de62.c
@@ -49,4 +49,5 @@ int main()
   }
 
   __VERIFIER_assert(x==0);
+  return 0;
 }

--- a/c/loops-crafted-1/in-de62.yml
+++ b/c/loops-crafted-1/in-de62.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'in-de62.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/loopv1.c
+++ b/c/loops-crafted-1/loopv1.c
@@ -13,7 +13,7 @@ void __VERIFIER_assert(int cond) {
 
 
 int main() {
-  int n,i,j,k;
+  int n,i,j;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   i = 0; j=0;

--- a/c/loops-crafted-1/loopv1.c
+++ b/c/loops-crafted-1/loopv1.c
@@ -1,4 +1,4 @@
-#define SIZE 50000001
+int SIZE = 50000001;
 
 
 int __VERIFIER_nondet_int();

--- a/c/loops-crafted-1/loopv1.c
+++ b/c/loops-crafted-1/loopv1.c
@@ -1,0 +1,28 @@
+#define SIZE 50000001
+
+
+int __VERIFIER_nondet_int();
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+
+int main() {
+  int n,i,j,k;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = 0; j=0;
+  while(i<n){ 
+ 
+    if(__VERIFIER_nondet_int())	  
+      i = i + 6; 
+    else
+     i = i + 3;    
+  }
+  __VERIFIER_assert( (i%3) == 0 );
+}

--- a/c/loops-crafted-1/loopv1.c
+++ b/c/loops-crafted-1/loopv1.c
@@ -25,4 +25,5 @@ int main() {
      i = i + 3;    
   }
   __VERIFIER_assert( (i%3) == 0 );
+  return 0;
 }

--- a/c/loops-crafted-1/loopv1.yml
+++ b/c/loops-crafted-1/loopv1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'loopv1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/loopv2.c
+++ b/c/loops-crafted-1/loopv2.c
@@ -1,4 +1,4 @@
-#define SIZE 50000001
+int SIZE = 50000001;
 int __VERIFIER_nondet_int();
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);

--- a/c/loops-crafted-1/loopv2.c
+++ b/c/loops-crafted-1/loopv2.c
@@ -1,0 +1,28 @@
+#define SIZE 50000001
+int __VERIFIER_nondet_int();
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+int main() {
+  int n,i,j,k;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = 0; j=0;
+  while(i<n){ 
+
+    i = i + 4;
+    j = i +2;    
+  }
+  k =i;
+  while( (j%2) == 0){
+   j-=4;
+   k -=4; 
+  }
+  __VERIFIER_assert( (k%2) == 0 );
+}

--- a/c/loops-crafted-1/loopv2.c
+++ b/c/loops-crafted-1/loopv2.c
@@ -25,4 +25,5 @@ int main() {
    k -=4; 
   }
   __VERIFIER_assert( (k%2) == 0 );
+  return 0;
 }

--- a/c/loops-crafted-1/loopv2.yml
+++ b/c/loops-crafted-1/loopv2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'loopv2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/loopv3.c
+++ b/c/loops-crafted-1/loopv3.c
@@ -1,4 +1,4 @@
-#define SIZE 50000001
+int SIZE = 50000001;
 
 
 int __VERIFIER_nondet_int();

--- a/c/loops-crafted-1/loopv3.c
+++ b/c/loops-crafted-1/loopv3.c
@@ -1,0 +1,28 @@
+#define SIZE 50000001
+
+
+int __VERIFIER_nondet_int();
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+
+int main() {
+  int i,j;
+  i = 0; j=0;
+  while(i<SIZE){ 
+
+    if(__VERIFIER_nondet_int())	  
+      i = i + 8; 
+    else
+     i = i + 4;    
+	  
+  }
+  j = i/4 ;
+    __VERIFIER_assert( (j * 4) == i);
+}

--- a/c/loops-crafted-1/loopv3.c
+++ b/c/loops-crafted-1/loopv3.c
@@ -25,4 +25,5 @@ int main() {
   }
   j = i/4 ;
     __VERIFIER_assert( (j * 4) == i);
+  return 0;
 }

--- a/c/loops-crafted-1/loopv3.yml
+++ b/c/loops-crafted-1/loopv3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'loopv3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_1.c
+++ b/c/loops-crafted-1/mono-crafted_1.c
@@ -1,7 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-int main(){
+int main()
+{
 	int x=0,y=50000,z=0;
 	x=0;
 	while(x<1000000){
@@ -12,10 +13,10 @@ int main(){
 			y++;
 		}
 	}
-	assert(x==y);
 	while(y>z){
 		y--;
 		x--;
 	}
 	__VERIFIER_assert(x==z);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_1.c
+++ b/c/loops-crafted-1/mono-crafted_1.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(){
+	int x=0,y=50000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<50000)
+			x++;
+		else{
+			x++;
+			y++;
+		}
+	}
+	assert(x==y);
+	while(y>z){
+		y--;
+		x--;
+	}
+	__VERIFIER_assert(x==z);
+}

--- a/c/loops-crafted-1/mono-crafted_1.yml
+++ b/c/loops-crafted-1/mono-crafted_1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_10.c
+++ b/c/loops-crafted-1/mono-crafted_10.c
@@ -1,15 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-int main(void) {
-unsigned int x = 0;
-unsigned int y = 10000000;
-unsigned int z=5000000;
+int main(void)
+{
+	unsigned int x = 0;
+	unsigned int y = 10000000;
+	unsigned int z=5000000;
 	while(x<y){	
 		if(x>=5000000)
 			z++;
 		x++;
 	}
-  __VERIFIER_assert(z==x);
-  return 0;
+	__VERIFIER_assert(z==x);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_10.c
+++ b/c/loops-crafted-1/mono-crafted_10.c
@@ -1,0 +1,15 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(void) {
+unsigned int x = 0;
+unsigned int y = 10000000;
+unsigned int z=5000000;
+	while(x<y){	
+		if(x>=5000000)
+			z++;
+		x++;
+	}
+  __VERIFIER_assert(z==x);
+  return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_10.yml
+++ b/c/loops-crafted-1/mono-crafted_10.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_10.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_11.c
+++ b/c/loops-crafted-1/mono-crafted_11.c
@@ -1,0 +1,16 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main() {
+  unsigned int x = 0;
+
+  while (x < 100000000) {
+    if (x < 10000000) {
+      x++;
+    } else {
+      x += 2;
+    }
+  }
+
+  __VERIFIER_assert((x%2)==0) ;
+  return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_11.yml
+++ b/c/loops-crafted-1/mono-crafted_11.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_11.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_12.c
+++ b/c/loops-crafted-1/mono-crafted_12.c
@@ -1,0 +1,15 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main() {
+unsigned int x = 0;
+unsigned int y = 10000000;
+unsigned int z=0;
+	while(x<y){	
+		if(x>=5000000)
+			z=z+2;
+		x++;
+	}
+  __VERIFIER_assert(!(z%2));
+  return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_12.yml
+++ b/c/loops-crafted-1/mono-crafted_12.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_12.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_13.c
+++ b/c/loops-crafted-1/mono-crafted_13.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(){
+	int x=0,y=50000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<50000)
+			x++;
+		else{
+			x=x+2;
+			y=y+2;
+		}
+	}
+	while(y>z){
+		y--;
+		x--;
+	}
+	__VERIFIER_assert((x%2==0));
+	return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_13.yml
+++ b/c/loops-crafted-1/mono-crafted_13.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_13.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_14.c
+++ b/c/loops-crafted-1/mono-crafted_14.c
@@ -1,0 +1,23 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(){
+	int x=0,y=500000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<500000)
+			x++;
+		else{
+			x++;
+			y++;
+		}
+	}
+	while(y>0){
+		x--;
+		z++;
+		y=y-2;
+	}
+	__VERIFIER_assert(z%2==0);
+	__VERIFIER_assert(x%2==0);
+	return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_14.yml
+++ b/c/loops-crafted-1/mono-crafted_14.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_14.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_3.c
+++ b/c/loops-crafted-1/mono-crafted_3.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(){
+	int x=0,y=500000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<500000)
+			x++;
+		else{
+			x++;
+			y++;
+		}
+	}
+	while(y>0){
+		x--;
+		z++;
+		y=y-2;
+	}
+	__VERIFIER_assert(x==z);
+}

--- a/c/loops-crafted-1/mono-crafted_3.c
+++ b/c/loops-crafted-1/mono-crafted_3.c
@@ -1,7 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-int main(){
+int main()
+{
 	int x=0,y=500000,z=0;
 	x=0;
 	while(x<1000000){
@@ -18,4 +19,5 @@ int main(){
 		y=y-2;
 	}
 	__VERIFIER_assert(x==z);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_3.yml
+++ b/c/loops-crafted-1/mono-crafted_3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_6.c
+++ b/c/loops-crafted-1/mono-crafted_6.c
@@ -1,7 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-void main(){
+int main()
+{
 	int x=0,y=500000,z=0;
 	x=0;
 	while(x<1000000){
@@ -18,4 +19,5 @@ void main(){
 		}
 	}
 	 __VERIFIER_assert(x==1000000);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_6.c
+++ b/c/loops-crafted-1/mono-crafted_6.c
@@ -1,0 +1,21 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+void main(){
+	int x=0,y=500000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<500000)
+			x++;
+		else{
+			if(x<750000){
+				x++;
+			}
+			else{
+				x=x+2;
+			}
+			y++;
+		}
+	}
+	 __VERIFIER_assert(x==1000000);
+}

--- a/c/loops-crafted-1/mono-crafted_6.yml
+++ b/c/loops-crafted-1/mono-crafted_6.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_6.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_7.c
+++ b/c/loops-crafted-1/mono-crafted_7.c
@@ -1,0 +1,20 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main(void) {
+	int x=0,y=50000,z=0;
+	x=0;
+	while(x<1000000){
+		if(x<50000)
+			x++;
+		else{
+			x++;
+			y++;
+		}
+	}
+	while(y>0){
+		y=y-2;
+		x=x-2;
+	}
+	 __VERIFIER_assert(z==x);
+}

--- a/c/loops-crafted-1/mono-crafted_7.c
+++ b/c/loops-crafted-1/mono-crafted_7.c
@@ -1,7 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-int main(void) {
+int main()
+{
 	int x=0,y=50000,z=0;
 	x=0;
 	while(x<1000000){
@@ -17,4 +18,5 @@ int main(void) {
 		x=x-2;
 	}
 	 __VERIFIER_assert(z==x);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_7.yml
+++ b/c/loops-crafted-1/mono-crafted_7.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_7.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_8.c
+++ b/c/loops-crafted-1/mono-crafted_8.c
@@ -1,13 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__	));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-int main(void) {
-unsigned int x = 0;
-unsigned int y = 10000000;
-unsigned int z=5000000;
+
+int main()
+{
+	unsigned int x = 0;
+	unsigned int y = 10000000;
+	unsigned int z=5000000;
 	while(x<y){	
 		if(x>=5000000)
 			z--;
 		x++;
 	}
-  __VERIFIER_assert(z==0);
+	__VERIFIER_assert(z==0);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_8.c
+++ b/c/loops-crafted-1/mono-crafted_8.c
@@ -1,0 +1,13 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__	));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int main(void) {
+unsigned int x = 0;
+unsigned int y = 10000000;
+unsigned int z=5000000;
+	while(x<y){	
+		if(x>=5000000)
+			z--;
+		x++;
+	}
+  __VERIFIER_assert(z==0);
+}

--- a/c/loops-crafted-1/mono-crafted_8.yml
+++ b/c/loops-crafted-1/mono-crafted_8.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_8.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/mono-crafted_9.c
+++ b/c/loops-crafted-1/mono-crafted_9.c
@@ -1,17 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
-int main() {
-    int x = 0;
-    int y = 500000;
-    while(x < 1000000) {
-	if (x < 500000) {
-	    x = x + 1;
-	} else {
-	    x = x + 1;
-	    y = y + 1;
+int main()
+{
+	int x = 0;
+	int y = 500000;
+	while(x < 1000000) {
+		if (x < 500000) {
+			x = x + 1;
+		} else {
+			x = x + 1;
+			y = y + 1;
+		}
 	}
-    }
-    __VERIFIER_assert(y==x);
-    return 0;
+	__VERIFIER_assert(y==x);
+	return 0;
 }

--- a/c/loops-crafted-1/mono-crafted_9.c
+++ b/c/loops-crafted-1/mono-crafted_9.c
@@ -1,0 +1,17 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+
+int main() {
+    int x = 0;
+    int y = 500000;
+    while(x < 1000000) {
+	if (x < 500000) {
+	    x = x + 1;
+	} else {
+	    x = x + 1;
+	    y = y + 1;
+	}
+    }
+    __VERIFIER_assert(y==x);
+    return 0;
+}

--- a/c/loops-crafted-1/mono-crafted_9.yml
+++ b/c/loops-crafted-1/mono-crafted_9.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'mono-crafted_9.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/nested3-1.c
+++ b/c/loops-crafted-1/nested3-1.c
@@ -7,7 +7,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int main(void) {
+int main()
+{
   unsigned int x = 0;
   unsigned int y = 0;
   unsigned int z = 0;
@@ -29,5 +30,6 @@ int main(void) {
     x++;
   }
   __VERIFIER_assert(x % 2);
+  return 0;
 
 }

--- a/c/loops-crafted-1/nested3-2.c
+++ b/c/loops-crafted-1/nested3-2.c
@@ -7,7 +7,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int main(void) {
+int main()
+{
   unsigned int x = 0;
   unsigned int y = 0;
   unsigned int z = 0;
@@ -29,5 +30,6 @@ int main(void) {
     x++;
   }
   __VERIFIER_assert(!(x % 2));
+ return 0;
 
 }

--- a/c/loops-crafted-1/nested5-1.c
+++ b/c/loops-crafted-1/nested5-1.c
@@ -7,7 +7,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int main(void) {
+int main()
+{
   unsigned int x = 0;
   unsigned int y = 0;
   unsigned int z = 0;
@@ -20,6 +21,5 @@ int main(void) {
 			for(v=0;v< 10;v++);
 			__VERIFIER_assert(v % 4);
 	   }
+  return 0;
 }
-
-

--- a/c/loops-crafted-1/nested5-2.c
+++ b/c/loops-crafted-1/nested5-2.c
@@ -7,7 +7,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int main(void) {
+int main()
+{
   unsigned int x = 0;
   unsigned int y = 0;
   unsigned int z = 0;
@@ -22,6 +23,5 @@ int main(void) {
 			__VERIFIER_assert(!(v % 4));
 	  	}
   }
+  return 0;
 }
-
-

--- a/c/loops-crafted-1/nested_delay_nd.c
+++ b/c/loops-crafted-1/nested_delay_nd.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern void __VERIFIER_assume(int);
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {

--- a/c/loops-crafted-1/nested_delay_nd.c
+++ b/c/loops-crafted-1/nested_delay_nd.c
@@ -1,0 +1,48 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+
+//VERIFICATION RESULT : TRUE
+
+
+int last ;
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+     ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int nondet()
+{
+	int x;
+	return x;
+}
+
+#define SIZE 200000 
+
+int main() {
+	last = nondet();
+	__VERIFIER_assume(last > 0);
+	int a=0,b=0,c=0,st=0,d=0,e=0,f=0;
+	while(1) {
+		st=1;  
+		for(c=0;c<SIZE;c++) {
+			if (c>=last)  { st = 0; }
+		}
+		if(st==0 && c==last+1){
+			a+=3; b+=3;}
+		else { a+=2; b+=2; } 
+		if(c==last && st==0) { 
+			a = a+1;
+		}
+		else if(st==1 && last<SIZE) { 
+			d++;
+		}
+		if(d == SIZE) {
+			a = 0; 
+			b = 1;
+		}
+			
+		__VERIFIER_assert(a==b && c==SIZE);
+	}
+}

--- a/c/loops-crafted-1/nested_delay_nd.c
+++ b/c/loops-crafted-1/nested_delay_nd.c
@@ -10,7 +10,7 @@ void __VERIFIER_assert(int cond) {
 }
 
 
-#define SIZE 200000 
+int SIZE = 200000; 
 
 int main()
 {

--- a/c/loops-crafted-1/nested_delay_nd.c
+++ b/c/loops-crafted-1/nested_delay_nd.c
@@ -1,9 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-//VERIFICATION RESULT : TRUE
-
-
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -20,7 +16,8 @@ int nondet()
 
 #define SIZE 200000 
 
-int main() {
+int main()
+{
 	last = nondet();
 	__VERIFIER_assume(last > 0);
 	int a=0,b=0,c=0,st=0,d=0,e=0,f=0;
@@ -45,4 +42,5 @@ int main() {
 			
 		__VERIFIER_assert(a==b && c==SIZE);
 	}
+	return 0;
 }

--- a/c/loops-crafted-1/nested_delay_nd.c
+++ b/c/loops-crafted-1/nested_delay_nd.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -8,19 +9,14 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int nondet()
-{
-	int x;
-	return x;
-}
 
 #define SIZE 200000 
 
 int main()
 {
-	last = nondet();
+	last = __VERIFIER_nondet_int();
 	__VERIFIER_assume(last > 0);
-	int a=0,b=0,c=0,st=0,d=0,e=0,f=0;
+	int a=0,b=0,c=0,st=0,d=0;
 	while(1) {
 		st=1;  
 		for(c=0;c<SIZE;c++) {

--- a/c/loops-crafted-1/nested_delay_nd.yml
+++ b/c/loops-crafted-1/nested_delay_nd.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'nested_delay_nd.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/nested_delay_notd2.c
+++ b/c/loops-crafted-1/nested_delay_notd2.c
@@ -10,7 +10,7 @@ void __VERIFIER_assert(int cond) {
 }
 
 
-#define SIZE 20
+int SIZE = 20;
 int main() {
 	last = __VERIFIER_nondet_int();
 	__VERIFIER_assume(last > 0);

--- a/c/loops-crafted-1/nested_delay_notd2.c
+++ b/c/loops-crafted-1/nested_delay_notd2.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
+extern int __VERIFIER_nondet_int(void);
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -8,17 +9,12 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-int nondet()
-{
-	int x;
-	return x;
-}
 
 #define SIZE 20
 int main() {
-	last = nondet();
+	last = __VERIFIER_nondet_int();
 	__VERIFIER_assume(last > 0);
-	int a=0,b=0,c=0,st=0,d=0,e=0,f=0;
+	int a=0,b=0,c=0,st=0,d=0;
 	while(1) {
 		st=1;  
 		for(c=0;c<SIZE;c++) {

--- a/c/loops-crafted-1/nested_delay_notd2.c
+++ b/c/loops-crafted-1/nested_delay_notd2.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern void __VERIFIER_assume(int);
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {

--- a/c/loops-crafted-1/nested_delay_notd2.c
+++ b/c/loops-crafted-1/nested_delay_notd2.c
@@ -1,0 +1,47 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+
+//VERIFICATION RESULT : TRUE
+
+
+int last ;
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+     ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int nondet()
+{
+	int x;
+	return x;
+}
+
+#define SIZE 20
+int main() {
+	last = nondet();
+	__VERIFIER_assume(last > 0);
+	int a=0,b=0,c=0,st=0,d=0,e=0,f=0;
+	while(1) {
+		st=1;  
+		for(c=0;c<SIZE;c++) {
+			if (c>=last)  { st = 0; }
+		}
+		if(st==0 && c==last+1){
+			a+=3; b+=3;}
+		else { a+=2; b+=2; } 
+		if(c==last && st==0) { 
+			a = a+1;
+		}
+		else if(st==1 && last>=SIZE) { 
+			d++;
+		}
+		if(d == SIZE) {
+			a = 0; 
+			b = 1;
+		}
+			
+		__VERIFIER_assert(a==b && c==SIZE);
+	}
+}

--- a/c/loops-crafted-1/nested_delay_notd2.c
+++ b/c/loops-crafted-1/nested_delay_notd2.c
@@ -1,9 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-//VERIFICATION RESULT : TRUE
-
-
 int last ;
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -44,4 +40,5 @@ int main() {
 			
 		__VERIFIER_assert(a==b && c==SIZE);
 	}
+	return 0;
 }

--- a/c/loops-crafted-1/nested_delay_notd2.yml
+++ b/c/loops-crafted-1/nested_delay_notd2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'nested_delay_notd2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: false

--- a/c/loops-crafted-1/net_reset.c
+++ b/c/loops-crafted-1/net_reset.c
@@ -205,7 +205,7 @@ int  net_send_batch()
 int  i;
 for(i = fstTTL - 1 ; i < batch_at ; i++ )
 {
-if(((( "1_0_727_4294969421" /*Grp 0*/, __VERIFIER_assert(i>=0 && i< 256)) , (__tmpTR__int_1 = addrcmp((void *) & (host[i] . addr), (void *) & unspec_addr, af))) , __tmpTR__int_1 == 0))
+if(((( "1_0_727_4294969421", __VERIFIER_assert(i>=0 && i< 256)) , (__tmpTR__int_1 = addrcmp((void *) & (host[i] . addr), (void *) & unspec_addr, af))) , __tmpTR__int_1 == 0))
 ;
 
 }
@@ -228,7 +228,8 @@ net_reset();
 net_send_batch();
 }
 
-main(){
+int main(){
  struct hostent h;
  net_reopen(&h); 
+ return 0;
 }

--- a/c/loops-crafted-1/net_reset.c
+++ b/c/loops-crafted-1/net_reset.c
@@ -1,0 +1,234 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+int __tmpTR__int_1;
+struct timeval;
+struct timezone;
+struct sockaddr;
+struct sockaddr_storage;
+struct in_addr;
+struct in6_addr;
+union in_h_196;
+struct sockaddr_in;
+struct sockaddr_in6;
+struct _IO_FILE;
+struct _IO_marker;
+struct hostent;
+struct nethost;
+struct sequence;
+struct IPHeader;
+struct ICMPHeader;
+struct hostent{
+char * h_name;
+char ** h_aliases;
+int  h_addrtype;
+int  h_length;
+char ** h_addr_list;
+} ;
+typedef struct in6_addr ip_t;
+struct _IO_marker{
+struct _IO_marker* _next;
+struct _IO_FILE* _sbuf;
+int  _pos;
+} ;
+typedef long  __off_t;
+typedef long long  __quad_t;
+typedef __quad_t __off64_t;
+typedef void  _IO_lock_t;
+typedef struct _IO_FILE FILE;
+typedef enum {IPPROTO_IP= 0, IPPROTO_HOPOPTS= 0, IPPROTO_ICMP= 1, IPPROTO_IGMP= 2, IPPROTO_IPIP= 4, IPPROTO_TCP= 6, IPPROTO_EGP= 8, IPPROTO_PUP= 12, IPPROTO_UDP= 17, IPPROTO_IDP= 22, IPPROTO_TP= 29, IPPROTO_IPV6= 41, IPPROTO_ROUTING= 43, IPPROTO_FRAGMENT= 44, IPPROTO_RSVP= 46, IPPROTO_GRE= 47, IPPROTO_ESP= 50, IPPROTO_AH= 51, IPPROTO_ICMPV6= 58, IPPROTO_NONE= 59, IPPROTO_DSTOPTS= 60, IPPROTO_MTP= 92, IPPROTO_ENCAP= 98, IPPROTO_PIM= 103, IPPROTO_COMP= 108, IPPROTO_SCTP= 132, IPPROTO_RAW= 255, IPPROTO_MAX}netin_32_0;
+typedef unsigned int  uint32_t;
+typedef uint32_t in_addr_t;
+struct in_addr{
+in_addr_t s_addr;
+} ;
+typedef unsigned short  uint16_t;
+typedef uint16_t in_port_t;
+typedef unsigned char  uint8_t;
+union in_h_196{
+uint8_t u6_addr8 [16];
+uint16_t u6_addr16 [8];
+uint32_t u6_addr32 [4];
+} ;
+struct in6_addr{
+union in_h_196 in6_u;
+} ;
+struct nethost{
+ip_t addr;
+ip_t addrs [8];
+int  xmit;
+int  returned;
+int  sent;
+int  up;
+long long  var;
+int  last;
+int  best;
+int  worst;
+int  avg;
+int  gmean;
+int  jitter;
+int  javg;
+int  jworst;
+int  jinta;
+int  transit;
+int  saved [200];
+int  saved_seq_offset;
+} ;
+typedef unsigned short  sa_family_t;
+struct sockaddr_in6{
+sa_family_t sin6_family;
+in_port_t sin6_port;
+uint32_t sin6_flowinfo;
+struct in6_addr sin6_addr;
+uint32_t sin6_scope_id;
+} ;
+struct sockaddr_in{
+sa_family_t sin_family;
+in_port_t sin_port;
+struct in_addr sin_addr;
+unsigned char  sin_zero [8];
+} ;
+struct sockaddr{
+sa_family_t sa_family;
+char  sa_data [14];
+} ;
+enum __socket_type{SOCK_STREAM= 1, SOCK_DGRAM= 2, SOCK_RAW= 3, SOCK_RDM= 4, SOCK_SEQPACKET= 5, SOCK_PACKET= 10};
+typedef struct timezone* __restrict __timezone_ptr_t;
+struct timezone{
+int  tz_minuteswest;
+int  tz_dsttime;
+} ;
+typedef unsigned int  __socklen_t;
+typedef __socklen_t socklen_t;
+typedef int  __ssize_t;
+typedef __ssize_t ssize_t;
+typedef long  __suseconds_t;
+typedef long  __time_t;
+struct timeval{
+__time_t tv_sec;
+__suseconds_t tv_usec;
+} ;
+struct sequence{
+int  index;
+int  transit;
+int  saved_seq;
+struct timeval time;
+} ;
+typedef int  __pid_t;
+typedef unsigned int  __uint32_t;
+struct sockaddr_storage{
+sa_family_t ss_family;
+__uint32_t __ss_align;
+char  __ss_padding [120];
+} ;
+typedef unsigned long  size_t;
+struct _IO_FILE{
+int  _flags;
+char * _IO_read_ptr;
+char * _IO_read_end;
+char * _IO_read_base;
+char * _IO_write_base;
+char * _IO_write_ptr;
+char * _IO_write_end;
+char * _IO_buf_base;
+char * _IO_buf_end;
+char * _IO_save_base;
+char * _IO_backup_base;
+char * _IO_save_end;
+struct _IO_marker* _markers;
+struct _IO_FILE* _chain;
+int  _fileno;
+int  _flags2;
+__off_t _old_offset;
+unsigned short  _cur_column;
+signed char  _vtable_offset;
+char  _shortbuf [1];
+_IO_lock_t* _lock;
+__off64_t _offset;
+void * __pad1;
+void * __pad2;
+void * __pad3;
+void * __pad4;
+size_t __pad5;
+int  _mode;
+char  _unused2 [40];
+} ;
+typedef unsigned int  uint32;
+typedef unsigned short  uint16;
+typedef unsigned char  uint8;
+struct ICMPHeader{
+uint8 type;
+uint8 code;
+uint16 checksum;
+uint16 id;
+uint16 sequence;
+} ;
+struct IPHeader{
+uint8 version;
+uint8 tos;
+uint16 len;
+uint16 id;
+uint16 frag;
+uint8 ttl;
+uint8 protocol;
+uint16 check;
+uint32 saddr;
+uint32 daddr;
+} ;
+void  net_reset();
+extern void  net_reopen(struct hostent* address);
+void  net_reopen(struct hostent* addr);
+int  net_send_batch();
+int  addrcmp(char * a, char * b, int  af);
+extern void  net_reset();
+extern int  net_send_batch();
+extern int  addrcmp(char * a, char * b, int  af);
+static int  batch_at = 0;
+extern int  fstTTL;
+static struct nethost host [256];
+extern int  af;
+ip_t unspec_addr;
+int  fstTTL = 1;
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+void  net_reset()
+{
+batch_at = fstTTL - 1;
+
+}
+int  net_send_batch()
+{
+int  i;
+for(i = fstTTL - 1 ; i < batch_at ; i++ )
+{
+if(((( "1_0_727_4294969421" /*Grp 0*/, __VERIFIER_assert(i>=0 && i< 256)) , (__tmpTR__int_1 = addrcmp((void *) & (host[i] . addr), (void *) & unspec_addr, af))) , __tmpTR__int_1 == 0))
+;
+
+}
+return 0;
+}
+void  net_reopen(struct hostent* addr)
+{
+switch(addr->h_addrtype)
+{
+case 2: 
+;
+break;
+case 10: 
+;
+break;
+default: ;
+
+}
+net_reset();
+net_send_batch();
+}
+
+main(){
+ struct hostent h;
+ net_reopen(&h); 
+}

--- a/c/loops-crafted-1/net_reset.yml
+++ b/c/loops-crafted-1/net_reset.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'net_reset.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sum_by_3.c
+++ b/c/loops-crafted-1/sum_by_3.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,k;

--- a/c/loops-crafted-1/sum_by_3.c
+++ b/c/loops-crafted-1/sum_by_3.c
@@ -1,0 +1,30 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = 0;
+  while( i < n ) {
+    i = i + 1;
+  }
+  int j = i;
+  while( j < n ) {
+    j = j+1;
+  }
+  k = j;
+  while( k < n ) {
+    k = k+1;
+  }
+  __VERIFIER_assert((i+j+k)/3 <= SIZE);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sum_by_3.yml
+++ b/c/loops-crafted-1/sum_by_3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sum_by_3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sum_natnum.c
+++ b/c/loops-crafted-1/sum_natnum.c
@@ -19,4 +19,5 @@ int main() {
       sum += i;
   }
   __VERIFIER_assert( sum == (SIZE *(SIZE+1))/2 );
+  return 0;
 }

--- a/c/loops-crafted-1/sum_natnum.c
+++ b/c/loops-crafted-1/sum_natnum.c
@@ -1,4 +1,4 @@
-#define SIZE 40000 
+int SIZE = 40000; 
 
 
 int __VERIFIER_nondet_int();

--- a/c/loops-crafted-1/sum_natnum.c
+++ b/c/loops-crafted-1/sum_natnum.c
@@ -1,4 +1,4 @@
-#define SIZE 100000 
+#define SIZE 40000 
 
 
 int __VERIFIER_nondet_int();
@@ -12,12 +12,13 @@ void __VERIFIER_assert(int cond) {
 }
 
 int main() {
-  int i,sum;
+  int i;
+  unsigned long long sum;
   i = 0, sum =0; 
   while(i< SIZE){ 
       i = i + 1; 
       sum += i;
   }
-  __VERIFIER_assert( sum == (SIZE *(SIZE+1))/2 );
+  __VERIFIER_assert( sum == ((SIZE *(SIZE+1))/2));
   return 0;
 }

--- a/c/loops-crafted-1/sum_natnum.c
+++ b/c/loops-crafted-1/sum_natnum.c
@@ -1,0 +1,22 @@
+#define SIZE 100000 
+
+
+int __VERIFIER_nondet_int();
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+int main() {
+  int i,sum;
+  i = 0, sum =0; 
+  while(i< SIZE){ 
+      i = i + 1; 
+      sum += i;
+  }
+  __VERIFIER_assert( sum == (SIZE *(SIZE+1))/2 );
+}

--- a/c/loops-crafted-1/sum_natnum.yml
+++ b/c/loops-crafted-1/sum_natnum.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sum_natnum.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt2.c
+++ b/c/loops-crafted-1/sumt2.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,j,l=0;

--- a/c/loops-crafted-1/sumt2.c
+++ b/c/loops-crafted-1/sumt2.c
@@ -1,0 +1,29 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k,j,sum =0, l=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = 0;
+  j = 0;
+  l=0;
+  while( l < n ) {
+	
+	  if(!(l%2))
+	    i = i + 1;
+	  else 
+		  j = j+1;
+    l = l+1;
+  }
+  __VERIFIER_assert((i+j) == l);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt2.c
+++ b/c/loops-crafted-1/sumt2.c
@@ -9,7 +9,7 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 unsigned int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n,i,k,j,sum =0, l=0;
+  unsigned int n,i,j,l=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   i = 0;

--- a/c/loops-crafted-1/sumt2.yml
+++ b/c/loops-crafted-1/sumt2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt3.c
+++ b/c/loops-crafted-1/sumt3.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,k,j,l=0;

--- a/c/loops-crafted-1/sumt3.c
+++ b/c/loops-crafted-1/sumt3.c
@@ -1,0 +1,32 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k,j,sum =0, l=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = 0;
+  j = 0;
+  k = 0;
+  l=0;
+  while( l < n ) {
+	
+	  if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+  }
+  __VERIFIER_assert((i+j+k) == l);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt3.c
+++ b/c/loops-crafted-1/sumt3.c
@@ -9,7 +9,7 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 unsigned int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n,i,k,j,sum =0, l=0;
+  unsigned int n,i,k,j,l=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   i = 0;

--- a/c/loops-crafted-1/sumt3.yml
+++ b/c/loops-crafted-1/sumt3.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt3.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt4.c
+++ b/c/loops-crafted-1/sumt4.c
@@ -1,0 +1,31 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+  }
+  __VERIFIER_assert((i+j+k+v4) == l);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt4.c
+++ b/c/loops-crafted-1/sumt4.c
@@ -9,8 +9,8 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 unsigned int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
-  unsigned int v1=0, v2=0, v3=0, v4=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
+  unsigned int v4=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   while( l < n ) {

--- a/c/loops-crafted-1/sumt4.c
+++ b/c/loops-crafted-1/sumt4.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt4.yml
+++ b/c/loops-crafted-1/sumt4.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt4.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt5.c
+++ b/c/loops-crafted-1/sumt5.c
@@ -9,8 +9,8 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
-  unsigned int v1=0, v2=0, v3=0, v4=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
+  unsigned int v3=0, v4=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   while( l < n ) {

--- a/c/loops-crafted-1/sumt5.c
+++ b/c/loops-crafted-1/sumt5.c
@@ -1,0 +1,33 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%5))
+	    v3 = v3 + 1;
+	  else if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+  }
+  __VERIFIER_assert((i+j+k+v4+v3) == l);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt5.c
+++ b/c/loops-crafted-1/sumt5.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt5.yml
+++ b/c/loops-crafted-1/sumt5.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt5.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt6.c
+++ b/c/loops-crafted-1/sumt6.c
@@ -1,0 +1,35 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%6))
+	    v2 = v2 + 1;
+	  else if(!(l%5))
+	    v3 = v3 + 1;
+	  else if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+  }
+  __VERIFIER_assert((i+j+k+v4+v3+v2) == l);
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt6.c
+++ b/c/loops-crafted-1/sumt6.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt6.c
+++ b/c/loops-crafted-1/sumt6.c
@@ -9,8 +9,8 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
-  unsigned int v1=0, v2=0, v3=0, v4=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
+  unsigned int v2=0, v3=0, v4=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   while( l < n ) {

--- a/c/loops-crafted-1/sumt6.yml
+++ b/c/loops-crafted-1/sumt6.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt6.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt7.c
+++ b/c/loops-crafted-1/sumt7.c
@@ -9,7 +9,7 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
   unsigned int v1=0, v2=0, v3=0, v4=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;

--- a/c/loops-crafted-1/sumt7.c
+++ b/c/loops-crafted-1/sumt7.c
@@ -1,0 +1,37 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%7))
+	    v1 = v1 + 1;
+	  else if(!(l%6))
+	    v2 = v2 + 1;
+	  else if(!(l%5))
+	    v3 = v3 + 1;
+	  else if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+    __VERIFIER_assert((i+j+k+v1+v2+v3+v4) == l);
+  }
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt7.c
+++ b/c/loops-crafted-1/sumt7.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt7.yml
+++ b/c/loops-crafted-1/sumt7.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt7.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt8.c
+++ b/c/loops-crafted-1/sumt8.c
@@ -1,0 +1,39 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0, v6=0, v7=0, v8=0, v9=0, v10=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%8))
+	    v5 = v5 + 1;
+	  else if(!(l%7))
+	    v1 = v1 + 1;
+	  else if(!(l%6))
+	    v2 = v2 + 1;
+	  else if(!(l%5))
+	    v3 = v3 + 1;
+	  else if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+    __VERIFIER_assert((i+j+k+v1+v2+v3+v4+v5) == l);
+  }
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt8.c
+++ b/c/loops-crafted-1/sumt8.c
@@ -9,8 +9,8 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
-  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0, v6=0, v7=0, v8=0, v9=0, v10=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   while( l < n ) {

--- a/c/loops-crafted-1/sumt8.c
+++ b/c/loops-crafted-1/sumt8.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt8.yml
+++ b/c/loops-crafted-1/sumt8.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt8.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/sumt9.c
+++ b/c/loops-crafted-1/sumt9.c
@@ -1,0 +1,41 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0, v6=0, v7=0, v8=0, v9=0, v10=0;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  while( l < n ) {
+	
+	  if(!(l%9))
+	    v6 = v6 + 1;
+	  else if(!(l%8))
+	    v5 = v5 + 1;
+	  else if(!(l%7))
+	    v1 = v1 + 1;
+	  else if(!(l%6))
+	    v2 = v2 + 1;
+	  else if(!(l%5))
+	    v3 = v3 + 1;
+	  else if(!(l%4))
+	    v4 = v4 + 1;
+	  else if(!(l%3))
+	    i = i + 1;
+	  else if(!(l%2)) 
+		  j = j+1;
+	  else 
+	    k = k+1;
+    l = l+1;
+    __VERIFIER_assert((i+j+k+v1+v2+v3+v4+v5+v6) == l);
+  }
+  return 0;
+}
+

--- a/c/loops-crafted-1/sumt9.c
+++ b/c/loops-crafted-1/sumt9.c
@@ -9,8 +9,8 @@ void __VERIFIER_assert(int cond) {
 #define SIZE 20000001
 int __VERIFIER_nondet_int();
 int main() {
-  unsigned int n=0,i=0,k=0,j=0,sum =0, l=0;
-  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0, v6=0, v7=0, v8=0, v9=0, v10=0;
+  unsigned int n=0,i=0,k=0,j=0,l=0;
+  unsigned int v1=0, v2=0, v3=0, v4=0, v5=0, v6=0;
   n = __VERIFIER_nondet_int();
   if (!(n <= SIZE)) return 0;
   while( l < n ) {

--- a/c/loops-crafted-1/sumt9.c
+++ b/c/loops-crafted-1/sumt9.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 int __VERIFIER_nondet_int();
 int main() {
   unsigned int n=0,i=0,k=0,j=0,l=0;

--- a/c/loops-crafted-1/sumt9.yml
+++ b/c/loops-crafted-1/sumt9.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'sumt9.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/theatreSquare.c
+++ b/c/loops-crafted-1/theatreSquare.c
@@ -29,7 +29,7 @@ void __VERIFIER_assert(int cond) {
 //
 // student_version is identical to correct version.
 
-void main()
+int main()
 {
 
     int a, n, m;
@@ -49,6 +49,7 @@ void main()
         n_stones2 = student_version(n, m, a);
     }
     __VERIFIER_assert(n_stones1 == n_stones2);
+    return 0;
 }
 
 int correct_version(int n, int m, int a)

--- a/c/loops-crafted-1/theatreSquare.c
+++ b/c/loops-crafted-1/theatreSquare.c
@@ -1,0 +1,107 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+        ERROR: __VERIFIER_error();
+    }
+    return;
+}
+
+// The main function checks for output equivalence for two function:
+// 1. correct_version
+// 2. student_version
+//
+// correct_version computes the solution for the following problem:
+// 
+// Setting: Theatre Square in the capital city of Berland has a rectangular
+// shape with the size n × m meters. On the occasion of the city's anniversary,
+// a decision was taken to pave the Square with square granite flagstones. Each
+// flagstone is of the size a × a.
+//
+// Find: What is the least number of flagstones needed to pave the Square?
+// 
+// Conditions to be satisfied:
+// 1. The Square has to be covered.
+// 2. It's allowed to cover the surface larger than the Theatre Square.
+// 3. It's not allowed to break the flagstones.
+// 4. The sides of flagstones should be parallel to the sides of the Square.
+// 5. n, m and a are positive integers.
+//
+// student_version is identical to correct version.
+
+void main()
+{
+
+    int a, n, m;
+
+    int n_stones1, n_stones2;
+
+    n_stones1 = n_stones2;
+
+    if((1 <= n) &&
+       (1 <= m) &&
+       (1 <= a) &&
+       (n <= 109) &&
+       (m <= 109) &&
+       (a <= 109))
+    {
+        n_stones1 = correct_version(n, m, a);
+        n_stones2 = student_version(n, m, a);
+    }
+    __VERIFIER_assert(n_stones1 == n_stones2);
+}
+
+int correct_version(int n, int m, int a)
+{
+    int i = 0, j = 0, b = 0, l = 0;
+
+    while(b < n)
+    {
+        b = b + a;
+        i = i + 1;
+    }
+
+    while(l < m)
+    {
+        l = l + a;
+        j = j + 1;
+    }
+    
+    int x = 0, y = 0;
+    
+    while(x < i)
+    {
+        y = y + j;
+        x = x + 1;
+    }
+
+    return y;
+}
+
+int student_version(int n, int m, int a)
+{
+    int i = 0, j = 0, b = 0, l = 0;
+
+    while(b < n)
+    {
+        b = b + a;
+        i = i + 1;
+    }
+
+    while(l < m)
+    {
+        l = l + a;
+        j = j + 1;
+    }
+    
+    int x = 0, y = 0;
+    
+    while(x < i)
+    {
+        y = y + j;
+        x = x + 1;
+    }
+
+    return y;
+}
+

--- a/c/loops-crafted-1/theatreSquare.c
+++ b/c/loops-crafted-1/theatreSquare.c
@@ -29,29 +29,6 @@ void __VERIFIER_assert(int cond) {
 //
 // student_version is identical to correct version.
 
-int main()
-{
-
-    int a, n, m;
-
-    int n_stones1, n_stones2;
-
-    n_stones1 = n_stones2;
-
-    if((1 <= n) &&
-       (1 <= m) &&
-       (1 <= a) &&
-       (n <= 109) &&
-       (m <= 109) &&
-       (a <= 109))
-    {
-        n_stones1 = correct_version(n, m, a);
-        n_stones2 = student_version(n, m, a);
-    }
-    __VERIFIER_assert(n_stones1 == n_stones2);
-    return 0;
-}
-
 int correct_version(int n, int m, int a)
 {
     int i = 0, j = 0, b = 0, l = 0;
@@ -104,5 +81,28 @@ int student_version(int n, int m, int a)
     }
 
     return y;
+}
+
+int main()
+{
+
+    int a, n, m;
+
+    int n_stones1, n_stones2;
+
+    n_stones1 = n_stones2;
+
+    if((1 <= n) &&
+       (1 <= m) &&
+       (1 <= a) &&
+       (n <= 109) &&
+       (m <= 109) &&
+       (a <= 109))
+    {
+        n_stones1 = correct_version(n, m, a);
+        n_stones2 = student_version(n, m, a);
+    }
+    __VERIFIER_assert(n_stones1 == n_stones2);
+    return 0;
 }
 

--- a/c/loops-crafted-1/theatreSquare.c
+++ b/c/loops-crafted-1/theatreSquare.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
         ERROR: __VERIFIER_error();
@@ -86,9 +86,9 @@ int student_version(int n, int m, int a)
 int main()
 {
 
-    int a, n, m;
+    int a=__VERIFIER_nondet_int(), n=__VERIFIER_nondet_int(), m=__VERIFIER_nondet_int();
 
-    int n_stones1, n_stones2;
+    int n_stones1, n_stones2=__VERIFIER_nondet_int();
 
     n_stones1 = n_stones2;
 

--- a/c/loops-crafted-1/theatreSquare.yml
+++ b/c/loops-crafted-1/theatreSquare.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'theatreSquare.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/vnew1.c
+++ b/c/loops-crafted-1/vnew1.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  k = n;
+  i = 0;
+  while( i < n ) {
+    k--;
+    i = i + 3;
+  }
+  int j = 0;
+  while( j < n/3 ) {
+    __VERIFIER_assert(k > 0);
+    k--;
+    j++;
+  }
+  return 0;
+}

--- a/c/loops-crafted-1/vnew1.c
+++ b/c/loops-crafted-1/vnew1.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,k;

--- a/c/loops-crafted-1/vnew1.yml
+++ b/c/loops-crafted-1/vnew1.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'vnew1.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/vnew2.c
+++ b/c/loops-crafted-1/vnew2.c
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-#define SIZE 20000001
+int SIZE = 20000001;
 unsigned int __VERIFIER_nondet_int();
 int main() {
   unsigned int n,i,k,j;

--- a/c/loops-crafted-1/vnew2.c
+++ b/c/loops-crafted-1/vnew2.c
@@ -1,0 +1,25 @@
+extern void __VERIFIER_error(void);
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+#define SIZE 20000001
+unsigned int __VERIFIER_nondet_int();
+int main() {
+  unsigned int n,i,k,j;
+  n = __VERIFIER_nondet_int();
+  if (!(n <= SIZE)) return 0;
+  i = j = k = 0;
+  while( i < n ) {
+    i = i + 3;
+    j = j+3;
+    k = k+3;
+  }
+  if(n>0)
+	  __VERIFIER_assert( i==j && j==k && (i%(SIZE+2)) );
+  return 0;
+}
+

--- a/c/loops-crafted-1/vnew2.yml
+++ b/c/loops-crafted-1/vnew2.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'vnew2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true

--- a/c/loops-crafted-1/watermelon.c
+++ b/c/loops-crafted-1/watermelon.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
       ERROR: __VERIFIER_error();
@@ -51,7 +51,7 @@ bool student_version(int w)
 
 int main(){
 
-  unsigned int w;
+  unsigned int w=__VERIFIER_nondet_uint();
 
   bool is_divisible1 = true, is_divisible2 = true;
 

--- a/c/loops-crafted-1/watermelon.c
+++ b/c/loops-crafted-1/watermelon.c
@@ -7,13 +7,12 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-#define bool int
-#define true 1
-#define false 0
+int true = 1;
+int false = 0;
 
-bool correct_version(int w)
+int correct_version(int w)
 {
-  bool is_divisible = true;
+  int is_divisible = true;
 
   if(w < 4)
     is_divisible = false;
@@ -30,9 +29,9 @@ bool correct_version(int w)
   return is_divisible;
 }
 
-bool student_version(int w)
+int student_version(int w)
 {
-  bool is_divisible = true;
+  int is_divisible = true;
 
   if(w < 4)
     is_divisible = false;
@@ -53,7 +52,7 @@ int main(){
 
   unsigned int w=__VERIFIER_nondet_uint();
 
-  bool is_divisible1 = true, is_divisible2 = true;
+  int is_divisible1 = true, is_divisible2 = true;
 
   if(w > 0 && w < 10000000)
   {

--- a/c/loops-crafted-1/watermelon.c
+++ b/c/loops-crafted-1/watermelon.c
@@ -1,0 +1,68 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+      ERROR: __VERIFIER_error();
+  }
+  return;
+}
+
+#define bool int
+#define true 1
+#define false 0
+
+void main(){
+
+  unsigned int w;
+
+  bool is_divisible1 = true, is_divisible2 = true;
+
+  if(w > 0 && w < 10000000)
+  {
+    is_divisible1 = correct_version(w);
+    is_divisible2 = student_version(w);
+    __VERIFIER_assert(is_divisible1 == is_divisible2);
+  }
+
+
+}
+
+bool correct_version(int w)
+{
+  bool is_divisible = true;
+
+  if(w < 4)
+    is_divisible = false;
+  else
+  {
+    int i;
+    for(i = 0; i < w; i += 2)
+    {}
+
+    if(i != w)
+      is_divisible = false;
+  }
+
+  return is_divisible;
+}
+
+bool student_version(int w)
+{
+  bool is_divisible = true;
+
+  if(w < 4)
+    is_divisible = false;
+  else
+  {
+    int i;
+    for(i = 0; i < w; i += 2)
+    {}
+
+    if(i != w)
+      is_divisible = false;
+  }
+
+  return is_divisible;
+}
+
+

--- a/c/loops-crafted-1/watermelon.c
+++ b/c/loops-crafted-1/watermelon.c
@@ -11,7 +11,7 @@ void __VERIFIER_assert(int cond) {
 #define true 1
 #define false 0
 
-void main(){
+int main(){
 
   unsigned int w;
 
@@ -23,7 +23,7 @@ void main(){
     is_divisible2 = student_version(w);
     __VERIFIER_assert(is_divisible1 == is_divisible2);
   }
-
+  return 0;
 
 }
 

--- a/c/loops-crafted-1/watermelon.c
+++ b/c/loops-crafted-1/watermelon.c
@@ -11,22 +11,6 @@ void __VERIFIER_assert(int cond) {
 #define true 1
 #define false 0
 
-int main(){
-
-  unsigned int w;
-
-  bool is_divisible1 = true, is_divisible2 = true;
-
-  if(w > 0 && w < 10000000)
-  {
-    is_divisible1 = correct_version(w);
-    is_divisible2 = student_version(w);
-    __VERIFIER_assert(is_divisible1 == is_divisible2);
-  }
-  return 0;
-
-}
-
 bool correct_version(int w)
 {
   bool is_divisible = true;
@@ -65,4 +49,19 @@ bool student_version(int w)
   return is_divisible;
 }
 
+int main(){
+
+  unsigned int w;
+
+  bool is_divisible1 = true, is_divisible2 = true;
+
+  if(w > 0 && w < 10000000)
+  {
+    is_divisible1 = correct_version(w);
+    is_divisible2 = student_version(w);
+    __VERIFIER_assert(is_divisible1 == is_divisible2);
+  }
+  return 0;
+
+}
 

--- a/c/loops-crafted-1/watermelon.yml
+++ b/c/loops-crafted-1/watermelon.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'watermelon.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true


### PR DESCRIPTION
<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
