### PR TITLE
memsafety-bftpd: incomplete *.yml

### DIFF
--- a/c/MemSafety-MemCleanup.set
+++ b/c/MemSafety-MemCleanup.set
@@ -3,3 +3,4 @@ heap-manipulation/*.yml
 forester-heap/*.yml
 list-properties/*.yml
 list-ext3-properties/*.yml
+memsafety-bftpd/*.yml

--- a/c/memsafety-bftpd/bftpd_3.yml
+++ b/c/memsafety-bftpd/bftpd_3.yml
@@ -5,3 +5,4 @@ input_files: 'bftpd_3.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
+    subproperty: valid-memtrack


### PR DESCRIPTION
Missing `*.yml` for `bftpd_2.c` in `MemSafety-MemCleanup.set` (without free for static variable - invalid memcleanup) and incomplete `bftpd_3.yml` (rewrite unfreed static variable - invalid memtrack).