### PR TITLE
Add coverage prp

### DIFF
--- a/c/array-examples/data_structures_set_multi_proc_ground-1.yml
+++ b/c/array-examples/data_structures_set_multi_proc_ground-1.yml
@@ -6,3 +6,7 @@ input_files: 'data_structures_set_multi_proc_ground-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/data_structures_set_multi_proc_ground-2.yml
+++ b/c/array-examples/data_structures_set_multi_proc_ground-2.yml
@@ -6,3 +6,6 @@ input_files: 'data_structures_set_multi_proc_ground-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/data_structures_set_multi_proc_trivial_ground.yml
+++ b/c/array-examples/data_structures_set_multi_proc_trivial_ground.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/relax-1.yml
+++ b/c/array-examples/relax-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/relax-2.yml
+++ b/c/array-examples/relax-2.yml
@@ -6,3 +6,6 @@ input_files: 'relax-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sanfoundry_02_ground.yml
+++ b/c/array-examples/sanfoundry_02_ground.yml
@@ -6,3 +6,6 @@ input_files: 'sanfoundry_02_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sanfoundry_24-2.yml
+++ b/c/array-examples/sanfoundry_24-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sanfoundry_27_ground.yml
+++ b/c/array-examples/sanfoundry_27_ground.yml
@@ -6,3 +6,6 @@ input_files: 'sanfoundry_27_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sanfoundry_43_ground.yml
+++ b/c/array-examples/sanfoundry_43_ground.yml
@@ -6,3 +6,6 @@ input_files: 'sanfoundry_43_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sorting_bubblesort_2_ground.yml
+++ b/c/array-examples/sorting_bubblesort_2_ground.yml
@@ -6,3 +6,7 @@ input_files: 'sorting_bubblesort_2_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/sorting_bubblesort_ground-1.yml
+++ b/c/array-examples/sorting_bubblesort_ground-1.yml
@@ -6,3 +6,6 @@ input_files: 'sorting_bubblesort_ground-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/sorting_bubblesort_ground-2.yml
+++ b/c/array-examples/sorting_bubblesort_ground-2.yml
@@ -6,3 +6,7 @@ input_files: 'sorting_bubblesort_ground-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/sorting_selectionsort_2_ground.yml
+++ b/c/array-examples/sorting_selectionsort_2_ground.yml
@@ -6,3 +6,7 @@ input_files: 'sorting_selectionsort_2_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/sorting_selectionsort_ground-1.yml
+++ b/c/array-examples/sorting_selectionsort_ground-1.yml
@@ -6,3 +6,7 @@ input_files: 'sorting_selectionsort_ground-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/sorting_selectionsort_ground-2.yml
+++ b/c/array-examples/sorting_selectionsort_ground-2.yml
@@ -6,3 +6,6 @@ input_files: 'sorting_selectionsort_ground-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_allDiff2_ground.yml
+++ b/c/array-examples/standard_allDiff2_ground.yml
@@ -6,3 +6,7 @@ input_files: 'standard_allDiff2_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_compareModified_ground.yml
+++ b/c/array-examples/standard_compareModified_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_compareModified_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_compare_ground.yml
+++ b/c/array-examples/standard_compare_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_compare_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_copy1_ground-2.yml
+++ b/c/array-examples/standard_copy1_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy2_ground-1.yml
+++ b/c/array-examples/standard_copy2_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy3_ground-2.yml
+++ b/c/array-examples/standard_copy3_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy4_ground-2.yml
+++ b/c/array-examples/standard_copy4_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy5_ground-2.yml
+++ b/c/array-examples/standard_copy5_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy6_ground-1.yml
+++ b/c/array-examples/standard_copy6_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy7_ground-1.yml
+++ b/c/array-examples/standard_copy7_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy8_ground-2.yml
+++ b/c/array-examples/standard_copy8_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy9_ground-1.yml
+++ b/c/array-examples/standard_copy9_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_maxInArray_ground.yml
+++ b/c/array-examples/standard_maxInArray_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_maxInArray_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_minInArray_ground-1.yml
+++ b/c/array-examples/standard_minInArray_ground-1.yml
@@ -6,3 +6,7 @@ input_files: 'standard_minInArray_ground-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_minInArray_ground-2.yml
+++ b/c/array-examples/standard_minInArray_ground-2.yml
@@ -6,3 +6,6 @@ input_files: 'standard_minInArray_ground-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_palindrome_ground.yml
+++ b/c/array-examples/standard_palindrome_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_palindrome_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_partial_init_ground.yml
+++ b/c/array-examples/standard_partial_init_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_partial_init_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_partition_ground-1.yml
+++ b/c/array-examples/standard_partition_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_partition_ground-2.yml
+++ b/c/array-examples/standard_partition_ground-2.yml
@@ -6,3 +6,6 @@ input_files: 'standard_partition_ground-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_partition_original_ground.yml
+++ b/c/array-examples/standard_partition_original_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_partition_original_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_password_ground.yml
+++ b/c/array-examples/standard_password_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_password_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_reverse_ground.yml
+++ b/c/array-examples/standard_reverse_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_reverse_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_running-1.yml
+++ b/c/array-examples/standard_running-1.yml
@@ -6,3 +6,7 @@ input_files: 'standard_running-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_running-2.yml
+++ b/c/array-examples/standard_running-2.yml
@@ -6,3 +6,6 @@ input_files: 'standard_running-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_strcmp_ground.yml
+++ b/c/array-examples/standard_strcmp_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_strcmp_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_strcpy_ground-2.yml
+++ b/c/array-examples/standard_strcpy_ground-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_strcpy_original-1.yml
+++ b/c/array-examples/standard_strcpy_original-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_vararg_ground.yml
+++ b/c/array-examples/standard_vararg_ground.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-examples/standard_vector_difference_ground.yml
+++ b/c/array-examples/standard_vector_difference_ground.yml
@@ -6,3 +6,6 @@ input_files: 'standard_vector_difference_ground.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-industry-pattern/array_of_struct_ptr_cond_init.yml
+++ b/c/array-industry-pattern/array_of_struct_ptr_cond_init.yml
@@ -6,3 +6,6 @@ input_files: 'array_of_struct_ptr_cond_init.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-industry-pattern/array_of_struct_ptr_monotonic.yml
+++ b/c/array-industry-pattern/array_of_struct_ptr_monotonic.yml
@@ -6,3 +6,6 @@ input_files: 'array_of_struct_ptr_monotonic.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-industry-pattern/array_ptr_single_elem_init-1.yml
+++ b/c/array-industry-pattern/array_ptr_single_elem_init-1.yml
@@ -6,3 +6,6 @@ input_files: 'array_ptr_single_elem_init-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-industry-pattern/array_ptr_single_elem_init-2.yml
+++ b/c/array-industry-pattern/array_ptr_single_elem_init-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-industry-pattern/array_single_elem_init.yml
+++ b/c/array-industry-pattern/array_single_elem_init.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-lopstr16/base_case.yml
+++ b/c/array-lopstr16/base_case.yml
@@ -5,3 +5,6 @@ input_files: 'base_case.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-lopstr16/break-1.yml
+++ b/c/array-lopstr16/break-1.yml
@@ -5,3 +5,6 @@ input_files: 'break-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-lopstr16/flag_loopdep_simple.yml
+++ b/c/array-lopstr16/flag_loopdep_simple.yml
@@ -5,3 +5,6 @@ input_files: 'flag_loopdep_simple.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-lopstr16/motivex.yml
+++ b/c/array-lopstr16/motivex.yml
@@ -5,3 +5,6 @@ input_files: 'motivex.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-lopstr16/single_elem_safe.yml
+++ b/c/array-lopstr16/single_elem_safe.yml
@@ -5,3 +5,6 @@ input_files: 'single_elem_safe.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-lopstr16/sum_multi_array.yml
+++ b/c/array-lopstr16/sum_multi_array.yml
@@ -5,3 +5,6 @@ input_files: 'sum_multi_array.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety-realloc/array-realloc-1.yml
+++ b/c/array-memsafety-realloc/array-realloc-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety-realloc/array-realloc-2.yml
+++ b/c/array-memsafety-realloc/array-realloc-2.yml
@@ -6,3 +6,6 @@ input_files: 'array-realloc-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/add_last-alloca-1.yml
+++ b/c/array-memsafety/add_last-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/add_last_unsafe.yml
+++ b/c/array-memsafety/add_last_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/array01-alloca-2.yml
+++ b/c/array-memsafety/array01-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/array02-alloca-2.yml
+++ b/c/array-memsafety/array02-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/array03-alloca-2.yml
+++ b/c/array-memsafety/array03-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/bubblesort-alloca-2.yml
+++ b/c/array-memsafety/bubblesort-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/count_down-alloca-1.yml
+++ b/c/array-memsafety/count_down-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/count_down_unsafe.yml
+++ b/c/array-memsafety/count_down_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrcat-alloca-2.yml
+++ b/c/array-memsafety/cstrcat-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrchr-alloca-2.yml
+++ b/c/array-memsafety/cstrchr-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrchr_unsafe.yml
+++ b/c/array-memsafety/cstrchr_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrcmp-alloca-2.yml
+++ b/c/array-memsafety/cstrcmp-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrcpy-alloca-1.yml
+++ b/c/array-memsafety/cstrcpy-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrcspn-alloca-1.yml
+++ b/c/array-memsafety/cstrcspn-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrlen-alloca-2.yml
+++ b/c/array-memsafety/cstrlen-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrlen_unsafe.yml
+++ b/c/array-memsafety/cstrlen_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrncat-alloca-2.yml
+++ b/c/array-memsafety/cstrncat-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrncmp-alloca-1.yml
+++ b/c/array-memsafety/cstrncmp-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrncpy-alloca-2.yml
+++ b/c/array-memsafety/cstrncpy-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrpbrk-alloca-2.yml
+++ b/c/array-memsafety/cstrpbrk-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrpbrk_unsafe.yml
+++ b/c/array-memsafety/cstrpbrk_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/cstrspn-alloca-1.yml
+++ b/c/array-memsafety/cstrspn-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/diff-alloca-2.yml
+++ b/c/array-memsafety/diff-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/insertionsort-alloca-1.yml
+++ b/c/array-memsafety/insertionsort-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/java_BubbleSort-alloca-1.yml
+++ b/c/array-memsafety/java_BubbleSort-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/knapsack_alloca_unsafe.yml
+++ b/c/array-memsafety/knapsack_alloca_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/lis-alloca-1.yml
+++ b/c/array-memsafety/lis-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/lis_unsafe.yml
+++ b/c/array-memsafety/lis_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/mult_array-alloca-1.yml
+++ b/c/array-memsafety/mult_array-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/mult_array_unsafe.yml
+++ b/c/array-memsafety/mult_array_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cbzero-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cbzero-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cmemchr-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cmemchr-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cmemrchr-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cmemrchr-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cmemrchr-alloca-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cmemset-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cmemset-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstpcpy-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstpcpy-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstpncpy-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstpncpy-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrcat-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrcat-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrcmp-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstrcmp-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrcpy-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrcpy-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrcspn-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrcspn-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrlcpy-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstrlcpy-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrlen-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstrlen-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrncat-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrncat-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrncmp-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrncmp-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrncpy-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrncpy-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrnlen-alloca-1.yml
+++ b/c/array-memsafety/openbsd_cstrnlen-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrpbrk-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrpbrk-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrspn-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrspn-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/openbsd_cstrstr-alloca-2.yml
+++ b/c/array-memsafety/openbsd_cstrstr-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/rec_strlen-alloca-1.yml
+++ b/c/array-memsafety/rec_strlen-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/reverse_array_alloca_unsafe.yml
+++ b/c/array-memsafety/reverse_array_alloca_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/reverse_array_unsafe.yml
+++ b/c/array-memsafety/reverse_array_unsafe.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/selectionsort-alloca-1.yml
+++ b/c/array-memsafety/selectionsort-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/stroeder1-alloca-1.yml
+++ b/c/array-memsafety/stroeder1-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/stroeder2-alloca-1.yml
+++ b/c/array-memsafety/stroeder2-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/strreplace-alloca-2.yml
+++ b/c/array-memsafety/strreplace-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/subseq-alloca-2.yml
+++ b/c/array-memsafety/subseq-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-memsafety/substring-alloca-2.yml
+++ b/c/array-memsafety/substring-alloca-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/array-programs/copysome1-2.yml
+++ b/c/array-programs/copysome1-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-programs/copysome2-2.yml
+++ b/c/array-programs/copysome2-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/bitvector/byte_add-1.yml
+++ b/c/bitvector/byte_add-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/bitvector/byte_add-2.yml
+++ b/c/bitvector/byte_add-2.yml
@@ -6,3 +6,6 @@ input_files: 'byte_add-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/bitvector/byte_add_1-2.yml
+++ b/c/bitvector/byte_add_1-2.yml
@@ -6,3 +6,6 @@ input_files: 'byte_add_1-2.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/bitvector/byte_add_2-1.yml
+++ b/c/bitvector/byte_add_2-1.yml
@@ -6,3 +6,6 @@ input_files: 'byte_add_2-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/bitvector/modulus-1.yml
+++ b/c/bitvector/modulus-1.yml
@@ -6,3 +6,6 @@ input_files: 'modulus-1.i'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/basename-2.yml
+++ b/c/busybox-1.22.0/basename-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/cut-2.yml
+++ b/c/busybox-1.22.0/cut-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/date-1.yml
+++ b/c/busybox-1.22.0/date-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/expand-2.yml
+++ b/c/busybox-1.22.0/expand-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/ls-incomplete-2.yml
+++ b/c/busybox-1.22.0/ls-incomplete-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/od-1.yml
+++ b/c/busybox-1.22.0/od-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/printf-2.yml
+++ b/c/busybox-1.22.0/printf-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/stty-2.yml
+++ b/c/busybox-1.22.0/stty-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/touch-2.yml
+++ b/c/busybox-1.22.0/touch-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/wc-2.yml
+++ b/c/busybox-1.22.0/wc-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_4.yml
+++ b/c/floats-cdfpl/newton_1_4.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_5.yml
+++ b/c/floats-cdfpl/newton_1_5.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_6.yml
+++ b/c/floats-cdfpl/newton_1_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_7.yml
+++ b/c/floats-cdfpl/newton_1_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_8.yml
+++ b/c/floats-cdfpl/newton_1_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_6.yml
+++ b/c/floats-cdfpl/newton_2_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_7.yml
+++ b/c/floats-cdfpl/newton_2_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_8.yml
+++ b/c/floats-cdfpl/newton_2_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_6.yml
+++ b/c/floats-cdfpl/newton_3_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_7.yml
+++ b/c/floats-cdfpl/newton_3_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_8.yml
+++ b/c/floats-cdfpl/newton_3_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_1.yml
+++ b/c/floats-cdfpl/sine_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_2.yml
+++ b/c/floats-cdfpl/sine_2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_3.yml
+++ b/c/floats-cdfpl/sine_3.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_1.yml
+++ b/c/floats-cdfpl/square_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_2.yml
+++ b/c/floats-cdfpl/square_2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_3.yml
+++ b/c/floats-cdfpl/square_3.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-01-1.yml
+++ b/c/forester-heap/dll-01-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-01-2.yml
+++ b/c/forester-heap/dll-01-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-circular-1.yml
+++ b/c/forester-heap/dll-circular-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-circular-2.yml
+++ b/c/forester-heap/dll-circular-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-optional-1.yml
+++ b/c/forester-heap/dll-optional-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-optional-2.yml
+++ b/c/forester-heap/dll-optional-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-queue-1.yml
+++ b/c/forester-heap/dll-queue-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-queue-2.yml
+++ b/c/forester-heap/dll-queue-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-rb-cnstr_1-1.yml
+++ b/c/forester-heap/dll-rb-cnstr_1-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-rb-cnstr_1-2.yml
+++ b/c/forester-heap/dll-rb-cnstr_1-2.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-rb-sentinel-1.yml
+++ b/c/forester-heap/dll-rb-sentinel-1.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-rb-sentinel-2.yml
+++ b/c/forester-heap/dll-rb-sentinel-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-reverse.yml
+++ b/c/forester-heap/dll-reverse.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-simple-white-blue-1.yml
+++ b/c/forester-heap/dll-simple-white-blue-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-simple-white-blue-2.yml
+++ b/c/forester-heap/dll-simple-white-blue-2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-sorted-1.yml
+++ b/c/forester-heap/dll-sorted-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/dll-sorted-2.yml
+++ b/c/forester-heap/dll-sorted-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-token-1.yml
+++ b/c/forester-heap/dll-token-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/dll-token-2.yml
+++ b/c/forester-heap/dll-token-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-01-1.yml
+++ b/c/forester-heap/sll-01-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-01-2.yml
+++ b/c/forester-heap/sll-01-2.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-buckets-1.yml
+++ b/c/forester-heap/sll-buckets-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-buckets-2.yml
+++ b/c/forester-heap/sll-buckets-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-circular-1.yml
+++ b/c/forester-heap/sll-circular-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-circular-2.yml
+++ b/c/forester-heap/sll-circular-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-optional-1.yml
+++ b/c/forester-heap/sll-optional-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-optional-2.yml
+++ b/c/forester-heap/sll-optional-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-queue-1.yml
+++ b/c/forester-heap/sll-queue-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-queue-2.yml
+++ b/c/forester-heap/sll-queue-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-rb-cnstr_1-1.yml
+++ b/c/forester-heap/sll-rb-cnstr_1-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-rb-cnstr_1-2.yml
+++ b/c/forester-heap/sll-rb-cnstr_1-2.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-rb-sentinel-1.yml
+++ b/c/forester-heap/sll-rb-sentinel-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-rb-sentinel-2.yml
+++ b/c/forester-heap/sll-rb-sentinel-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-reverse_simple.yml
+++ b/c/forester-heap/sll-reverse_simple.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-simple-white-blue-1.yml
+++ b/c/forester-heap/sll-simple-white-blue-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-simple-white-blue-2.yml
+++ b/c/forester-heap/sll-simple-white-blue-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-sorted-1.yml
+++ b/c/forester-heap/sll-sorted-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-sorted-2.yml
+++ b/c/forester-heap/sll-sorted-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/forester-heap/sll-token-1.yml
+++ b/c/forester-heap/sll-token-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/forester-heap/sll-token-2.yml
+++ b/c/forester-heap/sll-token-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/calendar.yml
+++ b/c/heap-data/calendar.yml
@@ -6,3 +6,6 @@ input_files: 'calendar.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/cart.yml
+++ b/c/heap-data/cart.yml
@@ -6,3 +6,6 @@ input_files: 'cart.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/hash_fun.yml
+++ b/c/heap-data/hash_fun.yml
@@ -6,3 +6,6 @@ input_files: 'hash_fun.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/min_max.yml
+++ b/c/heap-data/min_max.yml
@@ -6,3 +6,6 @@ input_files: 'min_max.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/process_queue.yml
+++ b/c/heap-data/process_queue.yml
@@ -6,3 +6,6 @@ input_files: 'process_queue.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/quick_sort_split.yml
+++ b/c/heap-data/quick_sort_split.yml
@@ -6,3 +6,6 @@ input_files: 'quick_sort_split.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/running_example.yml
+++ b/c/heap-data/running_example.yml
@@ -6,3 +6,6 @@ input_files: 'running_example.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/shared_mem1.yml
+++ b/c/heap-data/shared_mem1.yml
@@ -6,3 +6,6 @@ input_files: 'shared_mem1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-data/shared_mem2.yml
+++ b/c/heap-data/shared_mem2.yml
@@ -6,3 +6,6 @@ input_files: 'shared_mem2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/bubble_sort_linux-1.yml
+++ b/c/heap-manipulation/bubble_sort_linux-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/bubble_sort_linux-2.yml
+++ b/c/heap-manipulation/bubble_sort_linux-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/heap-manipulation/dancing.yml
+++ b/c/heap-manipulation/dancing.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/dll_of_dll-1.yml
+++ b/c/heap-manipulation/dll_of_dll-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/dll_of_dll-2.yml
+++ b/c/heap-manipulation/dll_of_dll-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/heap-manipulation/merge_sort-1.yml
+++ b/c/heap-manipulation/merge_sort-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/heap-manipulation/merge_sort-2.yml
+++ b/c/heap-manipulation/merge_sort-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/sll_to_dll_rev-1.yml
+++ b/c/heap-manipulation/sll_to_dll_rev-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/heap-manipulation/sll_to_dll_rev-2.yml
+++ b/c/heap-manipulation/sll_to_dll_rev-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/tree-1.yml
+++ b/c/heap-manipulation/tree-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/tree-2.yml
+++ b/c/heap-manipulation/tree-2.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/heap-manipulation/tree-3.yml
+++ b/c/heap-manipulation/tree-3.yml
@@ -6,3 +6,6 @@ input_files: 'tree-3.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/heap-manipulation/tree-4.yml
+++ b/c/heap-manipulation/tree-4.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: 'linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,7 @@ input_files: '32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--st
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--tuners--tda18271.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--sja1000--sja1000.ko-entry_point.cil.out.yml
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--sja1000--sja1000.ko-entry_point.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--container.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_mai
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--hwmon--gpio-fan.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-backli
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-defaul
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--leds--ledtrig-gpio.k
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.k
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuners--mc44s803.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuners--mc44s803.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--common--tuner
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--dvb_dummy_fe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--dvb_dummy_fe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tua6100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontends--tua6100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--frontend
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--rc--keymaps--
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bu
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_sc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--sungem_phy.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topst
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--power--wm831x_power.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--regulator--userspace
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uwb--i1480--i1480-es
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--ili9320.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--ili9320.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--video--backlight--il
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds240
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds242
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds243
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds243
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds276
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds278
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds278
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_smem.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-cl
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--dell-led.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backligh
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--common--tuners-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--m
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--frontends-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_9
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ld
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_oobtest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_oobtest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_subpagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_subpagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--topstar
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-eb
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--test_power.ko-l
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--userspace-c
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--cytherm.ko-
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibra
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--storage--ums-free
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--l4f0
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--lms2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--ltv3
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo24m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo24m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--tdo2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--masters--ds2490.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -6,3 +6,6 @@ input_files: '43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
+++ b/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
@@ -6,3 +6,7 @@ input_files: 'main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
+++ b/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-memsafety/memleaks_test1-1.yml
+++ b/c/ldv-memsafety/memleaks_test1-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test1-2.yml
+++ b/c/ldv-memsafety/memleaks_test1-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test1-3.yml
+++ b/c/ldv-memsafety/memleaks_test1-3.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test10-1.yml
+++ b/c/ldv-memsafety/memleaks_test10-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test10-2.yml
+++ b/c/ldv-memsafety/memleaks_test10-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test11.yml
+++ b/c/ldv-memsafety/memleaks_test11.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test11_1.yml
+++ b/c/ldv-memsafety/memleaks_test11_1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test11_2.yml
+++ b/c/ldv-memsafety/memleaks_test11_2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test12-1.yml
+++ b/c/ldv-memsafety/memleaks_test12-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test12-2.yml
+++ b/c/ldv-memsafety/memleaks_test12-2.yml
@@ -6,3 +6,6 @@ input_files: 'memleaks_test12-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test13.yml
+++ b/c/ldv-memsafety/memleaks_test13.yml
@@ -6,3 +6,6 @@ input_files: 'memleaks_test13.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test13_1.yml
+++ b/c/ldv-memsafety/memleaks_test13_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test13_2.yml
+++ b/c/ldv-memsafety/memleaks_test13_2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test14.yml
+++ b/c/ldv-memsafety/memleaks_test14.yml
@@ -6,3 +6,6 @@ input_files: 'memleaks_test14.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test14_1.yml
+++ b/c/ldv-memsafety/memleaks_test14_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test14_2.yml
+++ b/c/ldv-memsafety/memleaks_test14_2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test14_3.yml
+++ b/c/ldv-memsafety/memleaks_test14_3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test15-1.yml
+++ b/c/ldv-memsafety/memleaks_test15-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test15-2.yml
+++ b/c/ldv-memsafety/memleaks_test15-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test16.yml
+++ b/c/ldv-memsafety/memleaks_test16.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test16_1.yml
+++ b/c/ldv-memsafety/memleaks_test16_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test16_2.yml
+++ b/c/ldv-memsafety/memleaks_test16_2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test17_1-1.yml
+++ b/c/ldv-memsafety/memleaks_test17_1-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test17_1-2.yml
+++ b/c/ldv-memsafety/memleaks_test17_1-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test17_2-1.yml
+++ b/c/ldv-memsafety/memleaks_test17_2-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test17_2-2.yml
+++ b/c/ldv-memsafety/memleaks_test17_2-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test17_3.yml
+++ b/c/ldv-memsafety/memleaks_test17_3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test18.yml
+++ b/c/ldv-memsafety/memleaks_test18.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test18_1.yml
+++ b/c/ldv-memsafety/memleaks_test18_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test18_2.yml
+++ b/c/ldv-memsafety/memleaks_test18_2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test18_3.yml
+++ b/c/ldv-memsafety/memleaks_test18_3.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test19-1.yml
+++ b/c/ldv-memsafety/memleaks_test19-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test19-2.yml
+++ b/c/ldv-memsafety/memleaks_test19-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test20-1.yml
+++ b/c/ldv-memsafety/memleaks_test20-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test20-2.yml
+++ b/c/ldv-memsafety/memleaks_test20-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test21-1.yml
+++ b/c/ldv-memsafety/memleaks_test21-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test21-2.yml
+++ b/c/ldv-memsafety/memleaks_test21-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_1-1.yml
+++ b/c/ldv-memsafety/memleaks_test22_1-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_1-2.yml
+++ b/c/ldv-memsafety/memleaks_test22_1-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_2-1.yml
+++ b/c/ldv-memsafety/memleaks_test22_2-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_2-2.yml
+++ b/c/ldv-memsafety/memleaks_test22_2-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_3-1.yml
+++ b/c/ldv-memsafety/memleaks_test22_3-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_3-2.yml
+++ b/c/ldv-memsafety/memleaks_test22_3-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_4.yml
+++ b/c/ldv-memsafety/memleaks_test22_4.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test22_5.yml
+++ b/c/ldv-memsafety/memleaks_test22_5.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test23_1.yml
+++ b/c/ldv-memsafety/memleaks_test23_1.yml
@@ -6,3 +6,6 @@ input_files: 'memleaks_test23_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test23_2.yml
+++ b/c/ldv-memsafety/memleaks_test23_2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test23_3.yml
+++ b/c/ldv-memsafety/memleaks_test23_3.yml
@@ -6,3 +6,6 @@ input_files: 'memleaks_test23_3.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test23_4.yml
+++ b/c/ldv-memsafety/memleaks_test23_4.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test3-1.yml
+++ b/c/ldv-memsafety/memleaks_test3-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test3-2.yml
+++ b/c/ldv-memsafety/memleaks_test3-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test4-1.yml
+++ b/c/ldv-memsafety/memleaks_test4-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test4-2.yml
+++ b/c/ldv-memsafety/memleaks_test4-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test5.yml
+++ b/c/ldv-memsafety/memleaks_test5.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test5_1.yml
+++ b/c/ldv-memsafety/memleaks_test5_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test5_2.yml
+++ b/c/ldv-memsafety/memleaks_test5_2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test6.yml
+++ b/c/ldv-memsafety/memleaks_test6.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test6_1.yml
+++ b/c/ldv-memsafety/memleaks_test6_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test6_2.yml
+++ b/c/ldv-memsafety/memleaks_test6_2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test6_3.yml
+++ b/c/ldv-memsafety/memleaks_test6_3.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test7-1.yml
+++ b/c/ldv-memsafety/memleaks_test7-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test7-2.yml
+++ b/c/ldv-memsafety/memleaks_test7-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test8.yml
+++ b/c/ldv-memsafety/memleaks_test8.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test8_1.yml
+++ b/c/ldv-memsafety/memleaks_test8_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test8_2.yml
+++ b/c/ldv-memsafety/memleaks_test8_2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test9.yml
+++ b/c/ldv-memsafety/memleaks_test9.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test9_1.yml
+++ b/c/ldv-memsafety/memleaks_test9_1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-memsafety/memleaks_test9_2.yml
+++ b/c/ldv-memsafety/memleaks_test9_2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/fo_test.yml
+++ b/c/ldv-regression/fo_test.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/fo_test.yml
+++ b/c/ldv-regression/fo_test.yml
@@ -13,3 +13,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule57_ebda_blast.c_1.yml
+++ b/c/ldv-regression/rule57_ebda_blast.c_1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/rule57_ebda_blast.yml
+++ b/c/ldv-regression/rule57_ebda_blast.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule57_ebda_blast.yml
+++ b/c/ldv-regression/rule57_ebda_blast.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule60_list2.c_1.yml
+++ b/c/ldv-regression/rule60_list2.c_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule60_list2.c_1.yml
+++ b/c/ldv-regression/rule60_list2.c_1.yml
@@ -13,3 +13,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_add-1.yml
+++ b/c/ldv-sets/test_add-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_add-1.yml
+++ b/c/ldv-sets/test_add-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_add-2.yml
+++ b/c/ldv-sets/test_add-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-sets/test_mutex.yml
+++ b/c/ldv-sets/test_mutex.yml
@@ -6,3 +6,6 @@ input_files: 'test_mutex.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-sets/test_mutex_double_lock.yml
+++ b/c/ldv-sets/test_mutex_double_lock.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_double_lock.yml
+++ b/c/ldv-sets/test_mutex_double_lock.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_double_unlock.yml
+++ b/c/ldv-sets/test_mutex_double_unlock.yml
@@ -6,3 +6,7 @@ input_files: 'test_mutex_double_unlock.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_double_unlock.yml
+++ b/c/ldv-sets/test_mutex_double_unlock.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unbounded-1.yml
+++ b/c/ldv-sets/test_mutex_unbounded-1.yml
@@ -6,3 +6,6 @@ input_files: 'test_mutex_unbounded-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-sets/test_mutex_unbounded-2.yml
+++ b/c/ldv-sets/test_mutex_unbounded-2.yml
@@ -6,3 +6,7 @@ input_files: 'test_mutex_unbounded-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unbounded-2.yml
+++ b/c/ldv-sets/test_mutex_unbounded-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unlock_at_exit.yml
+++ b/c/ldv-sets/test_mutex_unlock_at_exit.yml
@@ -6,3 +6,7 @@ input_files: 'test_mutex_unlock_at_exit.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unlock_at_exit.yml
+++ b/c/ldv-sets/test_mutex_unlock_at_exit.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext-properties/960521-1_1-1.yml
+++ b/c/list-ext-properties/960521-1_1-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/960521-1_1-2.yml
+++ b/c/list-ext-properties/960521-1_1-2.yml
@@ -6,3 +6,6 @@ input_files: '960521-1_1-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/960521-1_1-3.yml
+++ b/c/list-ext-properties/960521-1_1-3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/list-ext.yml
+++ b/c/list-ext-properties/list-ext.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext-properties/list-ext_1.yml
+++ b/c/list-ext-properties/list-ext_1.yml
@@ -6,3 +6,6 @@ input_files: 'list-ext_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/list-ext_flag.yml
+++ b/c/list-ext-properties/list-ext_flag.yml
@@ -9,3 +9,7 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext-properties/list-ext_flag_1.yml
+++ b/c/list-ext-properties/list-ext_flag_1.yml
@@ -6,3 +6,6 @@ input_files: 'list-ext_flag_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/simple-ext.yml
+++ b/c/list-ext-properties/simple-ext.yml
@@ -10,3 +10,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext-properties/simple-ext_1.yml
+++ b/c/list-ext-properties/simple-ext_1.yml
@@ -6,3 +6,6 @@ input_files: 'simple-ext_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0158_1-1.yml
+++ b/c/list-ext-properties/test-0158_1-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0158_1-2.yml
+++ b/c/list-ext-properties/test-0158_1-2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0158_1-3.yml
+++ b/c/list-ext-properties/test-0158_1-3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0214_1.yml
+++ b/c/list-ext-properties/test-0214_1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0214_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0217_1.yml
+++ b/c/list-ext-properties/test-0217_1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0217_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0232_1-1.yml
+++ b/c/list-ext-properties/test-0232_1-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0232_1-2.yml
+++ b/c/list-ext-properties/test-0232_1-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0504_1.yml
+++ b/c/list-ext-properties/test-0504_1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0504_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext-properties/test-0513_1.yml
+++ b/c/list-ext-properties/test-0513_1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0513_1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl-1.yml
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl-1.yml
@@ -6,3 +6,7 @@ input_files: 'simple_and_skiplist_2lvl-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext2-properties/simple_and_skiplist_2lvl-2.yml
+++ b/c/list-ext2-properties/simple_and_skiplist_2lvl-2.yml
@@ -6,3 +6,6 @@ input_files: 'simple_and_skiplist_2lvl-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext2-properties/simple_search_value-1.yml
+++ b/c/list-ext2-properties/simple_search_value-1.yml
@@ -6,3 +6,6 @@ input_files: 'simple_search_value-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext2-properties/simple_search_value-2.yml
+++ b/c/list-ext2-properties/simple_search_value-2.yml
@@ -6,3 +6,7 @@ input_files: 'simple_search_value-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext3-properties/dll_nondet_free_order-1.yml
+++ b/c/list-ext3-properties/dll_nondet_free_order-1.yml
@@ -6,3 +6,6 @@ input_files: 'dll_nondet_free_order-1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext3-properties/dll_nondet_free_order-2.yml
+++ b/c/list-ext3-properties/dll_nondet_free_order-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext3-properties/dll_nullified-1.yml
+++ b/c/list-ext3-properties/dll_nullified-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext3-properties/sll_length_check-1.yml
+++ b/c/list-ext3-properties/sll_length_check-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext3-properties/sll_length_check-2.yml
+++ b/c/list-ext3-properties/sll_length_check-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext3-properties/sll_nondet_insert-1.yml
+++ b/c/list-ext3-properties/sll_nondet_insert-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-ext3-properties/sll_nondet_insert-2.yml
+++ b/c/list-ext3-properties/sll_nondet_insert-2.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext3-properties/sll_of_sll_nondet_append-1.yml
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-ext3-properties/sll_of_sll_nondet_append-2.yml
+++ b/c/list-ext3-properties/sll_of_sll_nondet_append-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/alternating_list-1.yml
+++ b/c/list-properties/alternating_list-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-properties/alternating_list-2.yml
+++ b/c/list-properties/alternating_list-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/list-1.yml
+++ b/c/list-properties/list-1.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-properties/list-2.yml
+++ b/c/list-properties/list-2.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/list_flag-1.yml
+++ b/c/list-properties/list_flag-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/list_flag-2.yml
+++ b/c/list-properties/list_flag-2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-properties/simple-1.yml
+++ b/c/list-properties/simple-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/simple-2.yml
+++ b/c/list-properties/simple-2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-properties/simple_built_from_end.yml
+++ b/c/list-properties/simple_built_from_end.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/list-properties/splice-1.yml
+++ b/c/list-properties/splice-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/list-properties/splice-2.yml
+++ b/c/list-properties/splice-2.yml
@@ -9,3 +9,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/loop-acceleration/array3.yml
+++ b/c/loop-acceleration/array3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/loop-acceleration/array_3-2.yml
+++ b/c/loop-acceleration/array_3-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loop-invgen/id_trans.yml
+++ b/c/loop-invgen/id_trans.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loop-lit/mcmillan2006.yml
+++ b/c/loop-lit/mcmillan2006.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/loops/bubble_sort-2.yml
+++ b/c/loops/bubble_sort-2.yml
@@ -6,3 +6,7 @@ input_files: 'bubble_sort-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/n.c24.yml
+++ b/c/loops/n.c24.yml
@@ -6,3 +6,7 @@ input_files: 'n.c24.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/s3.yml
+++ b/c/loops/s3.yml
@@ -6,3 +6,7 @@ input_files: 's3.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/string-2.yml
+++ b/c/loops/string-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01-1.yml
+++ b/c/loops/sum01-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01_bug02.yml
+++ b/c/loops/sum01_bug02.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01_bug02_sum01_bug02_base.case.yml
+++ b/c/loops/sum01_bug02_sum01_bug02_base.case.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum03-1.yml
+++ b/c/loops/sum03-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/veris.c_OpenSER_cases1_stripFullBoth_arr.yml
+++ b/c/loops/veris.c_OpenSER_cases1_stripFullBoth_arr.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/loops/vogal-2.yml
+++ b/c/loops/vogal-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/memory-alloca/c.03-alloca-2.yml
+++ b/c/memory-alloca/c.03-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'c.03-alloca-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext/dll_extends_pointer.yml
+++ b/c/memsafety-ext/dll_extends_pointer.yml
@@ -6,3 +6,6 @@ input_files: 'dll_extends_pointer.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext/skiplist_2lvl.yml
+++ b/c/memsafety-ext/skiplist_2lvl.yml
@@ -6,3 +6,6 @@ input_files: 'skiplist_2lvl.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext/skiplist_3lvl.yml
+++ b/c/memsafety-ext/skiplist_3lvl.yml
@@ -6,3 +6,6 @@ input_files: 'skiplist_3lvl.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext/tree_of_cslls.yml
+++ b/c/memsafety-ext/tree_of_cslls.yml
@@ -6,3 +6,6 @@ input_files: 'tree_of_cslls.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/complex_data_creation_test01-1.yml
+++ b/c/memsafety-ext2/complex_data_creation_test01-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/complex_data_creation_test01-2.yml
+++ b/c/memsafety-ext2/complex_data_creation_test01-2.yml
@@ -6,3 +6,6 @@ input_files: 'complex_data_creation_test01-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/complex_data_creation_test02-1.yml
+++ b/c/memsafety-ext2/complex_data_creation_test02-1.yml
@@ -6,3 +6,6 @@ input_files: 'complex_data_creation_test02-1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/complex_data_creation_test02-2.yml
+++ b/c/memsafety-ext2/complex_data_creation_test02-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/length_test03-1.yml
+++ b/c/memsafety-ext2/length_test03-1.yml
@@ -6,3 +6,6 @@ input_files: 'length_test03-1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/length_test03-2.yml
+++ b/c/memsafety-ext2/length_test03-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/optional_data_creation_test04-1.yml
+++ b/c/memsafety-ext2/optional_data_creation_test04-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/optional_data_creation_test04-2.yml
+++ b/c/memsafety-ext2/optional_data_creation_test04-2.yml
@@ -6,3 +6,6 @@ input_files: 'optional_data_creation_test04-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/split_list_test05-1.yml
+++ b/c/memsafety-ext2/split_list_test05-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety-ext2/split_list_test05-2.yml
+++ b/c/memsafety-ext2/split_list_test05-2.yml
@@ -6,3 +6,6 @@ input_files: 'split_list_test05-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/lockfree-3.0.yml
+++ b/c/memsafety/lockfree-3.0.yml
@@ -6,3 +6,6 @@ input_files: 'lockfree-3.0.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/lockfree-3.1.yml
+++ b/c/memsafety/lockfree-3.1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/lockfree-3.2.yml
+++ b/c/memsafety/lockfree-3.2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/lockfree-3.3.yml
+++ b/c/memsafety/lockfree-3.3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0102-1.yml
+++ b/c/memsafety/test-0102-1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0102-1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0102-2.yml
+++ b/c/memsafety/test-0102-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0134.yml
+++ b/c/memsafety/test-0134.yml
@@ -6,3 +6,6 @@ input_files: 'test-0134.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0137.yml
+++ b/c/memsafety/test-0137.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0219.yml
+++ b/c/memsafety/test-0219.yml
@@ -6,3 +6,6 @@ input_files: 'test-0219.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0220.yml
+++ b/c/memsafety/test-0220.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0232-1.yml
+++ b/c/memsafety/test-0232-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0232-2.yml
+++ b/c/memsafety/test-0232-2.yml
@@ -6,3 +6,6 @@ input_files: 'test-0232-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0232-3.yml
+++ b/c/memsafety/test-0232-3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-free
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0234-1.yml
+++ b/c/memsafety/test-0234-1.yml
@@ -6,3 +6,6 @@ input_files: 'test-0234-1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0234-2.yml
+++ b/c/memsafety/test-0234-2.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0235-1.yml
+++ b/c/memsafety/test-0235-1.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-memtrack
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0235-2.yml
+++ b/c/memsafety/test-0235-2.yml
@@ -6,3 +6,6 @@ input_files: 'test-0235-2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0235-3.yml
+++ b/c/memsafety/test-0235-3.yml
@@ -7,3 +7,6 @@ properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
     subproperty: valid-deref
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0236.yml
+++ b/c/memsafety/test-0236.yml
@@ -6,3 +6,6 @@ input_files: 'test-0236.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0237.yml
+++ b/c/memsafety/test-0237.yml
@@ -6,3 +6,6 @@ input_files: 'test-0237.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0504.yml
+++ b/c/memsafety/test-0504.yml
@@ -6,3 +6,6 @@ input_files: 'test-0504.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0513.yml
+++ b/c/memsafety/test-0513.yml
@@ -6,3 +6,6 @@ input_files: 'test-0513.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/memsafety/test-0521.yml
+++ b/c/memsafety/test-0521.yml
@@ -6,3 +6,6 @@ input_files: 'test-0521.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/reducercommutativity/rangesum.yml
+++ b/c/reducercommutativity/rangesum.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum05.yml
+++ b/c/reducercommutativity/rangesum05.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum10.yml
+++ b/c/reducercommutativity/rangesum10.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum20.yml
+++ b/c/reducercommutativity/rangesum20.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum40.yml
+++ b/c/reducercommutativity/rangesum40.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum60.yml
+++ b/c/reducercommutativity/rangesum60.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_dekker.yml
+++ b/c/seq-pthread/cs_dekker.yml
@@ -6,3 +6,6 @@ input_files: 'cs_dekker.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_fib-1.yml
+++ b/c/seq-pthread/cs_fib-1.yml
@@ -6,3 +6,6 @@ input_files: 'cs_fib-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_fib-2.yml
+++ b/c/seq-pthread/cs_fib-2.yml
@@ -6,3 +6,7 @@ input_files: 'cs_fib-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_fib_longer-1.yml
+++ b/c/seq-pthread/cs_fib_longer-1.yml
@@ -6,3 +6,6 @@ input_files: 'cs_fib_longer-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_fib_longer-2.yml
+++ b/c/seq-pthread/cs_fib_longer-2.yml
@@ -6,3 +6,7 @@ input_files: 'cs_fib_longer-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_lamport.yml
+++ b/c/seq-pthread/cs_lamport.yml
@@ -6,3 +6,6 @@ input_files: 'cs_lamport.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_lazy.yml
+++ b/c/seq-pthread/cs_lazy.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_peterson.yml
+++ b/c/seq-pthread/cs_peterson.yml
@@ -6,3 +6,6 @@ input_files: 'cs_peterson.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_queue-1.yml
+++ b/c/seq-pthread/cs_queue-1.yml
@@ -6,3 +6,6 @@ input_files: 'cs_queue-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_queue-2.yml
+++ b/c/seq-pthread/cs_queue-2.yml
@@ -6,3 +6,7 @@ input_files: 'cs_queue-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_read_write_lock-1.yml
+++ b/c/seq-pthread/cs_read_write_lock-1.yml
@@ -6,3 +6,6 @@ input_files: 'cs_read_write_lock-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_read_write_lock-2.yml
+++ b/c/seq-pthread/cs_read_write_lock-2.yml
@@ -6,3 +6,7 @@ input_files: 'cs_read_write_lock-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_stack-1.yml
+++ b/c/seq-pthread/cs_stack-1.yml
@@ -6,3 +6,6 @@ input_files: 'cs_stack-1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_stack-2.yml
+++ b/c/seq-pthread/cs_stack-2.yml
@@ -6,3 +6,7 @@ input_files: 'cs_stack-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_stateful-1.yml
+++ b/c/seq-pthread/cs_stateful-1.yml
@@ -8,3 +8,7 @@ properties:
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/seq-pthread/cs_stateful-2.yml
+++ b/c/seq-pthread/cs_stateful-2.yml
@@ -6,3 +6,6 @@ input_files: 'cs_stateful-2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_sync.yml
+++ b/c/seq-pthread/cs_sync.yml
@@ -6,3 +6,6 @@ input_files: 'cs_sync.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_szymanski.yml
+++ b/c/seq-pthread/cs_szymanski.yml
@@ -6,3 +6,6 @@ input_files: 'cs_szymanski.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/seq-pthread/cs_time_var_mutex.yml
+++ b/c/seq-pthread/cs_time_var_mutex.yml
@@ -6,3 +6,6 @@ input_files: 'cs_time_var_mutex.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/add_first_alloca.yml
+++ b/c/termination-15/add_first_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'add_first_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array05_alloca.yml
+++ b/c/termination-15/array05_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array05_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array06_alloca.yml
+++ b/c/termination-15/array06_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array06_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array07_alloca.yml
+++ b/c/termination-15/array07_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array07_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array08_alloca.yml
+++ b/c/termination-15/array08_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array08_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array09_alloca.yml
+++ b/c/termination-15/array09_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array09_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array10_alloca.yml
+++ b/c/termination-15/array10_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array10_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array12_alloca.yml
+++ b/c/termination-15/array12_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array12_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array13_alloca.yml
+++ b/c/termination-15/array13_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array13_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array16_alloca_fixed.yml
+++ b/c/termination-15/array16_alloca_fixed.yml
@@ -6,3 +6,6 @@ input_files: 'array16_alloca_fixed.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array17_alloca.yml
+++ b/c/termination-15/array17_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array17_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/array18_alloca.yml
+++ b/c/termination-15/array18_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'array18_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/count_up_alloca.yml
+++ b/c/termination-15/count_up_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'count_up_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/count_up_and_down_alloca.yml
+++ b/c/termination-15/count_up_and_down_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'count_up_and_down_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcat_diffterm_alloca.yml
+++ b/c/termination-15/cstrcat_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcat_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcat_malloc.yml
+++ b/c/termination-15/cstrcat_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcat_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcat_mixed_alloca.yml
+++ b/c/termination-15/cstrcat_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcat_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcat_reverse_alloca.yml
+++ b/c/termination-15/cstrcat_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcat_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrchr_diffterm_alloca.yml
+++ b/c/termination-15/cstrchr_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrchr_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrchr_malloc.yml
+++ b/c/termination-15/cstrchr_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrchr_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrchr_reverse_alloca.yml
+++ b/c/termination-15/cstrchr_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrchr_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcmp_diffterm_alloca.yml
+++ b/c/termination-15/cstrcmp_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcmp_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcmp_malloc.yml
+++ b/c/termination-15/cstrcmp_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcmp_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcmp_mixed_alloca.yml
+++ b/c/termination-15/cstrcmp_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcmp_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcmp_reverse_alloca.yml
+++ b/c/termination-15/cstrcmp_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcmp_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcpy_diffterm_alloca.yml
+++ b/c/termination-15/cstrcpy_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcpy_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcpy_malloc.yml
+++ b/c/termination-15/cstrcpy_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcpy_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcpy_mixed_alloca.yml
+++ b/c/termination-15/cstrcpy_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcpy_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcpy_reverse_alloca.yml
+++ b/c/termination-15/cstrcpy_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcpy_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcspn_diffterm_alloca.yml
+++ b/c/termination-15/cstrcspn_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcspn_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcspn_malloc.yml
+++ b/c/termination-15/cstrcspn_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcspn_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcspn_mixed_alloca.yml
+++ b/c/termination-15/cstrcspn_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcspn_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrcspn_reverse_alloca.yml
+++ b/c/termination-15/cstrcspn_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcspn_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrlen_diffterm_alloca.yml
+++ b/c/termination-15/cstrlen_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrlen_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrlen_malloc.yml
+++ b/c/termination-15/cstrlen_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrlen_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrlen_reverse_alloca.yml
+++ b/c/termination-15/cstrlen_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrlen_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncat_diffterm_alloca.yml
+++ b/c/termination-15/cstrncat_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncat_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncat_malloc.yml
+++ b/c/termination-15/cstrncat_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncat_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncat_mixed_alloca.yml
+++ b/c/termination-15/cstrncat_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncat_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncat_reverse_alloca.yml
+++ b/c/termination-15/cstrncat_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncat_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncmp_diffterm_alloca.yml
+++ b/c/termination-15/cstrncmp_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncmp_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncmp_malloc.yml
+++ b/c/termination-15/cstrncmp_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncmp_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncmp_mixed_alloca.yml
+++ b/c/termination-15/cstrncmp_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncmp_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncmp_reverse_alloca.yml
+++ b/c/termination-15/cstrncmp_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncmp_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncpy_diffterm_alloca.yml
+++ b/c/termination-15/cstrncpy_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncpy_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncpy_malloc.yml
+++ b/c/termination-15/cstrncpy_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncpy_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncpy_mixed_alloca.yml
+++ b/c/termination-15/cstrncpy_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncpy_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrncpy_reverse_alloca.yml
+++ b/c/termination-15/cstrncpy_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncpy_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrpbrk_diffterm_alloca.yml
+++ b/c/termination-15/cstrpbrk_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrpbrk_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrpbrk_malloc.yml
+++ b/c/termination-15/cstrpbrk_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrpbrk_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrpbrk_mixed_alloca.yml
+++ b/c/termination-15/cstrpbrk_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrpbrk_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrpbrk_reverse_alloca.yml
+++ b/c/termination-15/cstrpbrk_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrpbrk_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrspn_diffterm_alloca.yml
+++ b/c/termination-15/cstrspn_diffterm_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrspn_diffterm_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrspn_malloc.yml
+++ b/c/termination-15/cstrspn_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'cstrspn_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrspn_mixed_alloca.yml
+++ b/c/termination-15/cstrspn_mixed_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrspn_mixed_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-15/cstrspn_reverse_alloca.yml
+++ b/c/termination-15/cstrspn_reverse_alloca.yml
@@ -6,3 +6,6 @@ input_files: 'cstrspn_reverse_alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/atoi.yml
+++ b/c/termination-libowfat/atoi.yml
@@ -6,3 +6,6 @@ input_files: 'atoi.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/atol.yml
+++ b/c/termination-libowfat/atol.yml
@@ -6,3 +6,6 @@ input_files: 'atol.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/atoll.yml
+++ b/c/termination-libowfat/atoll.yml
@@ -6,3 +6,6 @@ input_files: 'atoll.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/basename-3.yml
+++ b/c/termination-libowfat/basename-3.yml
@@ -6,3 +6,6 @@ input_files: 'basename-3.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/build_fullname.yml
+++ b/c/termination-libowfat/build_fullname.yml
@@ -6,3 +6,6 @@ input_files: 'build_fullname.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/dirname-2.yml
+++ b/c/termination-libowfat/dirname-2.yml
@@ -6,3 +6,6 @@ input_files: 'dirname-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/skip_to.yml
+++ b/c/termination-libowfat/skip_to.yml
@@ -6,3 +6,6 @@ input_files: 'skip_to.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/stpcpy.yml
+++ b/c/termination-libowfat/stpcpy.yml
@@ -6,3 +6,6 @@ input_files: 'stpcpy.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcasecmp.yml
+++ b/c/termination-libowfat/strcasecmp.yml
@@ -6,3 +6,6 @@ input_files: 'strcasecmp.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcat.yml
+++ b/c/termination-libowfat/strcat.yml
@@ -6,3 +6,6 @@ input_files: 'strcat.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcat_short.yml
+++ b/c/termination-libowfat/strcat_short.yml
@@ -6,3 +6,6 @@ input_files: 'strcat_short.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strchr-1.yml
+++ b/c/termination-libowfat/strchr-1.yml
@@ -6,3 +6,6 @@ input_files: 'strchr-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strchr_short.yml
+++ b/c/termination-libowfat/strchr_short.yml
@@ -6,3 +6,6 @@ input_files: 'strchr_short.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcmp_short.yml
+++ b/c/termination-libowfat/strcmp_short.yml
@@ -6,3 +6,6 @@ input_files: 'strcmp_short.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcpy_small.yml
+++ b/c/termination-libowfat/strcpy_small.yml
@@ -6,3 +6,6 @@ input_files: 'strcpy_small.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strcspn.yml
+++ b/c/termination-libowfat/strcspn.yml
@@ -6,3 +6,6 @@ input_files: 'strcspn.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strdup.yml
+++ b/c/termination-libowfat/strdup.yml
@@ -6,3 +6,6 @@ input_files: 'strdup.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strlcat.yml
+++ b/c/termination-libowfat/strlcat.yml
@@ -6,3 +6,6 @@ input_files: 'strlcat.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strlcpy.yml
+++ b/c/termination-libowfat/strlcpy.yml
@@ -6,3 +6,6 @@ input_files: 'strlcpy.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strlen.yml
+++ b/c/termination-libowfat/strlen.yml
@@ -6,3 +6,6 @@ input_files: 'strlen.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strpbrk.yml
+++ b/c/termination-libowfat/strpbrk.yml
@@ -6,3 +6,6 @@ input_files: 'strpbrk.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strrchr.yml
+++ b/c/termination-libowfat/strrchr.yml
@@ -6,3 +6,6 @@ input_files: 'strrchr.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strrchr_short.yml
+++ b/c/termination-libowfat/strrchr_short.yml
@@ -6,3 +6,6 @@ input_files: 'strrchr_short.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strspn.yml
+++ b/c/termination-libowfat/strspn.yml
@@ -6,3 +6,6 @@ input_files: 'strspn.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strstr.yml
+++ b/c/termination-libowfat/strstr.yml
@@ -6,3 +6,6 @@ input_files: 'strstr.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strtok_r.yml
+++ b/c/termination-libowfat/strtok_r.yml
@@ -6,3 +6,6 @@ input_files: 'strtok_r.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strtol.yml
+++ b/c/termination-libowfat/strtol.yml
@@ -6,3 +6,6 @@ input_files: 'strtol.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strtoul.yml
+++ b/c/termination-libowfat/strtoul.yml
@@ -6,3 +6,6 @@ input_files: 'strtoul.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/strtoull.yml
+++ b/c/termination-libowfat/strtoull.yml
@@ -6,3 +6,6 @@ input_files: 'strtoull.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/wcsrchr.yml
+++ b/c/termination-libowfat/wcsrchr.yml
@@ -6,3 +6,6 @@ input_files: 'wcsrchr.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-libowfat/wcsstr.yml
+++ b/c/termination-libowfat/wcsstr.yml
@@ -6,3 +6,6 @@ input_files: 'wcsstr.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Avery-2006FLOPS-Tabel1_true-alloca.yml
+++ b/c/termination-memory-alloca/Avery-2006FLOPS-Tabel1_true-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Avery-2006FLOPS-Tabel1_true-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Ben-Amram-2010LMCS-Ex2.3-alloca.yml
+++ b/c/termination-memory-alloca/Ben-Amram-2010LMCS-Ex2.3-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Ben-Amram-2010LMCS-Ex2.3-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/ChenFlurMukhopadhyay-2012SAS-Fig1-alloca.yml
+++ b/c/termination-memory-alloca/ChenFlurMukhopadhyay-2012SAS-Fig1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'ChenFlurMukhopadhyay-2012SAS-Fig1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig3-alloca.yml
+++ b/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig3-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'CookSeeZuleger-2013TACAS-Fig3-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig7a-alloca.yml
+++ b/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig7a-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'CookSeeZuleger-2013TACAS-Fig7a-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig7b-alloca.yml
+++ b/c/termination-memory-alloca/CookSeeZuleger-2013TACAS-Fig7b-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'CookSeeZuleger-2013TACAS-Fig7b-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/GulwaniJainKoskinen-2009PLDI-Fig1-alloca.yml
+++ b/c/termination-memory-alloca/GulwaniJainKoskinen-2009PLDI-Fig1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'GulwaniJainKoskinen-2009PLDI-Fig1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/HarrisLalNoriRajamani-2010SAS-Fig1-alloca.yml
+++ b/c/termination-memory-alloca/HarrisLalNoriRajamani-2010SAS-Fig1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'HarrisLalNoriRajamani-2010SAS-Fig1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/HarrisLalNoriRajamani-2010SAS-Fig3-alloca.yml
+++ b/c/termination-memory-alloca/HarrisLalNoriRajamani-2010SAS-Fig3-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'HarrisLalNoriRajamani-2010SAS-Fig3-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/KroeningSharyginaTsitovichWintersteiger-2010CAV-Fig1-alloca.yml
+++ b/c/termination-memory-alloca/KroeningSharyginaTsitovichWintersteiger-2010CAV-Fig1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'KroeningSharyginaTsitovichWintersteiger-2010CAV-Fig1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Masse-alloca.yml
+++ b/c/termination-memory-alloca/Masse-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Masse-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/TelAviv-Amir-Minimum-alloca.yml
+++ b/c/termination-memory-alloca/TelAviv-Amir-Minimum-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'TelAviv-Amir-Minimum-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Toulouse-BranchesToLoop-alloca.yml
+++ b/c/termination-memory-alloca/Toulouse-BranchesToLoop-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Toulouse-BranchesToLoop-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Toulouse-MultiBranchesToLoop-alloca.yml
+++ b/c/termination-memory-alloca/Toulouse-MultiBranchesToLoop-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Toulouse-MultiBranchesToLoop-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/Urban-alloca.yml
+++ b/c/termination-memory-alloca/Urban-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'Urban-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.01-alloca.yml
+++ b/c/termination-memory-alloca/a.01-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.04-alloca.yml
+++ b/c/termination-memory-alloca/a.04-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.05-alloca.yml
+++ b/c/termination-memory-alloca/a.05-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.06-alloca.yml
+++ b/c/termination-memory-alloca/a.06-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.07-alloca.yml
+++ b/c/termination-memory-alloca/a.07-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.08-alloca.yml
+++ b/c/termination-memory-alloca/a.08-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.09_assume-alloca.yml
+++ b/c/termination-memory-alloca/a.09_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/a.10-alloca.yml
+++ b/c/termination-memory-alloca/a.10-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/add_last-alloca-2.yml
+++ b/c/termination-memory-alloca/add_last-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'add_last-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/array01-alloca-1.yml
+++ b/c/termination-memory-alloca/array01-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'array01-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/array02-alloca-1.yml
+++ b/c/termination-memory-alloca/array02-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'array02-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/array03-alloca-1.yml
+++ b/c/termination-memory-alloca/array03-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'array03-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/aviad_true-alloca.yml
+++ b/c/termination-memory-alloca/aviad_true-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'aviad_true-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.01-alloca.yml
+++ b/c/termination-memory-alloca/b.01-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.02-alloca.yml
+++ b/c/termination-memory-alloca/b.02-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.03-no-inv_assume-alloca.yml
+++ b/c/termination-memory-alloca/b.03-no-inv_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.03_assume-alloca.yml
+++ b/c/termination-memory-alloca/b.03_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.04-alloca.yml
+++ b/c/termination-memory-alloca/b.04-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.05-alloca.yml
+++ b/c/termination-memory-alloca/b.05-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.06-alloca.yml
+++ b/c/termination-memory-alloca/b.06-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.07-alloca.yml
+++ b/c/termination-memory-alloca/b.07-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.09-no-inv_assume-alloca.yml
+++ b/c/termination-memory-alloca/b.09-no-inv_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.09_assume-alloca.yml
+++ b/c/termination-memory-alloca/b.09_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.10-alloca.yml
+++ b/c/termination-memory-alloca/b.10-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.11-alloca.yml
+++ b/c/termination-memory-alloca/b.11-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.12-alloca.yml
+++ b/c/termination-memory-alloca/b.12-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.13-alloca.yml
+++ b/c/termination-memory-alloca/b.13-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.14-alloca.yml
+++ b/c/termination-memory-alloca/b.14-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.15-alloca.yml
+++ b/c/termination-memory-alloca/b.15-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.16-alloca.yml
+++ b/c/termination-memory-alloca/b.16-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.17-alloca.yml
+++ b/c/termination-memory-alloca/b.17-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/b.18-alloca.yml
+++ b/c/termination-memory-alloca/b.18-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/bubblesort-alloca-1.yml
+++ b/c/termination-memory-alloca/bubblesort-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'bubblesort-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.01-no-inv-alloca.yml
+++ b/c/termination-memory-alloca/c.01-no-inv-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.01_assume-alloca.yml
+++ b/c/termination-memory-alloca/c.01_assume-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.02-alloca.yml
+++ b/c/termination-memory-alloca/c.02-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.03-alloca-1.yml
+++ b/c/termination-memory-alloca/c.03-alloca-1.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.07-alloca.yml
+++ b/c/termination-memory-alloca/c.07-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/c.08-alloca.yml
+++ b/c/termination-memory-alloca/c.08-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/count_down-alloca-2.yml
+++ b/c/termination-memory-alloca/count_down-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'count_down-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrcat-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrcat-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcat-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrchr-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrchr-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrchr-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrcmp-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrcmp-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcmp-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrcpy-alloca-2.yml
+++ b/c/termination-memory-alloca/cstrcpy-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcpy-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrcspn-alloca-2.yml
+++ b/c/termination-memory-alloca/cstrcspn-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'cstrcspn-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrlen-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrlen-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrlen-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrncat-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrncat-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncat-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrncmp-alloca-2.yml
+++ b/c/termination-memory-alloca/cstrncmp-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncmp-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrncpy-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrncpy-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrncpy-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrpbrk-alloca-1.yml
+++ b/c/termination-memory-alloca/cstrpbrk-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cstrpbrk-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/cstrspn-alloca-2.yml
+++ b/c/termination-memory-alloca/cstrspn-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'cstrspn-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/diff-alloca-1.yml
+++ b/c/termination-memory-alloca/diff-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'diff-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/easySum-alloca.yml
+++ b/c/termination-memory-alloca/easySum-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'easySum-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/ex1-alloca.yml
+++ b/c/termination-memory-alloca/ex1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'ex1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/ex2-alloca.yml
+++ b/c/termination-memory-alloca/ex2-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'ex2-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/ex3a-alloca.yml
+++ b/c/termination-memory-alloca/ex3a-alloca.yml
@@ -8,3 +8,6 @@ properties:
     expected_verdict: true
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/ex3b-alloca.yml
+++ b/c/termination-memory-alloca/ex3b-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'ex3b-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/flag-alloca.yml
+++ b/c/termination-memory-alloca/flag-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'flag-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/gcd1-alloca.yml
+++ b/c/termination-memory-alloca/gcd1-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'gcd1-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/insertionsort-alloca-2.yml
+++ b/c/termination-memory-alloca/insertionsort-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'insertionsort-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/java_AG313-alloca.yml
+++ b/c/termination-memory-alloca/java_AG313-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'java_AG313-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/java_BubbleSort-alloca-2.yml
+++ b/c/termination-memory-alloca/java_BubbleSort-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'java_BubbleSort-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/java_LogBuiltIn-alloca.yml
+++ b/c/termination-memory-alloca/java_LogBuiltIn-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'java_LogBuiltIn-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/lis-alloca-2.yml
+++ b/c/termination-memory-alloca/lis-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'lis-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/min_rf-alloca.yml
+++ b/c/termination-memory-alloca/min_rf-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'min_rf-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/mult_array-alloca-2.yml
+++ b/c/termination-memory-alloca/mult_array-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'mult_array-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cbzero-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cbzero-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cbzero-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cmemchr-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cmemchr-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cmemchr-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cmemrchr-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cmemrchr-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cmemset-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cmemset-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cmemset-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstpcpy-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstpcpy-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstpcpy-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstpncpy-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstpncpy-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstpncpy-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrcat-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrcat-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrcat-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrcmp-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstrcmp-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrcmp-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrcpy-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrcpy-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrcpy-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrcspn-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrcspn-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrcspn-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrlcpy-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstrlcpy-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrlcpy-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrlen-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstrlen-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrlen-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrncat-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrncat-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrncat-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrncmp-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrncmp-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrncmp-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrncpy-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrncpy-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrncpy-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrnlen-alloca-2.yml
+++ b/c/termination-memory-alloca/openbsd_cstrnlen-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrnlen-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrpbrk-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrpbrk-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrpbrk-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrspn-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrspn-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrspn-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/openbsd_cstrstr-alloca-1.yml
+++ b/c/termination-memory-alloca/openbsd_cstrstr-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'openbsd_cstrstr-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/rec_strlen-alloca-2.yml
+++ b/c/termination-memory-alloca/rec_strlen-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'rec_strlen-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/selectionsort-alloca-2.yml
+++ b/c/termination-memory-alloca/selectionsort-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'selectionsort-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/stroeder1-alloca-2.yml
+++ b/c/termination-memory-alloca/stroeder1-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'stroeder1-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/stroeder2-alloca-2.yml
+++ b/c/termination-memory-alloca/stroeder2-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'stroeder2-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/strreplace-alloca-1.yml
+++ b/c/termination-memory-alloca/strreplace-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'strreplace-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/subseq-alloca-1.yml
+++ b/c/termination-memory-alloca/subseq-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'subseq-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/substring-alloca-1.yml
+++ b/c/termination-memory-alloca/substring-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'substring-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-alloca/twisted-alloca.yml
+++ b/c/termination-memory-alloca/twisted-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'twisted-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/cll_by_lseg-alloca-2.yml
+++ b/c/termination-memory-linkedlists/cll_by_lseg-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'cll_by_lseg-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/cll_search-alloca-1.yml
+++ b/c/termination-memory-linkedlists/cll_search-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'cll_search-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_append-alloca-1.yml
+++ b/c/termination-memory-linkedlists/ll_append-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'll_append-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_append_rec-alloca-1.yml
+++ b/c/termination-memory-linkedlists/ll_append_rec-alloca-1.yml
@@ -6,3 +6,6 @@ input_files: 'll_append_rec-alloca-1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_create_rec-alloca-2.yml
+++ b/c/termination-memory-linkedlists/ll_create_rec-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'll_create_rec-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_search-alloca.yml
+++ b/c/termination-memory-linkedlists/ll_search-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'll_search-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_search_not_found-alloca.yml
+++ b/c/termination-memory-linkedlists/ll_search_not_found-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'll_search_not_found-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/ll_traverse-alloca.yml
+++ b/c/termination-memory-linkedlists/ll_traverse-alloca.yml
@@ -6,3 +6,6 @@ input_files: 'll_traverse-alloca.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-memory-linkedlists/nondet_ll_search-alloca-2.yml
+++ b/c/termination-memory-linkedlists/nondet_ll_search-alloca-2.yml
@@ -6,3 +6,6 @@ input_files: 'nondet_ll_search-alloca-2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/chunk1.yml
+++ b/c/termination-recursive-malloc/chunk1.yml
@@ -6,3 +6,6 @@ input_files: 'chunk1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/chunk2.yml
+++ b/c/termination-recursive-malloc/chunk2.yml
@@ -6,3 +6,6 @@ input_files: 'chunk2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/chunk3.yml
+++ b/c/termination-recursive-malloc/chunk3.yml
@@ -6,3 +6,6 @@ input_files: 'chunk3.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/insertionSort_recursive.yml
+++ b/c/termination-recursive-malloc/insertionSort_recursive.yml
@@ -6,3 +6,6 @@ input_files: 'insertionSort_recursive.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/mergeSort.yml
+++ b/c/termination-recursive-malloc/mergeSort.yml
@@ -6,3 +6,6 @@ input_files: 'mergeSort.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/mutual_simple.yml
+++ b/c/termination-recursive-malloc/mutual_simple.yml
@@ -6,3 +6,6 @@ input_files: 'mutual_simple.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/mutual_simple2.yml
+++ b/c/termination-recursive-malloc/mutual_simple2.yml
@@ -6,3 +6,6 @@ input_files: 'mutual_simple2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex1.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex1.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex1.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex10.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex10.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex10.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex11.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex11.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex11.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex11B.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex11B.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex11B.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex11C.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex11C.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex11C.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex11D.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex11D.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex11D.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex2.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex2.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex3.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex3.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex3.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex4.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex4.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex4.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex5.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex5.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex5.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex5B.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex5B.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex5B.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex6.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex6.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex6.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex7.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex7.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex7.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex7B.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex7B.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex7B.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex8.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex8.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex8.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_malloc_ex9.yml
+++ b/c/termination-recursive-malloc/rec_malloc_ex9.yml
@@ -6,3 +6,6 @@ input_files: 'rec_malloc_ex9.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_strcopy_malloc.yml
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'rec_strcopy_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_strcopy_malloc2.yml
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc2.yml
@@ -6,3 +6,6 @@ input_files: 'rec_strcopy_malloc2.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/rec_strlen_malloc.yml
+++ b/c/termination-recursive-malloc/rec_strlen_malloc.yml
@@ -6,3 +6,6 @@ input_files: 'rec_strlen_malloc.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp

--- a/c/termination-recursive-malloc/selectionSort_recursive.yml
+++ b/c/termination-recursive-malloc/selectionSort_recursive.yml
@@ -6,3 +6,6 @@ input_files: 'selectionSort_recursive.i'
 properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
Tasks were selected based on the following criteria:

1. Compiles, if __VERIFIER_X method definitions are provided,
2. No termination property or expected verdict for termination is true, and
3. Some __VERIFIER_nondet_* method exists that is not only declared, but used in at least one other location

I selected both tasks with and without memory-errors or overflows - I'm not sure whether this is wanted for Test-Comp, though.
