### PR TITLE
Add coverage properties to busybox tasks

### DIFF
--- a/c/busybox-1.22.0/basename-1.yml
+++ b/c/busybox-1.22.0/basename-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/basename-2.yml
+++ b/c/busybox-1.22.0/basename-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/chgrp-incomplete-1.yml
+++ b/c/busybox-1.22.0/chgrp-incomplete-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/chgrp-incomplete-2.yml
+++ b/c/busybox-1.22.0/chgrp-incomplete-2.yml
@@ -6,3 +6,6 @@ input_files: 'chgrp-incomplete-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/chroot-incomplete-1.yml
+++ b/c/busybox-1.22.0/chroot-incomplete-1.yml
@@ -6,3 +6,6 @@ input_files: 'chroot-incomplete-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/chroot-incomplete-2.yml
+++ b/c/busybox-1.22.0/chroot-incomplete-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/cut-1.yml
+++ b/c/busybox-1.22.0/cut-1.yml
@@ -6,3 +6,6 @@ input_files: 'cut-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/cut-2.yml
+++ b/c/busybox-1.22.0/cut-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/date-1.yml
+++ b/c/busybox-1.22.0/date-1.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/date-2.yml
+++ b/c/busybox-1.22.0/date-2.yml
@@ -6,3 +6,6 @@ input_files: 'date-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/dirname-1.yml
+++ b/c/busybox-1.22.0/dirname-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/du-1.yml
+++ b/c/busybox-1.22.0/du-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/du-2.yml
+++ b/c/busybox-1.22.0/du-2.yml
@@ -6,3 +6,6 @@ input_files: 'du-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/echo-1.yml
+++ b/c/busybox-1.22.0/echo-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/echo-2.yml
+++ b/c/busybox-1.22.0/echo-2.yml
@@ -6,3 +6,6 @@ input_files: 'echo-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/expand-1.yml
+++ b/c/busybox-1.22.0/expand-1.yml
@@ -6,3 +6,6 @@ input_files: 'expand-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/expand-2.yml
+++ b/c/busybox-1.22.0/expand-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/fold-1.yml
+++ b/c/busybox-1.22.0/fold-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/fold-2.yml
+++ b/c/busybox-1.22.0/fold-2.yml
@@ -6,3 +6,6 @@ input_files: 'fold-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/head-1.yml
+++ b/c/busybox-1.22.0/head-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/head-2.yml
+++ b/c/busybox-1.22.0/head-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/head-3.yml
+++ b/c/busybox-1.22.0/head-3.yml
@@ -6,3 +6,6 @@ input_files: 'head-3.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/hostid.yml
+++ b/c/busybox-1.22.0/hostid.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/logname-1.yml
+++ b/c/busybox-1.22.0/logname-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/logname-2.yml
+++ b/c/busybox-1.22.0/logname-2.yml
@@ -6,3 +6,6 @@ input_files: 'logname-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/ls-incomplete-1.yml
+++ b/c/busybox-1.22.0/ls-incomplete-1.yml
@@ -6,3 +6,6 @@ input_files: 'ls-incomplete-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/ls-incomplete-2.yml
+++ b/c/busybox-1.22.0/ls-incomplete-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/mkdir-1.yml
+++ b/c/busybox-1.22.0/mkdir-1.yml
@@ -6,3 +6,6 @@ input_files: 'mkdir-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/mkdir-2.yml
+++ b/c/busybox-1.22.0/mkdir-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/mkfifo-incomplete-1.yml
+++ b/c/busybox-1.22.0/mkfifo-incomplete-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/mkfifo-incomplete-2.yml
+++ b/c/busybox-1.22.0/mkfifo-incomplete-2.yml
@@ -6,3 +6,6 @@ input_files: 'mkfifo-incomplete-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/od-1.yml
+++ b/c/busybox-1.22.0/od-1.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/od-2.yml
+++ b/c/busybox-1.22.0/od-2.yml
@@ -6,3 +6,6 @@ input_files: 'od-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/printf-1.yml
+++ b/c/busybox-1.22.0/printf-1.yml
@@ -6,3 +6,6 @@ input_files: 'printf-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/printf-2.yml
+++ b/c/busybox-1.22.0/printf-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/readlink-1.yml
+++ b/c/busybox-1.22.0/readlink-1.yml
@@ -6,3 +6,6 @@ input_files: 'readlink-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/readlink-2.yml
+++ b/c/busybox-1.22.0/readlink-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/realpath-1.yml
+++ b/c/busybox-1.22.0/realpath-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/realpath-2.yml
+++ b/c/busybox-1.22.0/realpath-2.yml
@@ -6,3 +6,6 @@ input_files: 'realpath-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/rm-1.yml
+++ b/c/busybox-1.22.0/rm-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/rm-2.yml
+++ b/c/busybox-1.22.0/rm-2.yml
@@ -6,3 +6,6 @@ input_files: 'rm-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/seq-1.yml
+++ b/c/busybox-1.22.0/seq-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/seq-2.yml
+++ b/c/busybox-1.22.0/seq-2.yml
@@ -6,3 +6,6 @@ input_files: 'seq-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/sleep-1.yml
+++ b/c/busybox-1.22.0/sleep-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/sleep-2.yml
+++ b/c/busybox-1.22.0/sleep-2.yml
@@ -6,3 +6,6 @@ input_files: 'sleep-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/sleep-3.yml
+++ b/c/busybox-1.22.0/sleep-3.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/stty-1.yml
+++ b/c/busybox-1.22.0/stty-1.yml
@@ -6,3 +6,6 @@ input_files: 'stty-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/stty-2.yml
+++ b/c/busybox-1.22.0/stty-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/sync-1.yml
+++ b/c/busybox-1.22.0/sync-1.yml
@@ -6,3 +6,6 @@ input_files: 'sync-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/sync-2.yml
+++ b/c/busybox-1.22.0/sync-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/tac-1.yml
+++ b/c/busybox-1.22.0/tac-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/tac-2.yml
+++ b/c/busybox-1.22.0/tac-2.yml
@@ -6,3 +6,6 @@ input_files: 'tac-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/tee-1.yml
+++ b/c/busybox-1.22.0/tee-1.yml
@@ -6,3 +6,6 @@ input_files: 'tee-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/tee-2.yml
+++ b/c/busybox-1.22.0/tee-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/test-incomplete-1.yml
+++ b/c/busybox-1.22.0/test-incomplete-1.yml
@@ -10,3 +10,4 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/touch-1.yml
+++ b/c/busybox-1.22.0/touch-1.yml
@@ -6,3 +6,6 @@ input_files: 'touch-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/touch-2.yml
+++ b/c/busybox-1.22.0/touch-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uname-1.yml
+++ b/c/busybox-1.22.0/uname-1.yml
@@ -6,3 +6,6 @@ input_files: 'uname-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uname-2.yml
+++ b/c/busybox-1.22.0/uname-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uniq-1.yml
+++ b/c/busybox-1.22.0/uniq-1.yml
@@ -6,3 +6,6 @@ input_files: 'uniq-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uniq-2.yml
+++ b/c/busybox-1.22.0/uniq-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/usleep-1.yml
+++ b/c/busybox-1.22.0/usleep-1.yml
@@ -6,3 +6,6 @@ input_files: 'usleep-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/usleep-2.yml
+++ b/c/busybox-1.22.0/usleep-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uudecode-1.yml
+++ b/c/busybox-1.22.0/uudecode-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/uudecode-2.yml
+++ b/c/busybox-1.22.0/uudecode-2.yml
@@ -6,3 +6,6 @@ input_files: 'uudecode-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/wc-1.yml
+++ b/c/busybox-1.22.0/wc-1.yml
@@ -6,3 +6,6 @@ input_files: 'wc-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/wc-2.yml
+++ b/c/busybox-1.22.0/wc-2.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/who-1.yml
+++ b/c/busybox-1.22.0/who-1.yml
@@ -6,3 +6,6 @@ input_files: 'who-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/who-2.yml
+++ b/c/busybox-1.22.0/who-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/whoami-incomplete-1.yml
+++ b/c/busybox-1.22.0/whoami-incomplete-1.yml
@@ -6,3 +6,6 @@ input_files: 'whoami-incomplete-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/whoami-incomplete-2.yml
+++ b/c/busybox-1.22.0/whoami-incomplete-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/yes-1.yml
+++ b/c/busybox-1.22.0/yes-1.yml
@@ -6,3 +6,6 @@ input_files: 'yes-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/yes-2.yml
+++ b/c/busybox-1.22.0/yes-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
Most of the busybox tasks terminate and do compile if `__VERIFIER_*` definitions are provided,
so add the appropriate coverage-properties to their task definition.