### PR TITLE
Adding NanoXML equivalence check as a benchmark

### DIFF
--- a/java/java-ranger-regression/nanoxml_eqchk.yml
+++ b/java/java-ranger-regression/nanoxml_eqchk.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - nanoxml_eqchk/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+

--- a/java/java-ranger-regression/nanoxml_eqchk/ContentReader.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/ContentReader.java
@@ -1,0 +1,189 @@
+
+import java.io.IOException;
+import java.io.Reader;
+
+
+public class ContentReader extends Reader {
+
+	/**
+	 * The delimiter that will indicate the end of the stream.
+	 */
+	private String delimiter;
+
+	/**
+	 * The characters that have been read too much.
+	 */
+	private String charsReadTooMuch;
+
+	/**
+	 * The number of characters in the delimiter that stil need to be scanned.
+	 */
+	private int charsToGo;
+
+	/**
+	 * True if &amp; needs to be left untouched.
+	 */
+	private boolean useLowLevelReader;
+
+	/**
+	 * True if we are passed the initial prefix.
+	 */
+	private boolean pastInitialPrefix;
+	
+	private StdXMLParser parser;
+
+	/**
+	 * Creates the reader.
+	 * 
+	 * @param delimiter
+	 *            the delimiter, as a backwards string, that will indicate the
+	 *            end of the stream
+	 * @param useLowLevelReader
+	 *            true if &amp; needs to be left untouched; false if entities
+	 *            need to be processed
+	 */
+	ContentReader(StdXMLParser parser, String delimiter, boolean useLowLevelReader, String prefix) {
+		this.parser = parser;
+		this.delimiter = delimiter;
+		this.charsToGo = this.delimiter.length();
+		this.charsReadTooMuch = prefix;
+		this.useLowLevelReader = useLowLevelReader;
+		this.pastInitialPrefix = false;
+	}
+
+	/**
+	 * Reads a block of data.
+	 * 
+	 * @param buffer
+	 *            where to put the read data
+	 * @param offset
+	 *            first position in buffer to put the data
+	 * @param size
+	 *            maximum number of chars to read
+	 * 
+	 * @return the number of chars read, or -1 if at EOF
+	 * 
+	 * @throws java.io.IOException
+	 *             if an error occurred reading the data
+	 */
+	public int read(char[] buffer, int offset, int size) throws IOException {
+		int charsRead = 0;
+		boolean isEntity[] = new boolean[1];
+		isEntity[0] = false;
+		int bufferLen = buffer.length;
+		int endLen = offset + size;
+		if (endLen > bufferLen) {
+			size = bufferLen - offset;
+		}
+
+		while ((this.charsToGo > 0) && (charsRead < size)) {
+			char ch;
+			int l = this.charsReadTooMuch.length();
+			if (l > 0) {
+				ch = this.charsReadTooMuch.charAt(0);
+				this.charsReadTooMuch = this.charsReadTooMuch.substring(1);
+			} 
+			else {
+				this.pastInitialPrefix = true;
+
+				if (useLowLevelReader) {
+					ch = parser.reader.read();
+				} else {
+					ch = parser.read(isEntity);
+
+					if (!isEntity[0]) {
+						if (ch == '&') {
+							Reader r = parser.scanEntity(isEntity);
+							parser.reader.startNewStream(r);
+							ch = parser.reader.read();
+						}
+					}
+				}
+			}
+
+			if (isEntity[0]) {
+				int index = offset + charsRead;
+				buffer[index] = ch;
+				charsRead = charsRead + 1;
+			} 
+			else {
+				char s = this.delimiter.charAt(this.charsToGo - 1);
+				int len = this.delimiter.length();
+				if (ch == s && pastInitialPrefix) {
+					charsToGo = charsToGo - 1;
+				} 
+				else if (this.charsToGo < len) {
+					String str = this.delimiter.substring(this.charsToGo + 1);
+					this.charsReadTooMuch = str + ch;
+					this.charsToGo = this.delimiter.length();
+					int in = offset + charsRead;
+					buffer[in] = this.delimiter.charAt(this.charsToGo - 1);
+					charsRead = charsRead + 1;
+				} 
+				else {
+					int in = offset + charsRead;
+					buffer[in] = ch;
+					charsRead = charsRead + 1;
+				}
+			}
+		}
+
+		if (charsRead == 0) {
+			charsRead = -1;
+		}
+
+		return charsRead;
+	}
+
+	/**
+	 * Skips remaining data and closes the stream.
+	 * 
+	 * @throws java.io.IOException
+	 *             if an error occurred reading the data
+	 */
+	public void close() throws IOException {
+		int delimiterLen = delimiter.length();
+		while (charsToGo > 0) {
+			char ch;
+			if(useLowLevelReader){
+				ch = parser.reader.read();
+			}
+			else{
+				ch = parser.read(null);
+			}
+			char sh = this.delimiter.charAt(charsToGo - 1);
+			if(ch == sh){
+				charsToGo = charsToGo - 1;
+			}
+			else{
+				charsToGo = delimiterLen;
+			}
+		}
+//			//
+//			int length = this.charsReadTooMuch.length();
+//			if (length > 0) {
+//				ch = this.charsReadTooMuch.charAt(0);
+//				this.charsReadTooMuch = this.charsReadTooMuch.substring(1);
+//			} 
+//			else {
+//				if (useLowLevelReader) {
+//					ch = parser.reader.read();
+//				} 
+//				else {
+//					ch = parser.read(null);
+//				}
+//			}
+//
+//			char sh = this.delimiter.charAt(charsToGo - 1);
+//			if (ch == sh) {
+//				this.charsToGo = this.charsToGo - 1;
+//			} 
+//			else if (this.charsToGo < delimiterLen) {
+//				//
+//				String s = this.delimiter.substring(this.charsToGo + 1);
+//				this.charsReadTooMuch = s + ch;
+//				this.charsToGo = this.delimiter.length();
+//			}
+//		}
+	}
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/DumpXML.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/DumpXML.java
@@ -1,0 +1,45 @@
+
+
+import java.util.ArrayList;
+
+public class DumpXML {
+
+	public static int numIdentifiers;
+	public static int mainProcess(char i0, char i1, char i2, char i3, char i4, char i5, char i6, char i7, char i8){
+		numIdentifiers = 0; // commenting this line out causes the equivalence check to fail
+		char[] str = new char[12];
+		str[0] = i0;
+		str[1] = i1;
+		str[2] = i2;
+		str[3] = i3;
+		str[4] = i4;
+		str[5] = i5;
+		str[6] = i6;
+		str[7] = i7;
+		str[8] = i8;
+		StdXMLParser parser = new StdXMLParser();
+		
+		IntReader intReader = new IntReader(str);
+		StdXMLReader stdXMLReader =  new StdXMLReader(intReader);
+		parser.setReader(stdXMLReader);
+		
+//		StdXMLBuilder builder = new StdXMLBuilder();
+//		parser.setBuilder(builder);
+		
+//		NonValidator nonValidator = new NonValidator();
+//		parser.setValidator(nonValidator);
+		try{
+			parser.parse();
+			System.out.println("No output!");
+		}
+		catch(Exception e){
+			e.printStackTrace();
+		}
+
+//		(new XMLWriter(System.out)).write(xml);
+		return numIdentifiers;
+	}
+    public static void main(String args[]){   
+    	mainProcess('<','a', '\t', 't', '=', '=', '"', '1', '"');
+    }
+} 

--- a/java/java-ranger-regression/nanoxml_eqchk/IXMLBuilder.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/IXMLBuilder.java
@@ -1,0 +1,132 @@
+/* IXMLBuilder.java                                                NanoXML/Java
+ *
+ * $Revision: 1.3 $
+ * $Date: 2001/03/28 23:34:16 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.Reader;
+import java.io.IOException;
+
+
+/**
+ * NanoXML uses IXMLBuilder to construct the XML data structure it retrieved
+ * from its data source. You can supply your own builder or you can use the
+ * default builder of NanoXML.
+ *
+ * @see net.n3.nanoxmlModified.IXMLParser
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.3 $
+ */
+public interface IXMLBuilder
+{
+
+    /**
+     * This method is called before the parser starts processing its input.
+     *
+     * @param lineNr the line on which the parsing starts
+     */
+    public void startBuilding(int lineNr);
+
+
+    /**
+     * This method is called when a processing instruction is encountered.
+     * PIs with target "xml" are handled by the parser.
+     *
+     * @param target the PI target
+     * @param reader to read the data from the PI
+     */
+    public void newProcessingInstruction(String target,
+                                         Reader reader)
+        throws IOException;
+
+
+    /**
+     * This method is called when a new XML element is encountered.
+     *
+     * @see #endElement
+     *
+     * @param name the non-null name of the element
+     * @param lineNr the line in the source where the element starts
+     */
+    public void startElement(String name,
+                             int    lineNr);
+    
+    
+    /**
+     * This method is called when the end of an XML element is encountered.
+     *
+     * @see #startElement
+     *
+     * @param name the non-null name of the element
+     */
+    public void endElement(String name);
+    
+    
+    /**
+     * This method is called when a new attribute of an XML element is 
+     * encountered.
+     *
+     * @param key the non-null key (name) of the attribute
+     * @param value the non-null value of the attribute
+     */
+    public void addAttribute(String key,
+                             String value);
+    
+    
+    /**
+     * This method is called when a PCDATA element is encountered. A Java 
+     * reader is supplied from which you can read the data. The reader will
+     * only read the data of the element. You don't need to check for
+     * boundaries. If you don't read the full element, the rest of the data 
+     * is skipped. You also don't have to care about entities; they are 
+     * resolved by the parser.
+     *
+     * @param reader the Java reader from which you can retrieve the data
+     * @param lineNr the line in the source where the element starts
+     *
+     * @throws java.io.IOException
+     *		when the reader throws such exception
+     */
+    public void addPCData(Reader reader,
+                          int    lineNr)
+        throws IOException;
+                          
+    
+    /**
+     * Returns the result of the building process. This method is called just
+     * before the parse() method of IXMLParser returns.
+     *
+     * @see net.n3.nanoxmlModified.IXMLParser#parse
+     *
+     * @return the result of the building process.
+     */
+    public Object getResult();
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/IXMLParser.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/IXMLParser.java
@@ -1,0 +1,78 @@
+/* IXMLParser.java                                                 NanoXML/Java
+ *
+ * $Revision: 1.1.1.1 $
+ * $Date: 2001/03/19 18:08:54 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+import java.io.IOException;
+
+
+/**
+ * IXMLParser is the core parser of NanoXML.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.1.1.1 $
+ */
+public interface IXMLParser
+{
+
+    /**
+     * Sets the reader from which the parser retrieves its data.
+     *
+     * @param reader the non-null reader
+     */
+    public void setReader(IXMLReader reader);
+    
+    
+    /**
+     * Sets the builder which creates the logical structure of the XML data.
+     *
+     * @param builder the non-null builder
+     */
+    public void setBuilder(IXMLBuilder builder);
+    
+    
+    /**
+     * Sets the validator that will process entity references and validate the
+     * XML data.
+     *
+     * @param validator the non-null validator
+     */
+    public void setValidator(IXMLValidator validator);
+    
+    
+    /**
+     * Parses the data and lets the builder create the logical data structure.
+     *
+     * @return the logical structure built by the builder
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    public Object parse()
+        throws IOException;
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/IXMLReader.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/IXMLReader.java
@@ -1,0 +1,126 @@
+/* IXMLReader.java                                                 NanoXML/Java
+ *
+ * $Revision: 1.4 $
+ * $Date: 2001/03/28 23:34:16 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.Reader;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
+
+
+/**
+ * IXMLReader reads the data to be parsed.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.4 $
+ */
+public interface IXMLReader
+{
+
+    /**
+     * Reads a character.
+     *
+     * @return the character
+     *
+     * @throws java.io.IOException
+     *		if no character could be read
+     */
+    public char read()
+        throws IOException;
+        
+    
+    /**
+     * Returns true if the current stream has no more characters left to be
+     * read.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public boolean atEOFOfCurrentStream()
+        throws IOException;
+        
+        
+    /**
+     * Returns true if there are no more characters left to be read.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public boolean atEOF()
+        throws IOException;
+        
+    
+    /**
+     * Pushes the last character read back to the stream.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public void unread(char ch)
+        throws IOException;
+        
+
+    /**
+     * Returns the line number of the data in the current stream.
+     */
+    public int getLineNr();
+
+
+    /**
+     * Opens a stream from a public and system ID.
+     *
+     * @param publicID the public ID, which may be null
+     * @param systemID the system ID, which is never null
+     *
+     * @throws MalformedURLException
+     *		if the system ID does not contain a valid URL
+     * @throws FileNotFoundException
+     *		if the system ID refers to a local file which does not exist
+     * @throws IOException
+     *		if an error occurred opening the stream
+     */
+    public Reader openStream(String publicID,
+                             String systemID)
+        throws MalformedURLException,
+               FileNotFoundException,
+               IOException;
+
+
+    /**
+     * Starts a new stream from a Java reader. The new stream is used
+     * temporary to read data from. If that stream is exhausted, control
+     * returns to the parent stream.
+     *
+     * @param reader the non-null reader to read the new data from
+     */
+    public void startNewStream(Reader reader);
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/IXMLValidator.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/IXMLValidator.java
@@ -1,0 +1,110 @@
+/* IXMLValidator.java                                              NanoXML/Java
+ *
+ * $Revision: 1.5 $
+ * $Date: 2001/03/28 18:49:22 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.Reader;
+import java.io.IOException;
+import java.util.Properties;
+
+
+/**
+ * IXMLValidator processes the DTD and handles entity references.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.5 $
+ */
+public interface IXMLValidator
+{
+
+    /**
+     * Parses the DTD. The validator object is responsible for reading the
+     * full DTD.
+     *
+     * @param publicID the public ID.
+     * @param reader the reader to read the DTD from.
+     */
+    public void parseDTD(String     publicID,
+                         IXMLReader reader)
+        throws IOException;
+
+    
+    /**
+     * Indicates that an element has been started.
+     *
+     * @param name the name of the element.
+     * @param lineNr the line number in the XML data of the element.
+     */
+    public void elementStarted(String name,
+                               int    lineNr);
+    
+    
+    /**
+     * Indicates that the current element has ended.
+     * If there are attributes with a default value which have not been
+     * specified yet, they have to be put into <I>extraAttributes</I>.
+     *
+     * @param name the name of the element.
+     * @param extraAttributes where to put extra attributes.
+     */
+    public void elementEnded(String name,
+                             Properties extraAttributes);
+    
+    
+    /**
+     * Indicates that an attribute has been added to the current element.
+     *
+     * @param key the name of the attribute.
+     * @param value the value of the attribute.
+     */
+    public void attributeAdded(String key,
+                               String value);
+    
+    
+    /**
+     * Indicates that a new #PCDATA element has been encountered.
+     *
+     * @param lineNr the line number in the XML data of the element.
+     */
+    public void PCDataAdded(int lineNr);
+    
+    
+    /**
+     * Returns a Java reader containing the value of an entity.
+     *
+     * @param xmlReader the current XML reader
+     * @param name the name of the entity.
+     *
+     * @return the reader, or null if the entity could not be resolved.
+     */
+    public Reader getEntity(IXMLReader xmlReader,
+                            String name);
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/IntReader.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/IntReader.java
@@ -1,0 +1,65 @@
+
+import java.io.IOException;
+import java.io.Reader;
+
+public class IntReader extends Reader {
+    private char[] str;
+    private int length;
+    private int next = 0;
+
+    public IntReader(char[] s) {
+    	str = s;
+    	length = s.length;
+    }
+    
+//    private void ensureOpen() throws IOException{
+//    	if(str == null){
+//    		throw new IOException("Stream Closed");
+//    	}
+//    }
+
+    public int read() throws IOException {
+//    	ensureOpen();
+	    if (next >= length){
+	    	throw new IOException("IntReader EOF");
+	    }
+	    else{
+		    char ch = str[next];
+		    next = next + 1;
+		    return ch;
+	    }
+
+    }
+
+    public void close() {
+    	str = null;
+    }
+
+	public int read(char[] cbuf, int off, int len) throws IOException {
+//		ensureOpen();
+		if(off < 0 || off >= cbuf.length || len < 0 || off+len >= cbuf.length || off+len < 0){
+			throw new IndexOutOfBoundsException();
+		}
+		else if(len == 0){
+			return 0;
+		}
+		if(next >= length){
+			return -1;
+		}
+		int lenReader = -1;
+		int lenStr = length - next;
+		if(lenStr > len){
+			lenReader = len;
+		}
+		else{
+			lenReader = lenStr;
+		}
+		for(int i=0; i<lenReader; i++){
+			cbuf[off] = str[next];
+			off = off + 1;
+			next = next + 1;
+		}
+		return lenReader;
+	}
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/Main.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/Main.java
@@ -1,0 +1,22 @@
+import java.util.ArrayList;
+
+public class Main {
+
+    int runDumpXML(char c0, char c1, char c2, char c3, char c4, char c5, char c6, char c7, char c8) {
+        DumpXML t = new DumpXML();
+//        int ret = t.mainProcess(c0, c1, c2, c3, c4, c5, c6, c7, c8);
+        int ret = t.mainProcess(c0, c1, c2, c3, c4, c5, c6, c7, c8);
+        return ret;
+    }
+
+
+    public static void main(String[] args) {
+        TestVeritestingDumpXML t = new TestVeritestingDumpXML();
+        Main s = new Main();
+        t.runTest(s);
+    }
+
+    int testFunction(char c0, char c1, char c2, char c3, char c4, char c5, char c6, char c7, char c8) {
+        return runDumpXML(c0, c1, c2, c3, c4, c5, c6, c7, c8);
+    }
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/NonValidator.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/NonValidator.java
@@ -1,0 +1,672 @@
+/* NonValidator.java                                               NanoXML/Java
+ *
+ * $Revision: 1.5 $
+ * $Date: 2001/03/28 18:47:24 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+import java.io.Reader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Properties;
+import java.util.Stack;
+
+
+/**
+ * NonValidator processes the DTD and handles entity references.
+ * It does not do any validation itself.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.5 $
+ */
+public class NonValidator
+    implements IXMLValidator
+{
+
+    /**
+     * The list of all parsed entities.
+     */
+    protected Hashtable entities;
+    
+    
+    /**
+     * The list of all parameter entities.
+     */
+    protected Hashtable parameterEntities;
+    
+    
+    /**
+     * The parameter entity level.
+     */
+    protected int peLevel;
+    
+    
+    /**
+     * Contains the default values for attributes for the different element
+     * types.
+     */
+    protected Hashtable attributeDefaultValues;
+    
+    
+    /**
+     * The stack of elements to be processed.
+     */
+    protected Stack currentElements;
+    
+    
+    /**
+     * Creates the &quot;validator&quot;.
+     */
+    public NonValidator()
+    {
+        this.attributeDefaultValues = new Hashtable();
+        this.currentElements = new Stack();
+        this.parameterEntities = new Hashtable();
+        this.peLevel = 0;
+        this.entities = new Hashtable();
+        this.entities.put("amp", "&#38;#38;");
+        this.entities.put("quot", "&#38;#34;");
+        this.entities.put("apos", "&#38;#39;");
+        this.entities.put("lt", "&#38;#60;");
+        this.entities.put("gt", "&#38;#62;");
+    }
+    
+    
+    /**
+     * Parses the DTD.
+     *
+     * @param publicID the public ID.
+     * @param reader the reader to read the DTD from.
+     */
+    public void parseDTD(String     publicID,
+                         IXMLReader reader)
+        throws IOException
+    {
+        this.skipWhitespace(reader, false);
+        
+        while ((peLevel > 0) || (! reader.atEOFOfCurrentStream())) {
+            char ch = this.readChar(reader, true);
+            
+            if (ch == '<') {
+                this.processElement(reader);
+            } else if (ch == ']') {
+                break;
+            } else {
+                throw new XMLParseException(reader.getLineNr(),
+                                            "Invalid char: " + ch);
+            }
+            
+            this.skipWhitespace(reader, false);
+        }
+    }
+    
+
+    /**
+     * Processes an element in the DTD.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected void processElement(IXMLReader reader)
+        throws IOException
+    {
+		if (this.readChar(reader, true) != '!') {
+			this.skipTag(reader);
+			return;
+		}
+
+		char ch = this.readChar(reader, true);
+
+		if (ch == '-') {
+			this.skipComment(reader);
+		}
+
+		else if (ch == 'E') {
+			this.processEntity(reader);
+		}
+
+		else if (ch == 'A') {
+			this.processAttList(reader);
+		}
+
+		else {
+			this.skipTag(reader);
+		}
+    }
+    
+    
+    /**
+     * Processes an ATTLIST element.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected void processAttList(IXMLReader reader)
+        throws IOException
+    {
+        if (this.readChar(reader, true) != 'T') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'T') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'L') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'I') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'S') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'T') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        this.skipWhitespace(reader, false);
+        String elementName = this.scanIdentifier(reader);
+        this.skipWhitespace(reader, false);
+        char ch = this.readChar(reader, true);
+        Properties props = new Properties();
+        
+        while (ch != '>') {
+            reader.unread(ch);
+            String attName = this.scanIdentifier(reader);
+            this.skipWhitespace(reader, false);
+            ch = this.readChar(reader, true);
+            
+            if (ch == '(') {
+                while (ch != ')') {
+                    ch = this.readChar(reader, true);
+                }
+            } else {
+                reader.unread(ch);
+                this.scanIdentifier(reader);
+            }
+            
+            this.skipWhitespace(reader, false);
+            ch = this.readChar(reader, true);
+            
+            if (ch == '#') {
+                String str = this.scanIdentifier(reader);
+                this.skipWhitespace(reader, false);
+                
+                if (! str.equals("FIXED")) {
+                    // added lines to work with DTD files
+                      this.skipWhitespace(reader, false);
+                   ch = this.readChar(reader, true);
+                    continue;
+                }
+            } else {
+                reader.unread(ch);
+            }
+            
+            String value = this.scanString(reader);
+            props.put(attName, value);
+            this.skipWhitespace(reader, false);
+            ch = this.readChar(reader, true);
+        }
+        
+        if (! props.isEmpty()) {
+            this.attributeDefaultValues.put(elementName, props);
+        }
+    }
+    
+    
+    /**
+     * Processes an ENTITY element.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected void processEntity(IXMLReader reader)
+        throws IOException
+    {
+        if (this.readChar(reader, true) != 'N') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'T') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'I') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'T') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        if (this.readChar(reader, true) != 'Y') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        this.skipWhitespace(reader, true);
+        char ch = this.readChar(reader, false);
+        Hashtable entitySet = this.entities;
+        
+        if (ch == '%') {
+            this.skipWhitespace(reader, false);
+            entitySet = this.parameterEntities;
+        } else {
+            reader.unread(ch);
+        }
+        
+        String key = this.scanIdentifier(reader);
+        this.skipWhitespace(reader, false);
+        ch = this.readChar(reader, true);
+        String systemID = null;
+        String publicID = null;
+        
+		if (ch == 'P') {
+			if (this.readChar(reader, true) != 'U') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'B') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'L') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'I') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'C') {
+				this.skipTag(reader);
+				return;
+			}
+
+			this.skipWhitespace(reader, false);
+			publicID = this.scanString(reader);
+			this.skipWhitespace(reader, false);
+			systemID = this.scanString(reader);
+			this.skipWhitespace(reader, false);
+			this.readChar(reader, true);
+		}
+
+		else if (ch == 'S') {
+			if (this.readChar(reader, true) != 'Y') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'S') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'T') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'E') {
+				this.skipTag(reader);
+				return;
+			}
+
+			if (this.readChar(reader, true) != 'M') {
+				this.skipTag(reader);
+				return;
+			}
+
+			this.skipWhitespace(reader, false);
+			systemID = this.scanString(reader);
+			this.skipWhitespace(reader, false);
+			this.readChar(reader, true);
+
+		} else if (ch == '"' || ch == '\'') {
+			reader.unread(ch);
+
+			if (!entitySet.containsKey(key)) {
+				entitySet.put(key, this.scanString(reader));
+			}
+
+			this.skipWhitespace(reader, false);
+			this.readChar(reader, true);
+		} else {
+			this.skipTag(reader);
+		}
+        
+        if ((systemID != null) && (! entitySet.containsKey(key))) {
+            String[] value = new String[] { publicID, systemID };
+            entitySet.put(key, value);
+        }
+    }
+     
+
+    /**
+     * Reads a character, eventually resolving a parameter entity.
+     */
+    protected char readChar(IXMLReader reader,
+                            boolean    resolvePE)
+        throws IOException
+    {
+        if (reader.atEOFOfCurrentStream()) {
+            this.peLevel--;
+        }
+        
+        char ch = reader.read();
+        
+        if (resolvePE && (ch == '%')) {
+            this.peLevel++;
+            StringBuffer key = new StringBuffer();
+            ch = reader.read();
+            
+            while (ch != ';') {
+                key.append(ch);
+                ch = reader.read();
+            }
+            
+            Object value = this.parameterEntities.get(key.toString());
+            
+            if (value == null) {
+                throw new XMLParseException(reader.getLineNr(),
+                                            "Invalid entity: `&" + key + ";'");
+            } else if (value instanceof String) {
+                reader.startNewStream(new StringReader((String) value));
+                return this.readChar(reader, true);
+            } else {
+                String[] id = (String[]) value;
+                
+                try {
+                    reader.startNewStream(reader.openStream(id[0], id[1]));
+                    return this.readChar(reader, true);
+                } catch (Exception e) {
+                    throw new XMLParseException(reader.getLineNr(),
+                                                "Could not open " + id[1]);
+                }
+            }
+        } else {
+            return ch;
+        }
+    }
+    
+    
+    /**
+     * Skips the remainder of a comment.
+     * It is assumed that &lt;!- is already read.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected void skipComment(IXMLReader reader)
+        throws IOException
+    {
+        if (this.readChar(reader, true) != '-') {
+            this.skipTag(reader);
+            return;
+        }
+        
+        int dashesRead = 0;
+        
+        for (;;) {
+            char ch = this.readChar(reader, true);
+
+			if (ch == '-') {
+				dashesRead++;
+			}
+
+			else if (ch == '>') {
+				if (dashesRead == 2) {
+					return;
+				}
+				dashesRead = 0;
+			} else {
+				dashesRead = 0;
+			}
+        }
+    }
+    
+    
+    /**
+     * Skips the remainder of a tag.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected void skipTag(IXMLReader reader)
+        throws IOException
+    {
+        int level = 1;
+        
+        while (level > 0) {
+            char ch = this.readChar(reader, true);
+            
+			if (ch == '<') {
+				++level;
+			}
+
+			else if (ch == '>') {
+				--level;
+			} else {
+			}
+
+        }
+    }
+
+                         
+    /**
+     * Retrieves an identifier.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected String scanIdentifier(IXMLReader reader)
+        throws IOException
+    {
+        StringBuffer result = new StringBuffer();
+        
+        for (;;) {
+            char ch = this.readChar(reader, true);
+            
+            if ((ch == '_') || (ch == ':') || (ch == '-') || (ch == '.')
+                    || ((ch >= 'a') && (ch <= 'z'))
+                    || ((ch >= 'A') && (ch <= 'Z'))
+                    || ((ch >= '0') && (ch <= '9')) || (ch > '\u007E')) {
+                result.append(ch);
+            } else {
+                reader.unread(ch);
+                break;
+            }
+        }
+        
+        return result.toString();
+    }
+    
+    
+    /**
+     * Retrieves a delimited string.
+     *
+     * @param reader the reader to read the DTD from.
+     */
+    protected String scanString(IXMLReader reader)
+        throws IOException
+    {
+        StringBuffer result = new StringBuffer();
+        char delim = this.readChar(reader, true);
+        
+        if ((delim != '\'') && (delim != '"')) {
+            throw new XMLParseException(reader.getLineNr(),
+                                        "String need to be delimited");
+        }
+        
+        for (;;) {
+            char ch = this.readChar(reader, true);
+            
+            if (ch == delim) {
+                break;
+            } else {
+                result.append(ch);
+            }
+        }
+        
+        return result.toString();
+    }
+
+
+    /**
+     * Skips whitespace.
+     *
+     * @param reader the reader to read the DTD from.
+     * @param allowPercent if a '%' symbol is allowed here
+     */
+    protected void skipWhitespace(IXMLReader reader,
+                                  boolean    allowPercent)
+        throws IOException
+    {
+        char ch;
+        
+        do {
+            if ((peLevel <= 0) && reader.atEOFOfCurrentStream()) {
+                return;
+            }
+            
+            ch = this.readChar(reader, !allowPercent);
+        } while ((ch == ' ') || (ch == '\t') || (ch == '\n') || (ch == '\r'));
+        
+        reader.unread(ch);
+    }
+
+
+    /**
+     * Indicates that an element has been started.
+     *
+     * @param name the name of the element.
+     * @param lineNr the line number in the XML data of the element.
+     */
+    public void elementStarted(String name,
+                               int    lineNr)
+    {
+        Properties attribs
+                = (Properties) this.attributeDefaultValues.get(name);
+        
+        if (attribs == null) {
+            attribs = new Properties();
+        } else {
+            attribs = (Properties) attribs.clone();
+        }
+        
+        this.currentElements.push(attribs);
+    }
+    
+                             
+    /**
+     * Indicates that the current element has ended.
+     * If there are attributes with a default value which have not been
+     * specified yet, they have to be put into <I>extraAttributes</I>.
+     *
+     * @param name the name of the element.
+     * @param extraAttributes where to put extra attributes.
+     */
+    public void elementEnded(String name,
+                             Properties extraAttributes)
+    {
+        Properties props = (Properties) this.currentElements.pop();
+        Enumeration _enum = props.keys();
+        
+        while (_enum.hasMoreElements()) {
+            String key = (String) _enum.nextElement();
+            extraAttributes.put(key, props.get(key));
+        }
+    }
+    
+    
+    /**
+     * Indicates that an attribute has been added to the current element.
+     *
+     * @param key the name of the attribute.
+     * @param value the value of the attribute.
+     */
+    public void attributeAdded(String key,
+                               String value)
+    {
+        Properties props = (Properties) this.currentElements.peek();
+        
+        if (props.containsKey(key)) {
+            props.remove(key);
+        }
+    }
+    
+                             
+    /**
+     * Indicates that a new #PCDATA element has been encountered.
+     *
+     * @param lineNr the line number in the XML data of the element.
+     */
+    public void PCDataAdded(int lineNr)
+    {
+        // nothing to do
+    }
+
+
+    /**
+     * Returns a Java reader containing the value of an entity.
+     *
+     * @param xmlReader the current XML reader
+     * @param name the name of the entity.
+     *
+     * @return the reader, or null if the entity could not be resolved.
+     */
+    public Reader getEntity(IXMLReader xmlReader,
+                            String name)
+    {
+        Object obj = this.entities.get(name);
+        
+        if (obj == null) {
+            return null;
+        } else if (obj instanceof java.lang.String) {
+            return new StringReader((String)obj);
+        } else {
+            String[] id = (String[]) obj;
+            
+            try {
+                return xmlReader.openStream(id[0], id[1]);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/StdXMLBuilder.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/StdXMLBuilder.java
@@ -1,0 +1,220 @@
+/* StdXMLBuilder.java                                              NanoXML/Java
+ *
+ * $Revision: 1.4 $
+ * $Date: 2001/03/28 23:34:17 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Stack;
+
+
+/**
+ * StdXMLBuilder is a concrete implementation of IXMLBuilder which creates a
+ * tree of XMLElement from an XML data source.
+ *
+ * @see net.n3.nanoxmlModified.XMLElement
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.4 $
+ */
+public class StdXMLBuilder
+    implements IXMLBuilder
+{
+
+    /**
+     * This stack contains the current element and its parents.
+     */
+    private Stack stack;
+    
+    
+    /**
+     * The root element of the parsed XML tree.
+     */
+    private XMLElement root;
+    
+    
+    /**
+     * Creates the builder.
+     */
+    public StdXMLBuilder()
+    {
+        this.stack = null;
+        this.root = null;
+    }
+    
+    
+    /**
+     * This method is called before the parser starts processing its input.
+     *
+     * @param lineNr the line on which the parsing starts
+     */
+    public void startBuilding(int lineNr)
+    {
+        this.stack = new Stack();
+        this.root = null;
+    }
+    
+    
+    /**
+     * This method is called when a processing instruction is encountered.
+     * PIs with target "xml" are handled by the parser.
+     *
+     * @param target the PI target
+     * @param reader to read the data from the PI
+     */
+    public void newProcessingInstruction(String target,
+                                         Reader reader)
+        throws IOException
+    {
+        System.out.println("Processing instruction with target " + target);
+        // nothing to do
+    }
+    
+    
+    /**
+     * This method is called when a new XML element is encountered.
+     *
+     * @see #endElement
+     *
+     * @param name the non-null name of the element
+     * @param lineNr the line in the source where the element starts
+     */
+    public void startElement(String name,
+                             int    lineNr)
+    {
+        XMLElement elt = new XMLElement(name, lineNr);
+        
+        if (this.stack.empty()) {
+            this.root = elt;
+        } else {
+            XMLElement top = (XMLElement) this.stack.peek();
+            top.addChild(elt);
+        }
+        
+        this.stack.push(elt);
+    }
+    
+    
+    /**
+     * This method is called when the end of an XML elemnt is encountered.
+     *
+     * @see #startElement
+     *
+     * @param name the non-null name of the element
+     */
+    public void endElement(String name)
+    {
+        XMLElement elt = (XMLElement) this.stack.pop();
+        
+        if (elt.getChildrenCount() == 1) {
+            XMLElement child = elt.getChildAtIndex(0);
+            
+            if (child.getName() == null) {
+                elt.setContent(child.getContent());
+                elt.removeChildAtIndex(0);
+            }
+        }
+    }
+    
+    
+    /**
+     * This method is called when a new attribute of an XML element is 
+     * encountered.
+     *
+     * @param key the non-null key (name) of the attribute
+     * @param value the non-null value of the attribute
+     */
+    public void addAttribute(String key,
+                             String value)
+    {
+        XMLElement top = (XMLElement) this.stack.peek();
+        
+        if (top.hasAttribute(key)) {
+            throw new XMLParseException(top.getLineNr(),
+                                        "Duplicate attribute: " + key);
+        }
+        
+        top.setAttribute(key, value);
+    }
+    
+    
+    /**
+     * This method is called when a PCDATA element is encountered. A Java 
+     * reader is supplied from which you can read the data. The reader will
+     * only read the data of the element.
+     *
+     * @param reader the Java reader from which you can retrieve the data
+     * @param lineNr the line in the source where the element starts
+     *
+     * @throws java.io.IOException
+     *		when the reader throws such exception
+     */
+    public void addPCData(Reader reader,
+                          int    lineNr)
+        throws IOException
+    {
+        StringBuffer str = new StringBuffer();
+        
+        for (;;) {
+            int c = reader.read();
+            
+            if (c < 0) {
+                break;
+            }
+            
+            str.append((char) c);
+        }
+        
+        XMLElement elt = new XMLElement(null, lineNr);
+        elt.setContent(str.toString());
+        
+        if (! this.stack.empty()) {
+            XMLElement top = (XMLElement) this.stack.peek();
+            top.addChild(elt);
+        }
+    }
+
+
+    /**
+     * Returns the result of the building process. This method is called just
+     * before the parse() method of IXMLParser returns. This implementation
+     * returns an object of class XMLElement.
+     *
+     * @see net.n3.nanoxmlModified.IXMLParser#parse
+     * @see net.n3.nanoxmlModified.XMLElement
+     *
+     * @return the result of the building process.
+     */
+    public Object getResult()
+    {
+        return this.root;
+    }
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/StdXMLParser.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/StdXMLParser.java
@@ -1,0 +1,1225 @@
+
+/* StdXMLParser.java                                               NanoXML/Java
+ *
+ * $Revision: 1.6 $
+ * $Date: 2001/03/28 18:47:24 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+import java.io.IOException;
+import java.io.CharArrayReader;
+import java.io.Reader;
+import java.util.Enumeration;
+import java.util.Properties;
+
+
+/**
+ * StdXMLParser is the core parser of NanoXML.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.6 $
+ */
+public class StdXMLParser
+{
+
+    /**
+     * The builder which creates the logical structure of the XML data.
+     */
+//    protected IXMLBuilder builder;
+
+
+    /**
+     * The reader from which the parser retrieves its data.
+     */
+    protected StdXMLReader reader;
+
+
+    /**
+     * The validator that will process entity references and validate the XML
+     * data.
+     */
+//    protected IXMLValidator validator;
+
+
+    /**
+     * Creates a new parser.
+     */
+    public StdXMLParser()
+    {
+//        this.builder = null;
+//        this.validator = null;
+        this.reader = null;
+    }
+
+
+    /**
+     * Sets the builder which creates the logical structure of the XML data.
+     *
+     * @param builder the non-null builder
+     */
+    public void setBuilder(IXMLBuilder builder)
+    {
+//        this.builder = builder;
+    }
+
+
+    /**
+     * Sets the validator that will process entity references and validate the
+     * XML data.
+     *
+     * @param validator the non-null validator
+     */
+    public void setValidator(IXMLValidator validator)
+    {
+//        this.validator = validator;
+    }
+
+
+    /**
+     * Sets the reader from which the parser retrieves its data.
+     *
+     * @param reader the non-null reader
+     */
+    public void setReader(StdXMLReader reader)
+    {
+        this.reader = reader;
+    }
+
+
+    /**
+     * Parses the data and lets the builder create the logical data structure.
+     *
+     * @return the logical structure built by the builder
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    public Object parse() throws IOException
+    {
+//      this.builder.startBuilding(this.reader.getLineNr());
+        this.scanData();
+//        return this.builder.getResult();
+        return null;
+    }
+
+
+    /**
+     * Scans the XML data for elements.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void scanData() throws IOException
+    {
+    	boolean isEOF = this.reader.atEOF();
+        while (!isEOF) {
+            //
+        	char ch = this.read(null);
+			if (ch == '<') {
+				//CDATA begins with "<![CDATA[" and ends with "]]>"
+				//CDATA will not be parsed
+				//Process a Tag
+				this.scanSomeTag(false);
+			} 
+			else if (ch == ' '){
+				System.out.println("nothing!");
+			}
+			else if(ch == '\t'){
+				System.out.println("nothing!");
+			}
+			else if(ch == '\n'){
+				System.out.println("nothing!");
+			}
+			else if(ch == '\r'){
+				System.out.println("nothing!");
+			}
+			else {
+				System.out.println("unexpected:" + ch);
+			}
+			isEOF = this.reader.atEOF();
+        }
+    }
+
+
+    /**
+     * Scans an XML tag.
+     *
+     * @param allowCDATA true if CDATA sections are allowed at this point
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void scanSomeTag(boolean allowCDATA) throws IOException
+    {
+        char ch = this.read(null);
+        //<?xml version="1.0" encoding="UTF-8" ?>
+		if (ch == '?') {
+			this.processPI();
+		//Process <!DOCTYPE, <!-, <!D
+		} 
+		else if (ch == '!') {
+			this.processSpecialTag(allowCDATA);
+		}
+		else {
+			this.reader.unread(ch);
+			//
+			this.processElement();
+		}
+    }
+
+
+    /**
+     * Skips the remainder of a comment.
+     * It is assumed that &lt;!- is already read.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+    protected void skipComment() throws IOException
+    {
+    	char a = this.read(null);
+        if (a != '-') {
+            this.skipTag();
+        }
+        else{
+            int dashesRead = 0;
+            //
+            boolean continueIndex = true;
+            while(continueIndex){
+                char ch = this.read(null);
+    			if (ch == '-') {
+    				dashesRead = dashesRead + 1;
+    			}
+    			else if (ch == '>') {
+    				if (dashesRead == 2) {
+    					continueIndex = false;
+    				}
+    				dashesRead = 0;
+    			} 
+    			else {
+    				dashesRead = 0;
+    			}
+            }
+        }
+    }
+
+
+    /**
+     * Skips the remainder of the current XML tag.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void skipTag() throws IOException
+    {
+        int level = 1;
+        while (level > 0) {
+			char ch = this.read(null);
+
+			if (ch == '<') {
+				level = level + 1;
+			}
+
+			else if (ch == '>') {
+				level = level - 1;
+			}
+			else {
+				System.out.println("nothing!");
+			}
+        }
+    }
+
+    protected void skipInnerDTD() throws IOException
+    {
+        int level = 1;
+
+        while (level > 0) {
+			char ch = this.read(null);
+
+			if (ch == '[') {
+				level = level + 1;
+			}
+
+			else if (ch == ']') {
+				level = level - 1;
+			} 
+			else {
+				
+			}
+        }
+    }
+
+    /**
+     * Processes a "processing instruction".
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+//    <?xml version="1.0" encoding="UTF-8"?>
+//    <?xml-stylesheet type="text/xsl" href="show_book.xsl"?>
+    
+    protected void processPI() throws IOException
+    {
+    	
+//        this.skipWhitespace(null, null);
+//        String target = this.scanIdentifier();
+//        this.skipWhitespace(null, null);
+        //
+        Reader reader = new ContentReader(this, ">?", true, "");
+
+//        if (! equalsIgnoreCase(target)) {
+//            this.builder.newProcessingInstruction(target, reader);
+//        }
+        //read the left characters until ?>
+        reader.close();
+    }
+
+    /**
+     * 
+     * @param org
+     * @return
+     */
+    private boolean equalsIgnoreCase(String org){
+    	int length = org.length();
+    	if(length != 3){
+    		return false;
+    	}
+    	int i = 0;
+    	for(i = 0; i < 3; i++){
+    		char ch = org.charAt(i);
+    		char xml = "xml".charAt(i);
+    		int ret = compareNoCase(ch,xml);
+    		if(ret != 0){
+    			return false;
+    		}
+    	}
+    	return true;
+    }
+
+    private int compareNoCase(char ch, char org){
+    	if(ch == org){
+    		return 0;
+    	}
+    	char tempCh = (char)(ch - 'A' + 'a');
+    	if(tempCh == org){
+    		return 0;
+    	}
+    	tempCh  = (char)( ch - 'a' + 'A');
+    	if(tempCh == org){
+    		return 0;
+    	}
+    	return 1;
+    }
+
+    /**
+     * Processes a tag that starts with a bang (<!...>).
+     *
+     * @param allowCDATA true if CDATA sections are allowed at this point
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void processSpecialTag(boolean allowCDATA) throws IOException
+    {
+        char ch = this.read(null);
+        //"<![" is the prefix of CDATA
+		if (ch == '[') {
+			if (allowCDATA) {
+				this.processCDATA();
+			} 
+			else {
+				// skip one tag such as <....>
+				this.skipTag();
+			}
+			return;
+		}
+		//"<!D" is the prefix of <!DOCTYPE
+		else if (ch == 'D') {
+			this.processDocType();
+			return;
+		}
+		//
+		else if (ch == '-') {
+			this.skipComment();
+			return;
+		}
+		else {
+			System.out.println("nothing!");
+		}
+    }
+
+
+    /**
+     * Processes a CDATA section.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+    protected void processCDATA() throws IOException
+    {
+    	char a = this.read(null);
+        if (a != 'C') {
+        	this.skipTag();
+        }
+
+        char b = this.read(null);
+        if (b != 'D') {
+        	this.skipTag();
+        }
+
+        char c = this.read(null);
+        if (c != 'A') {
+        	this.skipTag();
+        }
+
+        char d = this.read(null);
+        if (d != 'T') {
+        	this.skipTag();
+        }
+
+        char e = this.read(null);
+        if (e != 'A') {
+        	this.skipTag();
+        }
+
+        char f = this.read(null);
+        if (f != '[') {
+        	this.skipTag();
+        }
+
+//        this.validator.PCDataAdded(this.reader.getLineNr());
+        Reader reader = new ContentReader(this, ">]]", true, "");
+        //
+//        readPCData(reader);
+//        this.builder.addPCData(reader, this.reader.getLineNr());
+        reader.close();
+    }
+
+
+    /**
+     * Processes a document type declaration.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void processDocType() throws IOException
+    {
+    	// http://msdn.microsoft.com/zh-cn/library/ms256059
+    	
+    	//http://blog.csdn.net/xia7139/article/details/9411001
+    	char a = this.read(null);
+        if (a != 'O') {
+        	this.skipTag();
+        }
+
+        char b = this.read(null);
+        if (b != 'C') {
+        	this.skipTag();
+        }
+
+        char c = this.read(null);
+        if (c != 'T') {
+        	this.skipTag();
+        }
+
+        char d = this.read(null);
+        if (d != 'Y') {
+        	this.skipTag();
+        }
+
+        char e = this.read(null);
+        if (e != 'P') {
+        	this.skipTag();
+        }
+
+        char f = this.read(null);
+        if (f != 'E') {
+        	this.skipTag();
+        }
+        String systemID = null;
+        StringBuffer publicID = new StringBuffer();
+        
+//        this.skipWhitespace(null, null);
+        //RootElement is required
+//        String rootElement = this.scanIdentifier();
+        char[] rootElement = this.scanIdentifier();
+//        this.skipWhitespace(null, null);
+        char ch = this.read(null);
+        
+        // <!DOCTYPE rootElement PUBLIC "PublicIdentifier" "URIreference">
+        if (ch == 'P') {
+            systemID = this.scanPublicID(publicID);
+//            this.skipWhitespace(null, null);
+            ch = this.read(null);
+        }
+        //<!DOCTYPE rootElement SYSTEM "URIreference">
+        else if (ch == 'S') {
+            systemID = this.scanSystemID();
+//            this.skipWhitespace(null, null);
+            ch = this.read(null);
+        }
+
+        // <!DOCTYPE rootElement [
+        //                        declarations
+        //                       ]>
+        if (ch == '[') {
+//            this.validator.parseDTD(publicID.toString(), this.reader);
+        	//
+        	this.skipInnerDTD();
+//            this.skipWhitespace(null, null);
+            ch = this.read(null);
+        }
+
+        if (ch != '>') {
+            this.errorExpectedInput(">");
+        }
+
+
+//        if (systemID != null) {
+//        	String p = publicID.toString();
+//            Reader reader = this.reader.openStream(p, systemID);
+//            this.reader.startNewStream(reader);
+//            this.validator.parseDTD(publicID.toString(), this.reader);
+//        }
+    }
+
+
+    /**
+     * Scans a public ID.
+     *
+     * @param publicID will contain the public ID
+     *
+     * @return the system ID
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+    protected String scanPublicID(StringBuffer publicID) throws IOException
+    {
+    	char a = this.read(null);
+        if (a != 'U') {
+        	return null;
+        }
+
+        char b = this.read(null);
+        if (b != 'B') {
+        	return null;
+        }
+
+        char c = this.read(null);
+        if (c != 'L') {
+        	return null;
+        }
+
+        char d = this.read(null);
+        if (d != 'I') {
+        	return null;
+        }
+
+        char e = this.read(null);
+        if (e != 'C') {
+        	return null;
+        }
+
+//        this.skipWhitespace(null, null);
+        String publicIdentity = this.scanString(false);
+        publicID.append(publicIdentity);
+//        this.skipWhitespace(null, null);
+        String systemIdentify = this.scanString(false);
+        return systemIdentify;
+    }
+
+
+    /**
+     * Scans a system ID.
+     *
+     * @return the system ID
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected String scanSystemID() throws IOException
+    {
+
+    	char a = this.read(null);
+        if (a != 'Y') {
+        	return null;
+        }
+
+        char b = this.read(null);
+        if (b != 'S') {
+        	return null;
+        }
+
+        char c = this.read(null);
+        if (c != 'T') {
+        	return null;
+        }
+
+        char d = this.read(null);
+        if (d != 'E') {
+        	return null;
+        }
+
+        char e = this.read(null);
+        if (e != 'M') {
+        	return null;
+        }
+
+//        this.skipWhitespace(null, null);
+        String systemIdentity = scanString(false);
+        return systemIdentity;
+    }
+
+
+    /**
+     * Processes a regular element.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void processElement() throws IOException
+    {
+    	//
+//        String name = this.scanIdentifier();
+        char[] name = this.scanIdentifier();
+//        this.skipWhitespace(null, null);
+//        this.validator.elementStarted(name, this.reader.getLineNr());
+//        this.builder.startElement(name, this.reader.getLineNr());
+        char ch = ' ';
+        boolean slashIndex = false;
+        boolean continueIndex = true;
+        while(continueIndex){
+        	ch = this.read(null);
+	        if (ch == '/') {
+	        	slashIndex = true;
+	            continueIndex = false;
+	        }
+	        else if(ch == '>'){
+	        	continueIndex = false;
+	        }
+	        else{
+	            this.reader.unread(ch);
+	            this.processAttribute();
+//	            this.skipWhitespace(null, null);  
+	        }
+        }
+        //
+        if (slashIndex) {
+        	char rightBracket = this.read(null);
+            if (rightBracket != '>') {
+                this.errorExpectedInput("'>'");
+            }
+            return;
+        }
+        //
+        StringBuffer whitespaceBuffer = new StringBuffer(16);
+        boolean angleIndex = true;
+        continueIndex = true;
+        while(continueIndex){
+            whitespaceBuffer.setLength(0);
+            //
+//            boolean fromEntity[] = new boolean[1];
+            //
+//            this.skipWhitespace(whitespaceBuffer, null);
+            ch = this.read(null);
+            boolean angleDetermine = true;
+            if(angleIndex){
+            	if(ch == '<'){
+            		angleDetermine = true;
+            	}
+            	else{
+            		angleDetermine = false;
+            	}
+            }
+            if (angleDetermine) {
+                ch = reader.read();
+                if (ch == '/') {
+//                    this.skipWhitespace(null, null);
+//                    String str = this.scanIdentifier();
+                    char[] str = this.scanIdentifier();
+                    //
+//                    boolean ret = str.equals(name);
+                    boolean ret = charArrayEquals(str, name);
+                    if (!ret) {
+                        this.errorWrongClosingTag(name, str);
+                    }
+//                    this.skipWhitespace(null, null);
+                    char a = this.read(null);
+                    if (a != '>') {
+                        this.errorClosingTagNotEmpty();
+                    }
+
+//                    Properties extraAttributes = new Properties();
+//                    this.validator.elementEnded(name, extraAttributes);
+//                    Enumeration _enum = extraAttributes.keys();
+//
+//                    while (_enum.hasMoreElements()) {
+//                        String key = (String) _enum.nextElement();
+//                        String value = extraAttributes.getProperty(key);
+//                        this.builder.addAttribute(key, value);
+//                    }
+//
+//                    this.builder.endElement(name);
+                    //
+                    continueIndex = false;
+                } 
+                else {
+                    this.reader.unread(ch);
+                    this.scanSomeTag(true);
+                }
+                angleIndex = true;
+            }
+            else {
+//                this.validator.PCDataAdded(this.reader.getLineNr());
+//                this.reader.unread(ch);
+                String s = whitespaceBuffer.toString();
+                Reader reader = new ContentReader(this, "<", false, s);
+                //
+//                readPCData(reader);
+//                this.builder.addPCData(reader, this.reader.getLineNr());
+                reader.close();
+                this.reader.unread('<');
+                angleIndex = false;
+            }
+        }
+    }
+
+    private boolean charArrayEquals(char[] str, char[] name) {
+        if (str.length != name.length) return false;
+        for (int i = 0; i < str.length; i++)
+            if (str[i] != name[i]) return false;
+        return true;
+    }
+
+//    public void readPCData(Reader reader) throws IOException
+//    {
+//    	StringBuffer str = new StringBuffer();
+//        
+//        boolean continueIndex = true;
+//        while(continueIndex){
+//            int c = reader.read();
+//            if (c < 0) {
+//                continueIndex = false;
+//            }
+//            else{
+//                char ch = (char) c;
+//                str.append(ch);
+//            }
+//
+//        }
+//    }
+
+
+    /**
+     * Processes an attribute of an element.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected void processAttribute() throws IOException
+    {
+//        String key = this.scanIdentifier();
+        char[] key = this.scanIdentifier();
+//        this.skipWhitespace(null, null);
+        char ch = this.read(null);
+        if (ch != '=') {
+            this.errorExpectedInput("'='");
+        }
+
+        String value = this.scanString(true);
+//        this.validator.attributeAdded(key, value);
+//        this.builder.addAttribute(key, value);
+    }
+
+
+    /**
+     * Retrieves an identifier from the data.
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+//    protected String scanIdentifier() throws IOException
+    protected char[] scanIdentifier() throws IOException
+    {
+//        StringBuffer result = new StringBuffer();
+        char result[] = new char[10];
+        int resultInd = 0;
+        boolean continueIndex = true;
+        while(continueIndex) {
+            char ch = this.read(null);
+
+            if (ch == '_') {
+//                result.append(ch);
+                result[resultInd++] = ch;
+            }
+            else if(ch == ':'){
+//            	result.append(ch);
+                result[resultInd++] = ch;
+            }
+            else if(ch == '-'){
+//            	result.append(ch);
+                result[resultInd++] = ch;
+            }
+            else if(ch == '.'){
+//            	result.append(ch);
+                result[resultInd++] = ch;
+            }
+            else if(ch > '\u007E'){
+//            	result.append(ch);
+                result[resultInd++] = ch;
+            }
+            else{
+            	boolean _isalnum = isalnum(ch);
+            	if(_isalnum){
+//            		result.append(ch);
+                    result[resultInd++] = ch;
+            	}
+            	else{
+//                    this.reader.unread(ch);
+                    continueIndex = false;
+            	}
+            }
+        }
+//        String ret = result.toString();
+        DumpXML.numIdentifiers += resultInd;
+//        return ret;
+        return result;
+    }
+    
+	private static boolean isalnum(char ch) {
+		if(ch >= '0'){
+			if(ch <= '9'){
+				return true;
+			}
+			else if (ch >= 'A'){
+				if(ch <= 'Z'){
+					return true;
+				}
+				else if(ch >= 'a'){
+					if(ch <= 'z'){
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+
+    /**
+     * Retrieves a delimited string from the data.
+     *
+     * @param normalizeWhitespace if all whitespace chars need to be converted
+     *                            to spaces
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+    protected String scanString(boolean normalizeWhitespace) throws IOException
+    {
+        StringBuffer result = new StringBuffer();
+        boolean isEntity[] = new boolean[1];
+        char delim = this.read(null);
+
+        if (delim != '\'') {
+        	if(delim != '"'){
+        		 this.errorExpectedInput("delimited string");
+        	}
+        }
+        boolean continueIndex = true;
+        while(continueIndex){
+            char ch = this.read(isEntity);
+//            //
+//            if (!isEntity[0]) {
+//            	if(ch == '&'){
+//                	Reader r = this.scanEntity(isEntity);
+//                    this.reader.startNewStream(r);
+//                    ch = this.reader.read();
+//            	}
+//            }
+            if (!isEntity[0]) {
+            	if(ch != delim){
+            		if(normalizeWhitespace){
+            			if(ch < ' '){
+            				 result.append(' ');
+            			}
+            			else{
+            				result.append(ch);
+            			}
+            		}
+            		else{
+            			result.append(ch);
+            		}
+            	}
+            	else{
+            		continueIndex = false;
+            	}
+            }
+            else{
+        		if(normalizeWhitespace){
+        			if(ch < ' '){
+        				 result.append(' ');
+        			}
+        			else{
+        				result.append(ch);
+        			}
+        		}
+        		else{
+        			result.append(ch);
+        		}
+            }
+        }
+        return result.toString();
+    }
+
+
+    /**
+     * Processes an entity.
+     *
+     * @return a reader from which the entity value can be retrieved
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    protected Reader scanEntity(boolean[] isCharLiteral) throws IOException
+    {
+        StringBuffer keyBuf = new StringBuffer();
+        
+        char ch = this.reader.read();
+        while (ch != ';') {
+            keyBuf.append(ch);
+            ch = this.reader.read();
+        }
+
+        String key = keyBuf.toString();
+        int _keySize = key.length();
+        if(_keySize == 0){
+        	throw new IOException("Unexpected the Defined Entity");
+        }
+        else{
+            char d = key.charAt(0);
+            //
+            //
+            if (d == '#') {
+                if (isCharLiteral != null) {
+                    isCharLiteral[0] = true;
+                }
+
+                char[] chArr = new char[1];
+                if(_keySize < 2){
+                	throw new IOException("Unexpected the Defined Entity");
+                }
+                else{
+                    char f = key.charAt(1);
+                    //
+                    if (f == 'x') {
+                    	String s = key.substring(2);
+                        chArr[0] = (char) parseInt(s,16);
+                    }
+                    else if(f == 'X'){
+                    	String s = key.substring(2);
+                        chArr[0] = (char) parseInt(s,16);
+                    }
+                    else {
+                    	String s = key.substring(1);
+                        chArr[0] = (char) parseInt(s,10);
+                    }
+
+                    return new CharArrayReader(chArr);
+                }
+
+            }
+            else {
+//                Reader entityReader = this.validator.getEntity(this.reader, key);
+//                if (entityReader == null) {
+//                    this.errorInvalidEntity(key);
+//                }
+//
+//                return entityReader;
+            	//
+            	//
+            	throw new IOException("Unexpected the Defined Entity that begins with charact!");
+            }
+        }
+    }
+
+
+    /**
+     * Skips whitespace from the reader.
+     *
+     * @param buffer where to put the whitespace; null if the whitespace does
+     *               not have to be stored.
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+//    protected void skipWhitespace(StringBuffer buffer, boolean[] isEntity) throws IOException
+//    {
+//        char ch = ' ';
+//        if (buffer == null) {
+//        	boolean continueIndex = true;
+//        	while(continueIndex){
+//            	ch = this.reader.read();
+//            	if(ch == ' '){
+//            		System.out.println("nothing!");
+//            	}
+//            	else if(ch == '\t'){
+//            		System.out.println("nothing!");
+//            	}
+//            	else if(ch == '\n'){
+//            		System.out.println("nothing!");
+//            	}
+//            	else if(ch == '\r'){
+//            		System.out.println("nothing!");
+//            	}
+//            	else{
+//            		continueIndex = false;
+//            	}
+//        	}
+//        } 
+//        else {
+//        	boolean continueIndex = true;
+//            while(continueIndex){
+//                ch = this.reader.read();
+//                if(ch == ' '){
+//                	 buffer.append(ch);
+//                }
+//                else if(ch == '\t'){
+//                	buffer.append(ch);
+//                }
+//                else if(ch == '\n'){
+//                	buffer.append(ch);
+//                }
+//                else if(ch == '\r'){
+//                	buffer.append(ch);
+//                }
+//                else{
+//                	continueIndex = false;
+//                }               
+//            }
+//        }
+//        this.reader.unread(ch);
+//    }
+
+
+    /**
+     * Reads a character from the reader.
+     *
+     * @param isEntityValue if the character is the first character in an
+     *                      entity
+     *
+     * @throws java.io.IOException
+     *		if an error occurred reading the data
+     */
+    //
+    //
+    //
+    protected char read(boolean[] isEntityValue) throws IOException
+    {
+    	//
+        char ch = this.reader.read();
+
+        if (isEntityValue != null) {
+            isEntityValue[0] = false;
+        }
+        // 
+        if (ch == '&') {
+            boolean[] charLiteral = new boolean[1];
+            charLiteral[0] = false;
+            //
+            //
+            Reader entityReader = this.scanEntity(charLiteral);
+            //
+            this.reader.startNewStream(entityReader);
+            //
+            if (charLiteral[0]){
+                ch = this.reader.read();
+
+                if (isEntityValue != null) {
+                    isEntityValue[0] = true;
+                }
+            } 
+            else {
+                ch = this.read(null);
+            }
+        }
+        return ch;
+    }
+
+
+    /**
+     * Throws an XMLParseException to indicate that an expected string is not
+     * encountered.
+     *
+     * @param expectedString the string that is expected
+     */
+    protected void errorExpectedInput(String expectedString)
+    {
+    	String str = "Expected: " + expectedString;
+//    	int nr = this.reader.getLineNr();
+//      throw new XMLParseException(nr,s);
+        throw new XMLParseException(str);
+    }
+
+
+    /**
+     * Throws an XMLParseException to indicate that a string is not expected
+     * at this point.
+     *
+     * @param unexpectedString the string that is unexpected
+     */
+    protected void errorInvalidInput(String unexpectedString)
+    {
+    	String str = "Invalid input: " + unexpectedString;
+//    	int nr = this.reader.getLineNr();
+//      throw new XMLParseException(nr, s);
+    	throw new XMLParseException(str);
+    }
+
+
+    /**
+     * Throws an XMLParseException to indicate that the closing tag of an
+     * element does not match the opening tag.
+     *
+     * @param expectedName the name of the opening tag
+     * @param wrongName the name of the closing tag
+     */
+//    protected void errorWrongClosingTag(String expectedName, String wrongName)
+    protected void errorWrongClosingTag(char[] expectedName, char[] wrongName)
+    {
+//    	int nr = this.reader.getLineNr();
+    	String str = "Closing tag does not match opening tag";
+//        throw new XMLParseException(nr, s);
+    	throw new XMLParseException(str);
+    }
+
+
+    /**
+     * Throws an XMLParseException to indicate that extra data is encountered
+     * in a closing tag.
+     */
+    protected void errorClosingTagNotEmpty()
+    {
+//    	int nr = this.reader.getLineNr();
+//        throw new XMLParseException(nr, "Closing tag must be empty");
+    	throw new XMLParseException("Closing tag must be empty");
+    }
+
+
+    /**
+     * Throws an XMLParseException to indicate that an entity could not be
+     * resolved.
+     *
+     * @param key the name of the entity
+     */
+    protected void errorInvalidEntity(String key)
+    {
+//    	int nr = this.reader.getLineNr();
+    	String str = "Invalid entity";
+//        throw new XMLParseException(nr, s);
+    	throw new XMLParseException(str);
+    }
+
+
+    /**
+     * This reader reads data from another reader until a certain string is
+     * encountered.
+     *
+     * @author Marc De Scheemaecker
+     * @version $Name: PRERELEASE_2_0_20010329 $, $Version$
+     */
+
+    //
+    private static int parseInt(String str, int base){
+    	if(base != 16 && base != 10){
+    		throw new RuntimeException("Unsupported in parseInt");
+    	}
+    	int result = 0;
+    	int length = str.length();
+    	
+    	int intArray[] = new int[length];
+    	//
+    	for(int i = 0; i < length;){
+    		char ch = str.charAt(i);
+    		int temp = 0;
+    		if(ch >= '0'){
+    			if(ch <= '9'){
+    				temp = ch -'0';
+    			}
+    			else{
+    				if(ch >= 'A'){
+    	    			if(ch <= 'E'){
+    	    				temp = ch - 'A' + 10;
+    	    			}
+    	    			else{
+    	    				if(ch >= 'a'){
+    	    					if(ch <= 'e'){
+    	    						temp = ch - 'a' + 10;
+    	    					}
+    	    					else{
+    	    						throw new NumberFormatException();
+    	    					}
+    	    				}
+    	    				else{
+    	    					throw new NumberFormatException();
+    	    				}
+    	    			}
+    				}
+    				else{
+    					throw new NumberFormatException();
+    				}
+    			}
+    		}
+    		else{
+    			throw new NumberFormatException();
+    		}
+    		intArray[i] = temp;
+    		i = i + 1;
+    	}
+    	//
+    	for(int i=0; i<length;){
+    		for(int j=0; j<i;){
+    			int temp = intArray[j];
+    			temp = temp * base;
+    			intArray[j] = temp;
+    			j = j + 1;
+    		}
+    		i = i + 1;
+    	}
+    	//
+    	for(int i=0; i<length;){
+    		result = result + intArray[i];
+    		i = i + 1;
+    	}
+    	return result;
+    }
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/StdXMLReader.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/StdXMLReader.java
@@ -1,0 +1,252 @@
+/* StdXMLReader.java                                               NanoXML/Java
+ *
+ * $Revision: 1.5 $
+ * $Date: 2001/03/28 23:34:17 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.io.LineNumberReader;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Stack;
+
+/**
+ * StdXMLReader reads the data to be parsed.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.5 $
+ */
+public class StdXMLReader
+{
+
+    /**
+     * The stack of push-back readers.
+     */
+    private Stack pbreaders;
+    
+    
+    /**
+     * The stack of line-number readers.
+     */
+//    private Stack linereaders;
+    
+    
+    /**
+     * The current push-back reader.
+     */
+    private PushbackReader currentPbReader;
+    
+    
+    /**
+     * The current line-number reader.
+     */
+//    private LineNumberReader currentLineReader;
+    
+    
+    /**
+     * Creates a new reader using a string as input.
+     *
+     * @param str the string containing the XML data
+     */
+    public static StdXMLReader stringReader(String str)
+    {
+    	StringReader s = new StringReader(str);
+        return new StdXMLReader(s);
+    }
+    
+    
+    /**
+     * Initializes the XML reader.
+     *
+     * @param reader the input for the XML data.
+     */
+    public StdXMLReader(Reader reader)
+    {
+//        this.currentLineReader = new LineNumberReader(reader);
+//        this.currentPbReader = new PushbackReader(this.currentLineReader, 2);
+//        this.pbreaders = new Stack();
+//        this.linereaders = new Stack();
+      this.currentPbReader = new PushbackReader(reader, 2);
+      this.pbreaders = new Stack();
+    	
+    }
+    
+    
+    /**
+     * Reads a character.
+     *
+     * @return the character
+     *
+     * @throws java.io.IOException
+     *		if no character could be read
+     */
+    public char read() throws IOException
+    {
+        int ch = this.currentPbReader.read();
+        
+        while (ch < 0) {
+        	boolean isEmpty = this.pbreaders.empty();
+            if (isEmpty) {
+                throw new IOException("Unexpected EOF");
+            }
+            
+            this.currentPbReader.close();
+            this.currentPbReader = (PushbackReader) this.pbreaders.pop();
+//            this.currentLineReader = (LineNumberReader) this.linereaders.pop();
+            ch = this.currentPbReader.read();
+        }
+        
+        //
+//        if (ch == 0x0D) { // CR
+//            ch = this.read();
+//            
+//            if (ch != 0x0A) {
+//                this.currentPbReader.unread(ch);
+//                return (char) 0x0A;
+//            }
+//        }
+                
+        return (char) ch;
+    }
+        
+    
+    /**
+     * Returns true if the current stream has no more characters left to be
+     * read.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public boolean atEOFOfCurrentStream() throws IOException
+    {
+        int ch = this.currentPbReader.read();
+        
+        if (ch < 0) {
+            return true;
+        }
+        else {
+            this.currentPbReader.unread(ch);
+            return false;
+        }
+    }
+    
+    
+    /**
+     * Returns true if there are no more characters left to be read.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public boolean atEOF() throws IOException
+    {
+    	//
+        int ch = this.currentPbReader.read();
+        //
+        while (ch < 0) {
+        	boolean isEmpty = this.pbreaders.empty();
+        	if(isEmpty){
+                return true;
+            }
+            this.currentPbReader.close();
+            this.currentPbReader = (PushbackReader) this.pbreaders.pop();
+//            this.currentLineReader = (LineNumberReader) this.linereaders.pop();
+            ch = this.currentPbReader.read();
+        }
+        //
+        this.currentPbReader.unread(ch);
+        return false;
+    }
+        
+    
+    /**
+     * Pushes the last character read back to the stream.
+     *
+     * @throws java.io.IOException
+     *		if an I/O error occurred
+     */
+    public void unread(char ch) throws IOException
+    {
+        this.currentPbReader.unread(ch);
+    }
+
+
+    /**
+     * Opens a stream from a public and system ID.
+     *
+     * @param publicID the public ID, which may be null
+     * @param systemID the system ID, which is never null
+     *
+     * @throws MalformedURLException
+     *		if the system ID does not contain a valid URL
+     * @throws FileNotFoundException
+     *		if the system ID refers to a local file which does not exist
+     * @throws IOException
+     *		if an error occurred opening the stream
+     */
+    public Reader openStream(String publicID, String systemID) throws MalformedURLException, FileNotFoundException, IOException
+    {   //added line here to make it work
+        systemID="file:"+systemID;
+        URL url = new URL(systemID);
+        InputStream input = url.openStream();
+        return new InputStreamReader(input);
+    }
+    
+    
+    /**
+     * Starts a new stream from a Java reader. The new stream is used
+     * temporary to read data from. If that stream is exhausted, control
+     * returns to the parent stream.
+     *
+     * @param reader the non-null reader to read the new data from
+     */
+    //
+    public void startNewStream(Reader reader)
+    {
+        this.pbreaders.push(this.currentPbReader);
+        this.currentPbReader = new PushbackReader(reader, 2);
+//        this.pbreaders.push(this.currentPbReader);
+//        this.linereaders.push(this.currentLineReader);
+//        this.currentLineReader = new LineNumberReader(reader);
+//        this.currentPbReader = new PushbackReader(this.currentLineReader, 2);
+    }
+    
+    
+    /**
+     * Returns the line number of the data in the current stream.
+     */
+//    public int getLineNr()
+//    {
+//    	int line  = this.currentLineReader.getLineNumber();
+//    	line = line + 1;
+//        return line;
+//    }
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/TestVeritestingDumpXML.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/TestVeritestingDumpXML.java
@@ -1,0 +1,58 @@
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+import java.util.ArrayList;
+
+public class TestVeritestingDumpXML {
+
+    void testHarness(Main v) {
+        char c0 = Verifier.nondetChar();
+        char c1 = Verifier.nondetChar();
+        char c2 = Verifier.nondetChar();
+        char c3 = Verifier.nondetChar();
+        char c4 = Verifier.nondetChar();
+        char c5 = Verifier.nondetChar();
+        char c6 = Verifier.nondetChar();
+        char c7 = Verifier.nondetChar();
+        char c8 = Verifier.nondetChar();
+        int outSPF = SPFWrapper(v, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+        int outJR = JRWrapper(v, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+        checkEquality(outSPF, outJR);
+    }
+
+    public void checkEquality(int outSPF, int outJR) {
+        if (outSPF == outJR) System.out.println("Match");
+        else {
+            System.out.println("Mismatch");
+            assert(false);
+        }
+//        assert(outSPF == outJR);
+    }
+
+    public int SPFWrapper(Main v, char c0, char c1, char c2, char c3, char c4, char c5,
+                                        char c6, char c7, char c8) {
+        return NonVeritest(v, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+    }
+
+    // This is a special method. Call this method to prevent SPF from veritesting any regions that appear in any
+    // function or method call higher up in the stack. In the future, this call to SPFWrapperInner can be changed to
+    // be a generic method call if other no-veritesting methods need to be invoked.
+    private int NonVeritest(Main v, char c0, char c1, char c2, char c3, char c4, char c5,
+                                         char c6, char c7, char c8){
+        return SPFWrapperInner(v, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+    }
+
+    private int SPFWrapperInner(Main v, char c0, char c1, char c2, char c3, char c4, char c5,
+                                              char c6, char c7, char c8) {
+        int ret = v.testFunction(c0, c1, c2, c3, c4, c5, c6, c7, c8);
+        return ret;
+    }
+
+    public int JRWrapper(Main v, char c0, char c1, char c2, char c3, char c4, char c5, char c6,
+                                       char c7, char c8) {
+        return v.testFunction(c0, c1, c2, c3, c4, c5, c6, c7, c8);
+    }
+
+    public void runTest(Main t) {
+        testHarness(t);
+    }
+};

--- a/java/java-ranger-regression/nanoxml_eqchk/XMLElement.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/XMLElement.java
@@ -1,0 +1,449 @@
+/* XMLElement.java                                                 NanoXML/Java
+ *
+ * $Revision: 1.2 $
+ * $Date: 2001/03/28 19:21:03 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.Serializable;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Properties;
+import java.util.Vector;
+
+
+/**
+ * XMLElement is an XML element. The standard NanoXML builder generates a
+ * tree of such elements.
+ *
+ * @see net.n3.nanoxmlModified.StdXMLBuilder
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.2 $
+ */
+public class XMLElement
+    implements Serializable
+{
+    
+    /**
+     * Necessary for serialization.
+     */
+    static final long serialVersionUID = -2383376380548624920L;
+    
+    
+    /**
+     * No line number defined.
+     */
+    public static final int NO_LINE = -1;
+    
+    
+    /**
+     * The attributes of the element.
+     */
+    private Properties attributes;
+    
+    
+    /**
+     * The child elements.
+     */
+    private Vector children;
+    
+    
+    /**
+     * The name of the element.
+     */
+    private String name;
+    
+    
+    /**
+     * The content of the element.
+     */
+    private String content;
+    
+    
+    /**
+     * The line in the source data where this element starts.
+     */
+    private int lineNr;
+    
+    
+    /**
+     * Creates an empty element to be used for #PCDATA content.
+     */
+    public XMLElement()
+    {
+        this(null, NO_LINE);
+    }
+    
+    
+    /**
+     * Creates an empty element.
+     *
+     * @param name the name of the element.
+     */
+    public XMLElement(String name)
+    {
+        this(name, NO_LINE);
+    }
+    
+    
+    /**
+     * Creates an empty element.
+     *
+     * @param name the name of the element.
+     * @param lineNr the line in the XML data where the element starts.
+     */
+    public XMLElement(String name,
+                      int    lineNr)
+    {
+        this.attributes = new Properties();
+        this.children = new Vector(8);
+        this.name = name;
+        this.content = null;
+        this.lineNr = lineNr;
+    }
+    
+    
+    /**
+     * Returns the name of the element.
+     *
+     * @return the name, or null if the element only contains #PCDATA.
+     */
+    public String getName()
+    {
+        return this.name;
+    }
+    
+    
+    /**
+     * Sets the name.
+     *
+     * @param name the non-null name.
+     */
+    public void setName(String name)
+    {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null");
+        }
+        
+        this.name = name;
+    }
+    
+    
+    /**
+     * Adds a child element.
+     *
+     * @param child the non-null child to add.
+     */
+    public void addChild(XMLElement child)
+    {
+        if (child == null) {
+            throw new IllegalArgumentException("child must not be null");
+        }
+        
+        if ((child.getName() == null) && (! this.children.isEmpty())) {
+            XMLElement lastChild = (XMLElement) this.children.lastElement();
+            
+            if (lastChild.getName() == null) {
+                lastChild.setContent(lastChild.getContent()
+                                     + child.getContent());
+                return;
+            }
+        }
+        
+        this.children.addElement(child);
+    }
+    
+    
+    /**
+     * Removes a child element.
+     *
+     * @param child the non-null child to remove.
+     */
+    public void removeChild(XMLElement child)
+    {
+        if (child == null) {
+            throw new IllegalArgumentException("child must not be null");
+        }
+        
+        this.children.removeElement(child);
+    }
+    
+    
+    /**
+     * Removes the child located at a certain index.
+     *
+     * @param index the index of the child, where the first child has index 0.
+     */
+    public void removeChildAtIndex(int index)
+    {
+        this.children.removeElementAt(index);
+    }
+    
+    
+    /**
+     * Returns an _enumeration of all child elements.
+     *
+     * @return the non-null _enumeration
+     */
+    public Enumeration _enumerateChildren()
+    {
+        return this.children.elements();
+    }
+    
+    
+    /**
+     * Returns whether the element is a leaf element.
+     *
+     * @return true if the element has no children.
+     */
+    public boolean isLeaf()
+    {
+        return this.children.isEmpty();
+    }
+    
+    
+    /**
+     * Returns whether the element has children.
+     *
+     * @return true if the element has children.
+     */
+    public boolean hasChildren()
+    {
+        return (! this.children.isEmpty());
+    }
+    
+    
+    /**
+     * Returns the number of children.
+     *
+     * @return the count.
+     */
+    public int getChildrenCount()
+    {
+        return this.children.size();
+    }
+    
+    
+    /**
+     * Returns a vector containing all the child elements.
+     *
+     * @return the vector.
+     */
+    public Vector getChildren()
+    {
+        return this.children;
+    }
+    
+    
+    /**
+     * Returns the child at a specific index.
+     *
+     * @return the non-null child
+     *
+     * @throws java.lang.ArrayIndexOutOfBoundsException
+     *		if the index is out of bounds.
+     */
+    public XMLElement getChildAtIndex(int index)
+        throws ArrayIndexOutOfBoundsException
+    {
+        return (XMLElement) this.children.elementAt(index);
+    }
+    
+    
+    /**
+     * Searches a child element.
+     *
+     * @param name the name of the child to search for.
+     *
+     * @return the child element, or null if no such child was found.
+     */
+    public XMLElement getFirstChildNamed(String name)
+    {
+        Enumeration _enum = this.children.elements();
+        
+        while (_enum.hasMoreElements()) {
+            XMLElement child = (XMLElement) _enum.nextElement();
+            
+            if (child.getName().equals(name)) {
+                return child;
+            }
+        }
+        
+        return null;
+    }
+    
+    
+    /**
+     * Returns a vector of all child elements named <I>name</I>.
+     *
+     * @param name the name of the children to search for.
+     *
+     * @return the non-null vector of child elements.
+     */
+    public Vector getChildrenNamed(String name)
+    {
+        Vector result = new Vector(this.children.size());
+        Enumeration _enum = this.children.elements();
+        
+        while (_enum.hasMoreElements()) {
+            XMLElement child = (XMLElement) _enum.nextElement();
+            
+            if (child.getName().equals(name)) {
+                result.addElement(child);
+            }
+        }
+        
+        return result;
+    }
+
+
+    /**
+     * Returns the value of an attribute.
+     *
+     * @param name the non-null name of the attribute.
+     *
+     * @return the value, or null if the attribute does not exist.
+     */
+    public String getAttribute(String name)
+    {
+        return this.getAttribute(name, null);
+    }
+    
+    
+    /**
+     * Returns the value of an attribute.
+     *
+     * @param name the non-null name of the attribute.
+     * @param defaultValue the default value of the attribute.
+     *
+     * @return the value, or defaultValue if the attribute does not exist.
+     */
+    public String getAttribute(String name,
+                               String defaultValue)
+    {
+        return this.attributes.getProperty(name, defaultValue);
+    }
+    
+    
+    /**
+     * Sets an attribute.
+     *
+     * @param name the non-null name of the attribute.
+     * @param value the non-null value of the attribute.
+     */
+    public void setAttribute(String name,
+                             String value)
+    {
+        this.attributes.put(name, value);
+    }
+    
+    
+    /**
+     * Removes an attribute.
+     *
+     * @param name the non-null name of the attribute.
+     */
+    public void removeAttribute(String name)
+    {
+        this.attributes.remove(name);
+    }
+    
+    
+    /**
+     * Returns an _enumeration of all attribute names.
+     *
+     * @return the non-null _enumeration.
+     */
+    public Enumeration _enumerateAttributeNames()
+    {
+        return this.attributes.keys();
+    }
+    
+    
+    /**
+     * Returns whether an attribute exists.
+     *
+     * @return true if the attribute exists.
+     */
+    public boolean hasAttribute(String name)
+    {
+        return this.attributes.containsKey(name);
+    }
+    
+    
+    /**
+     * Returns all attributes as a Properties object.
+     *
+     * @return the non-null set.
+     */
+    public Properties getAttributes()
+    {
+        return this.attributes;
+    }
+
+
+    /**
+     * Returns the line number in the data where the element started.
+     *
+     * @return the line number, or NO_LINE if unknown.
+     *
+     * @see #NO_LINE
+     */
+    public int getLineNr()
+    {
+        return this.lineNr;
+    }
+    
+    
+    /**
+     * Return the #PCDATA content of the element. If the element has a
+     * combination of #PCDATA content and child elements, the #PCDATA
+     * sections can be retrieved as unnamed child objects. In this case,
+     * this method returns null.
+     *
+     * @return the content.
+     */
+    public String getContent()
+    {
+        return this.content;
+    }
+    
+    
+    /**
+     * Sets the #PCDATA content. It is an error to call this method with a
+     * non-null value if there are child objects.
+     *
+     * @param content the (possibly null) content.
+     */
+    public void setContent(String content)
+    {
+        this.content = content;
+    }
+    
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/XMLParseException.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/XMLParseException.java
@@ -1,0 +1,86 @@
+/* XMLParseException.java                                          NanoXML/Java
+ *
+ * $Revision: 1.1.1.1 $
+ * $Date: 2001/03/19 18:08:54 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+/**
+ * An XMLParseException is thrown when the XML passed to the XML parser is not
+ * well-formed.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.1.1.1 $
+ */
+public class XMLParseException
+    extends RuntimeException
+{
+
+    /**
+     * The line number in the XML data where the exception occurred.
+     */
+    private int lineNr;
+    
+    
+    /**
+     * Creates a new exception.
+     *
+     * @param msg the message of the exception.
+     */
+    public XMLParseException(String msg)
+    {
+        super(msg);
+        this.lineNr = -1;
+    }
+    
+    
+    /**
+     * Creates a new exception.
+     *
+     * @param lineNr the line number in the XML data where the exception 
+     *               occurred.
+     * @param msg the message of the exception.
+     */
+    public XMLParseException(int    lineNr,
+                             String msg)
+    {
+        super("XML Not Well-Formed at Line " + lineNr + ": " + msg);
+        this.lineNr = lineNr;
+    }
+    
+    
+    /**
+     * Returns the line number in the XML data where the exception occurred.
+     * If there is no line number known, -1 is returned.
+     */
+    public int getLineNr()
+    {
+        return this.lineNr;
+    }
+    
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/XMLParserFactory.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/XMLParserFactory.java
@@ -1,0 +1,172 @@
+/* XMLParserFactory.java                                           NanoXML/Java
+ *
+ * $Revision: 1.2 $
+ * $Date: 2001/03/28 19:48:08 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.IOException;
+
+
+/**
+ * Creates an XML parser.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.2 $
+ */
+public class XMLParserFactory
+{
+
+    /**
+     * The class name of the default XML parser.
+     */
+    public static final String DEFAULT_CLASS = "net.n3.nanoxml.StdXMLParser";
+    
+    
+    /**
+     * The class name of the default XML validator.
+     */
+    public static final String VALIDATOR_CLASS = "net.n3.nanoxml.NonValidator";
+    
+    
+    /**
+     * The Java properties key of the XML parser class name.
+     */
+    public static final String CLASS_KEY = "net.n3.nanoxml.XMLParser";
+    
+    
+    /**
+     * Creates a default parser.
+     *
+     * @see #DEFAULT_CLASS
+     * @see #VALIDATOR_CLASS
+     * @see #CLASS_KEY
+     *
+     * @return the non-null parser.
+     *
+     * @throws java.lang.ClassNotFoundException
+     *		if the class of the parser or validator could not be found.
+     * @throws java.lang.InstantiationException
+     *		if the parser could not be created
+     * @throws java.lang.IllegalAccessException
+     *		if the parser could not be created
+     */
+    public static IXMLParser createDefaultXMLParser()
+        throws ClassNotFoundException,
+               InstantiationException,
+               IllegalAccessException
+    {
+        String className = System.getProperty(XMLParserFactory.CLASS_KEY,
+                                              XMLParserFactory.DEFAULT_CLASS);
+        return XMLParserFactory.createXMLParser(className,
+                                                new StdXMLBuilder(),
+                                                null, null);
+    }
+    
+    
+    /**
+     * Creates a default parser.
+     *
+     * @see #DEFAULT_CLASS
+     * @see #CLASS_KEY
+     *
+     * @param builder the XML builder.
+     * @param reader the XML reader.
+     * @param validator the XML validator.
+     *
+     * @return the non-null parser.
+     *
+     * @throws java.lang.ClassNotFoundException
+     *		if the class of the parser could not be found.
+     * @throws java.lang.InstantiationException
+     *		if the parser could not be created
+     * @throws java.lang.IllegalAccessException
+     *		if the parser could not be created
+     */
+    public static IXMLParser createDefaultXMLParser(IXMLBuilder   builder,
+                                                    IXMLReader    reader,
+                                                    IXMLValidator validator)
+        throws ClassNotFoundException,
+               InstantiationException,
+               IllegalAccessException
+    {
+        String className = System.getProperty(XMLParserFactory.CLASS_KEY,
+                                              XMLParserFactory.DEFAULT_CLASS);
+        return XMLParserFactory.createXMLParser(className, builder, reader,
+                                                validator);
+    }
+    
+    
+    /**
+     * Creates a parser.
+     *
+     * @param className the name of the class of the XML parser
+     * @param builder the XML builder.
+     * @param reader the XML reader.
+     * @param validator the XML validator.
+     *
+     * @return the non-null parser.
+     *
+     * @throws java.lang.ClassNotFoundException
+     *		if the class of the parser could not be found.
+     * @throws java.lang.InstantiationException
+     *		if the parser could not be created
+     * @throws java.lang.IllegalAccessException
+     *		if the parser could not be created
+     */
+    public static IXMLParser createXMLParser(String className,
+                                             IXMLBuilder builder,
+                                             IXMLReader  reader,
+                                             IXMLValidator validator)
+        throws ClassNotFoundException,
+               InstantiationException,
+               IllegalAccessException
+    {
+        Class cls = Class.forName(className);
+        IXMLParser parser = (IXMLParser) cls.newInstance();
+        parser.setBuilder(builder);
+        
+        if (validator == null) {
+            try {
+                cls = Class.forName(XMLParserFactory.VALIDATOR_CLASS);
+                validator = (IXMLValidator) cls.newInstance();
+            } catch (Exception e) {
+                // we can safely ignore any exceptions here
+            }
+        }
+        
+        parser.setValidator(validator);
+        
+        if (reader != null) {
+            parser.setReader(reader);
+        }
+        
+        return parser;
+    }
+
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/XMLValidationException.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/XMLValidationException.java
@@ -1,0 +1,192 @@
+/* XMLValidationException.java                                     NanoXML/Java
+ *
+ * $Revision: 1.1.1.1 $
+ * $Date: 2001/03/19 18:08:54 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+/**
+ * An XMLValidationException is thrown when the XML passed to the XML parser is
+ * well-formed but not valid.
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.1.1.1 $
+ */
+public class XMLValidationException
+    extends RuntimeException
+{
+
+    /**
+     * An element was missing.
+     */
+    public static final int MISSING_ELEMENT = 1;
+    
+    
+    /**
+     * An unexpected element was encountered.
+     */
+    public static final int UNEXPECTED_ELEMENT = 2;
+    
+    
+    /**
+     * An attribute was missing.
+     */
+    public static final int MISSING_ATTRIBUTE = 3;
+    
+    
+    /**
+     * An unexpected attribute was encountered.
+     */
+    public static final int UNEXPECTED_ATTRIBUTE = 4;
+    
+    
+    /**
+     * An attribute has an invalid value.
+     */
+    public static final int ATTRIBUTE_WITH_INVALID_VALUE = 5;
+    
+    
+    /**
+     * A PCDATA element was missing.
+     */
+    public static final int MISSING_PCDATA = 6;
+    
+    
+    /**
+     * An unexpected PCDATA element was encountered.
+     */
+    public static final int UNEXPECTED_PCDATA = 7;
+    
+    
+    /**
+     * Another error than those specified in this class was encountered.
+     */
+    public static final int MISC_ERROR = 0;
+    
+    
+    /**
+     * Which error occurred.
+     */
+    private int errorType;
+    
+    
+    /**
+     * The line number in the XML data where the exception occurred.
+     */
+    private int lineNr;
+    
+    
+    /**
+     * The name of the element where the exception occurred.
+     */
+    private String elementName;
+    
+    
+    /**
+     * The name of the attribute where the exception occurred.
+     */
+    private String attributeName;
+    
+    
+    /**
+     * The value of the attribute where the exception occurred.
+     */
+    private String attributeValue;
+    
+    
+    /**
+     * Creates a new exception.
+     *
+     * @param errorType the type of validity error
+     * @param lineNr the line number in the XML data where the exception 
+     *               occurred.
+     * @param elementName the name of the offending element
+     * @param attributeName the name of the offending attribute
+     * @param attributeValue the value of the offending attribute
+     * @param msg the message of the exception.
+     */
+    public XMLValidationException(int    errorType,
+                                  int    lineNr,
+                                  String elementName,
+                                  String attributeName,
+                                  String attributeValue,
+                                  String msg)
+    {
+        super("XML Not Valid at Line " + lineNr + ": " + msg
+              + "(type=" + errorType
+              + ((elementName == null) ? "" : (", element: " + elementName))
+              + ((attributeName == null) ? ""
+                    : (", attribute: " + attributeName + "=" + attributeValue))
+              + ")");
+        this.lineNr = lineNr;
+        this.elementName = elementName;
+        this.attributeName = attributeName;
+        this.attributeValue = attributeValue;
+    }
+    
+    
+    /**
+     * Returns the line number in the XML data where the exception occurred.
+     * If there is no line number known, -1 is returned.
+     */
+    public int getLineNr()
+    {
+        return this.lineNr;
+    }
+    
+    
+    /**
+     * Returns the name of the element in which the validation is violated.
+     * If there is no current element, null is returned.
+     */
+    public String getElementName()
+    {
+        return this.elementName;
+    }
+    
+    
+    /**
+     * Returns the name of the attribute in which the validation is violated.
+     * If there is no current attribute, null is returned.
+     */
+    public String getAttributeName()
+    {
+        return this.attributeName;
+    }
+    
+    
+    /**
+     * Returns the value of the attribute in which the validation is violated.
+     * If there is no current attribute, null is returned.
+     */
+    public String getAttributeValue()
+    {
+        return this.attributeValue;
+    }
+    
+}

--- a/java/java-ranger-regression/nanoxml_eqchk/XMLWriter.java
+++ b/java/java-ranger-regression/nanoxml_eqchk/XMLWriter.java
@@ -1,0 +1,190 @@
+/* XMLWriter.java                                                  NanoXML/Java
+ *
+ * $Revision: 1.3 $
+ * $Date: 2001/03/28 20:50:48 $
+ * $Name: PRERELEASE_2_0_20010329 $
+ *
+ * This file is part of NanoXML 2 for Java.
+ * Copyright (C) 2001 Marc De Scheemaecker, All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *  1. The origin of this software must not be misrepresented; you must not
+ *     claim that you wrote the original software. If you use this software in
+ *     a product, an acknowledgment in the product documentation would be
+ *     appreciated but is not required.
+ *
+ *  2. Altered source versions must be plainly marked as such, and must not be
+ *     misrepresented as being the original software.
+ *
+ *  3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+
+
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Enumeration;
+
+
+/**
+ * An XMLWriter writes XML data to a stream.
+ *
+ * @see net.n3.nanoxmlModified.XMLElement
+ * @see java.io.Writer
+ *
+ * @author Marc De Scheemaecker
+ * @version $Name: PRERELEASE_2_0_20010329 $, $Revision: 1.3 $
+ */
+public class XMLWriter
+{
+    
+    /**
+     * Where to write the output to.
+     */
+    private PrintWriter writer;
+    
+    
+    /**
+     * Creates a new XML writer.
+     *
+     * @param writer where to write the output to.
+     */
+    public XMLWriter(Writer writer)
+    {
+        if (writer instanceof PrintWriter) {
+            this.writer = (PrintWriter) writer;
+        } else {
+            this.writer = new PrintWriter(writer);
+        }
+    }
+    
+    
+    /**
+     * Creates a new XML writer.
+     *
+     * @param stream where to write the output to.
+     */
+    public XMLWriter(OutputStream stream)
+    {
+        this.writer = new PrintWriter(stream);
+    }
+    
+    
+    /**
+     * Writes an XML element.
+     *
+     * @param xml the non-null XML element to write.
+     */
+    public void write(XMLElement xml)
+        throws IOException
+    {
+        this.write(xml, 0);
+    }
+    
+    
+    /**
+     * Writes an XML element.
+     *
+     * @param xml the non-null XML element to write.
+     * @param indent how many spaces to indent the element.
+     */
+    public void write(XMLElement xml,
+                      int        indent)
+        throws IOException
+    {
+        for (int i = 0; i < indent; i++) {
+            this.writer.print(' ');
+        }
+
+        if (xml.getName() == null) {
+            if (xml.getContent() != null) {
+                this.writeEncoded(xml.getContent());
+                this.writer.println();
+            }
+        } else {
+            this.writer.print('<');
+            this.writer.print(xml.getName());
+            Enumeration _enum = xml._enumerateAttributeNames();
+            
+            while (_enum.hasMoreElements()) {
+                String key = (String) _enum.nextElement();
+                String value = xml.getAttribute(key);
+                this.writer.print(" " + key + "=\"");
+                this.writeEncoded(value);
+                this.writer.print('"');
+            }
+            
+            if ((xml.getContent() != null)
+                    && (xml.getContent().length() > 0)) {
+                writer.print('>');
+                this.writeEncoded(xml.getContent());
+                writer.println("</" + xml.getName() + '>');
+            } else if (xml.hasChildren()) {
+                writer.println('>');
+                _enum = xml._enumerateChildren();
+                
+                while (_enum.hasMoreElements()) {
+                    XMLElement child = (XMLElement) _enum.nextElement();
+                    this.write(child, indent + 4);
+                }
+                
+                for (int i = 0; i < indent; i++) {
+                    this.writer.print(' ');
+                }
+                
+                this.writer.println("</" + xml.getName() + ">");
+            } else {
+                this.writer.println("/>");
+            }
+        }
+        
+        this.writer.flush();
+    }
+
+
+    /**
+     * Writes a string encoding reserved characters.
+     *
+     * @param str the string to write.
+     */
+    private void writeEncoded(String str)
+    {
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+
+			if (c == 0x0D || c == 0x0A) {
+				this.writer.print(c);
+			} else if (c == '<') {
+				this.writer.print("&lt;");
+			} else if (c == '>') {
+				this.writer.print("&gt;");
+			} else if (c == '&') {
+				this.writer.print("&amp;");
+			} else if (c == '\'') {
+				this.writer.print("&apos;");
+			} else if (c == '"') {
+				this.writer.print("&quot;");
+			} else {
+				if ((c < ' ') || (c > 0x7E)) {
+					this.writer.print("&#x");
+					this.writer.print(Integer.toString(c, 16));
+					this.writer.print(';');
+				} else {
+					this.writer.print(c);
+				}
+			}
+		}
+    }
+
+}


### PR DESCRIPTION
Adding an equivalence-check from the NanoXML program.

* the license for this benchmark is the same as the license used for other benchmarks already in the java-ranger-regression folder
* As already mentioned in the README, this benchmark was originally contributed by Wang et al.
this new benchmark would be in the java-ranger-regression folder which is present in ReachSafety.set
* assert.prp is the property file used
* nanoxml_eqchk.yml is the newly introduced task definition file