### PR TITLE
Update mlceu.c to get the correct verdict

### DIFF
--- a/c/array-tiling/mlceu.c
+++ b/c/array-tiling/mlceu.c
@@ -6,33 +6,32 @@ void *malloc(unsigned int size);
 
 int SIZE;
 
-const int MAX = 100000;
-
 int main()
 {
 	SIZE = __VERIFIER_nondet_int();
-	if(SIZE > 1 && SIZE < MAX)
+	if(SIZE <= 0) return 1;
+	__VERIFIER_assume(SIZE <= 66060288/sizeof(int));
+
+	int i;
+	int *a = malloc(sizeof(int)*SIZE);
+
+	for(i=0; i<SIZE; i++)
 	{
-		int i;
-		int *a = malloc(sizeof(int)*SIZE);
-
-		for(i=0; i<SIZE; i++)
+		if( i>>16 > 250)
 		{
-			if( i>>16 > 250)
-			{
-				a[i] = 1;
-			}
-			else
-			{
-				a[i] = 0;
-			}
+			a[i] = 1;
 		}
-
-		//assert
-		for(i=0; i<SIZE; i++)
+		else
 		{
-			__VERIFIER_assert(a[i] == 0);
+			a[i] = 0;
 		}
 	}
+
+	//assert
+	for(i=0; i<SIZE; i++)
+	{
+		__VERIFIER_assert(a[i] == 0);
+	}
+
 	return 1;
 }

--- a/c/array-tiling/mlceu2.c
+++ b/c/array-tiling/mlceu2.c
@@ -1,0 +1,38 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int(void);
+void *malloc(unsigned int size);
+
+int SIZE;
+
+const int MAX = 100000;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_int();
+	if(SIZE > 1 && SIZE < MAX)
+	{
+		int i;
+		int *a = malloc(sizeof(int)*SIZE);
+
+		for(i=0; i<SIZE; i++)
+		{
+			if( i>>16 > 250)
+			{
+				a[i] = 1;
+			}
+			else
+			{
+				a[i] = 0;
+			}
+		}
+
+		//assert
+		for(i=0; i<SIZE; i++)
+		{
+			__VERIFIER_assert(a[i] == 0);
+		}
+	}
+	return 1;
+}

--- a/c/array-tiling/mlceu2.yml
+++ b/c/array-tiling/mlceu2.yml
@@ -5,7 +5,6 @@ input_files: 'mlceu2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
-  - property_file: ../properties/coverage-error-call.prp
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp

--- a/c/array-tiling/mlceu2.yml
+++ b/c/array-tiling/mlceu2.yml
@@ -1,0 +1,11 @@
+format_version: '1.0'
+
+input_files: 'mlceu2.c'
+
+properties:
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true
+  - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
#791 introduced a upper bound on the size of the array making the assertion in the program mlceu provable. This change corrects the upper bound making the assertion violable in mlceu as per its verdict.

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
