### PR TITLE
Fix path for Java sources

### DIFF
--- a/java/java-ranger-regression/siena_eqchk.yml
+++ b/java/java-ranger-regression/siena_eqchk.yml
@@ -1,7 +1,7 @@
 format_version: "1.0"
 input_files:
   - ../common/
-  - siena/
+  - siena_eqchk/
 properties:
   - property_file: ../properties/assert.prp
     expected_verdict: true


### PR DESCRIPTION
The task definition for `java/java-ranger-regression/siena_eqchk.yml` was wrong. This tries to fix it.