### PR TITLE
Adding an equivalence check on Schedule benchmark

### DIFF
--- a/c/Systems_SQLite_MemSafety.cfg
+++ b/c/Systems_SQLite_MemSafety.cfg
@@ -1,0 +1,4 @@
+Description: Contains problems from the software SQLite
+Architecture: 64 bit
+
+

--- a/c/Systems_SQLite_MemSafety.set
+++ b/c/Systems_SQLite_MemSafety.set
@@ -1,0 +1,1 @@
+sqlite/*.yml

--- a/c/array-examples/standard_copy1_ground-2.yml
+++ b/c/array-examples/standard_copy1_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy2_ground-1.yml
+++ b/c/array-examples/standard_copy2_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy3_ground-2.yml
+++ b/c/array-examples/standard_copy3_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy4_ground-2.yml
+++ b/c/array-examples/standard_copy4_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy5_ground-2.yml
+++ b/c/array-examples/standard_copy5_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy6_ground-1.yml
+++ b/c/array-examples/standard_copy6_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy7_ground-1.yml
+++ b/c/array-examples/standard_copy7_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy8_ground-2.yml
+++ b/c/array-examples/standard_copy8_ground-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_copy9_ground-1.yml
+++ b/c/array-examples/standard_copy9_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-examples/standard_partition_ground-1.yml
+++ b/c/array-examples/standard_partition_ground-1.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-industry-pattern/array_ptr_single_elem_init-2.yml
+++ b/c/array-industry-pattern/array_ptr_single_elem_init-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-industry-pattern/array_single_elem_init.yml
+++ b/c/array-industry-pattern/array_single_elem_init.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-programs/copysome1-2.yml
+++ b/c/array-programs/copysome1-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/array-programs/copysome2-2.yml
+++ b/c/array-programs/copysome2-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/bitvector/byte_add-1.yml
+++ b/c/bitvector/byte_add-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/basename-2.yml
+++ b/c/busybox-1.22.0/basename-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/cut-2.yml
+++ b/c/busybox-1.22.0/cut-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/date-1.yml
+++ b/c/busybox-1.22.0/date-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/expand-2.yml
+++ b/c/busybox-1.22.0/expand-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/ls-incomplete-2.yml
+++ b/c/busybox-1.22.0/ls-incomplete-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/od-1.yml
+++ b/c/busybox-1.22.0/od-1.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/printf-2.yml
+++ b/c/busybox-1.22.0/printf-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/stty-2.yml
+++ b/c/busybox-1.22.0/stty-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/touch-2.yml
+++ b/c/busybox-1.22.0/touch-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/busybox-1.22.0/wc-2.yml
+++ b/c/busybox-1.22.0/wc-2.yml
@@ -14,3 +14,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_4.yml
+++ b/c/floats-cdfpl/newton_1_4.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_5.yml
+++ b/c/floats-cdfpl/newton_1_5.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_6.yml
+++ b/c/floats-cdfpl/newton_1_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_7.yml
+++ b/c/floats-cdfpl/newton_1_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_1_8.yml
+++ b/c/floats-cdfpl/newton_1_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_6.yml
+++ b/c/floats-cdfpl/newton_2_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_7.yml
+++ b/c/floats-cdfpl/newton_2_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_2_8.yml
+++ b/c/floats-cdfpl/newton_2_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_6.yml
+++ b/c/floats-cdfpl/newton_3_6.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_7.yml
+++ b/c/floats-cdfpl/newton_3_7.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/newton_3_8.yml
+++ b/c/floats-cdfpl/newton_3_8.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_1.yml
+++ b/c/floats-cdfpl/sine_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_2.yml
+++ b/c/floats-cdfpl/sine_2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/sine_3.yml
+++ b/c/floats-cdfpl/sine_3.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_1.yml
+++ b/c/floats-cdfpl/square_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_2.yml
+++ b/c/floats-cdfpl/square_2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/floats-cdfpl/square_3.yml
+++ b/c/floats-cdfpl/square_3.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
+++ b/c/ldv-linux-3.7.3/main0_drivers--media--dvb-frontends--stv090x-ko---32_7a--linux-3.7.3.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/fo_test.yml
+++ b/c/ldv-regression/fo_test.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/fo_test.yml
+++ b/c/ldv-regression/fo_test.yml
@@ -13,3 +13,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule57_ebda_blast.yml
+++ b/c/ldv-regression/rule57_ebda_blast.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule60_list2.c_1.yml
+++ b/c/ldv-regression/rule60_list2.c_1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-regression/rule60_list2.c_1.yml
+++ b/c/ldv-regression/rule60_list2.c_1.yml
@@ -13,3 +13,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_add-1.yml
+++ b/c/ldv-sets/test_add-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_double_lock.yml
+++ b/c/ldv-sets/test_mutex_double_lock.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_double_unlock.yml
+++ b/c/ldv-sets/test_mutex_double_unlock.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unbounded-2.yml
+++ b/c/ldv-sets/test_mutex_unbounded-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/ldv-sets/test_mutex_unlock_at_exit.yml
+++ b/c/ldv-sets/test_mutex_unlock_at_exit.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
   - property_file: ../properties/coverage-error-call.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loop-acceleration/array_3-2.yml
+++ b/c/loop-acceleration/array_3-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loop-invgen/id_trans.yml
+++ b/c/loop-invgen/id_trans.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/string-2.yml
+++ b/c/loops/string-2.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01-1.yml
+++ b/c/loops/sum01-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01_bug02.yml
+++ b/c/loops/sum01_bug02.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum01_bug02_sum01_bug02_base.case.yml
+++ b/c/loops/sum01_bug02_sum01_bug02_base.case.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/sum03-1.yml
+++ b/c/loops/sum03-1.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/loops/vogal-2.yml
+++ b/c/loops/vogal-2.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum.yml
+++ b/c/reducercommutativity/rangesum.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum05.yml
+++ b/c/reducercommutativity/rangesum05.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum10.yml
+++ b/c/reducercommutativity/rangesum10.yml
@@ -12,3 +12,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum20.yml
+++ b/c/reducercommutativity/rangesum20.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum40.yml
+++ b/c/reducercommutativity/rangesum40.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/c/reducercommutativity/rangesum60.yml
+++ b/c/reducercommutativity/rangesum60.yml
@@ -10,3 +10,4 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp

--- a/java/java-ranger-regression/schedule_eqchk.yml
+++ b/java/java-ranger-regression/schedule_eqchk.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - schedule_eqchk/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+

--- a/java/java-ranger-regression/schedule_eqchk/Main.java
+++ b/java/java-ranger-regression/schedule_eqchk/Main.java
@@ -1,0 +1,19 @@
+
+public class Main {
+    Process[] runSchedule2(int in0, int in1, int in2) {
+        Schedule2 t = new Schedule2();
+        t.mainProcess(in0, in1, in2);
+        return Schedule2.block_queue;
+    }
+
+
+    public static void main(String[] args) {
+        TestSchedule2 t = new TestSchedule2();
+        Main s = new Main();
+        t.runTest(s);
+    }
+
+    Process[] testFunction(int in0, int in1, int in2) {
+        return runSchedule2(in0, in1, in2);
+    }
+}

--- a/java/java-ranger-regression/schedule_eqchk/Process.java
+++ b/java/java-ranger-regression/schedule_eqchk/Process.java
@@ -1,0 +1,39 @@
+
+import java.util.Objects;
+
+public class Process {
+	int pid = 0;
+	int priority = 0;
+	Process next = null;
+	
+	public int getPid() {
+		return pid;
+	}
+	public void setPid(int _pid) {
+		pid = _pid;
+	}
+	public int getPriority() {
+		return priority;
+	}
+	public void setPriority(int _priority) {
+		priority = _priority;
+	}
+	public Process getNext() {
+		return next;
+	}
+	public void setNext(Process _next) {
+		next = _next;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Process process = (Process) o;
+		boolean pidMatch = pid == process.pid;
+		boolean prioMatch = priority == process.priority;
+		boolean nextMatch = Objects.equals(next, process.next);
+		if (!pidMatch) System.out.println("pid mismatched: " + pid + ", " + process.pid);
+		return pidMatch && prioMatch && nextMatch;
+	}
+}

--- a/java/java-ranger-regression/schedule_eqchk/Queue.java
+++ b/java/java-ranger-regression/schedule_eqchk/Queue.java
@@ -1,0 +1,69 @@
+
+import java.util.Objects;
+
+public class Queue {
+	Process head;
+	Process tail;
+	int number;
+	
+	public Queue(){
+		head = new Process();
+		head.setNext(null);
+		tail = new Process();
+		tail.setNext(null);
+		number = 0;
+	}
+
+	public int getNumber(){
+		return number;
+	}
+	public void setNumber(int _number){
+		number = _number;
+	}
+	
+	public Process getHead() {
+		Process result = head.getNext();
+		return result;
+	}
+
+	public void setHead(Process _head) {
+		head.setNext(_head);
+	}
+	
+	public Process getTail(){
+		Process result = tail.getNext();
+		return result;
+	}
+	
+	public void setTail(Process _tail){
+		tail.setNext(_tail);
+	}
+		
+//	public int getQueue_count() {
+//		int number = 0;
+//		Process process = head.getNext();
+//		while(process != null){
+//			number = number + 1;
+//			process = process.getNext();
+//		}
+//		return number;
+//	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Queue queue = (Queue) o;
+		return number == queue.number &&
+				Objects.equals(head, queue.head) &&
+				Objects.equals(tail, queue.tail);
+	}
+
+	public Process getCurrent_job(){
+		return head.getNext();
+	}
+	
+	public void setCurrent_job(Process current_job){
+		head.setNext(current_job);
+	}
+}

--- a/java/java-ranger-regression/schedule_eqchk/Schedule2.java
+++ b/java/java-ranger-regression/schedule_eqchk/Schedule2.java
@@ -1,0 +1,343 @@
+
+public class Schedule2 {
+	//
+	public static final int NEW_JOB = 1;
+	public static final int UPGRADE_PRIO = 2;
+	public static final int BLOCK = 3; 
+	public static final int UNBLOCK = 4;
+	public static final int QUANTUM_EXPIRE = 5;
+	public static final int FINISH = 6;
+	public static final int FLUSH = 7;
+	
+	//
+	public static final int MAXPRIO = 3;
+	//
+	public static final int MAXLOPRIO = 2;
+	//
+	public static int next_pid = 0;
+	
+	//
+	public static Queue current_job; 
+	//
+	public static Queue[] prio_queue; 
+	
+	public static Process[] block_queue;
+	public static final int block_length = 3;
+	public static int block_in;
+	public static int block_out;
+	
+	public static void main(String[] args) {
+		mainProcess(5, 3, 2);
+	}
+	
+	public static void mainProcess(int a1, int a2, int a3){
+		next_pid = 0; // not having this line causes inequivalence
+		current_job = new Queue(); 
+		//
+		prio_queue = new Queue[MAXPRIO + 1];
+		for(int i = 1; i <= MAXPRIO;){
+			prio_queue[i] = new Queue();
+			i = i + 1;
+		}
+		block_queue = new Process[block_length];
+		for(int i=0; i<block_length;){
+			block_queue[i] = null;
+			i = i + 1;
+		}
+		block_in = 0;
+		block_out = 0;
+		//
+		int[] argv = {0, 8, 7, 6};
+		//
+		for(int prio=MAXPRIO; prio>0;){
+			int nprocs = argv[MAXPRIO + 1 - prio];
+			while(nprocs > 0){
+				//
+				boolean status = new_job(prio);
+				if(!status){
+					return;
+				}
+				nprocs = nprocs - 1;
+			}
+			prio = prio - 1;
+		}
+		for(int i = 0; i < 3;){
+			if(i == 0){
+				schedule(a1, 2, 0.03);
+			}
+			else if(i == 1){
+				schedule(a2, 1, 0.02);
+			}
+			else if(i == 2){
+				schedule(a3, 2, 0.01);
+			}
+			i = i + 1;
+		}		
+	}
+	
+	private static void schedule(int command, int prio, double ratio) {
+
+		if(command == BLOCK){
+			//
+			block();
+		}
+		else if(command == NEW_JOB){
+			new_job(prio);
+		}
+		else if(command == UNBLOCK){
+			unblock(ratio);
+		}
+		else if(command == QUANTUM_EXPIRE){
+			//
+			quantum_expire();
+		}
+		else if(command == UPGRADE_PRIO){
+			//
+			upgrade_prio(prio, ratio);
+		}
+		else if(command == FINISH){
+			finish();
+		}
+		else{
+			System.out.println("NO COMMAND!");
+		}
+		
+//		int result[] = new int[100];
+//		int index = 0;
+//		int i = 0;
+//		while(i < MAXPRIO + 1){
+//			
+//			Process head = prio_queue[i].getHead();
+//			result[index++] = i;
+//			result[index++] = -1;
+//			while (head != null) {
+//				result[index++] = head.getPid();
+//				head = head.getNext();
+//			}
+//			result[index++] = -1;
+//			i ++;
+//		}
+//		System.out.println("out!");
+	}
+//
+//	private static void flush() {
+//		boolean continueIndex = false;
+//		while(!continueIndex){
+//			continueIndex = finish();
+//		}
+//	}
+
+	/*
+	 * 
+	 */
+	private static boolean finish() {
+		Process job = get_current();
+		if(job != null){
+			current_job.setCurrent_job(null);
+			reschedule(0);
+			return false;
+		}
+		return true;
+	}
+
+	/*
+	 * 
+	 */
+	private static void unblock(double ratio) {
+		Process job = block_queue[block_out];
+		block_out = block_out + 1;
+		block_out = block_out % block_length;
+		if(job != null){
+			int _prio = job.getPriority();
+			enqueue(_prio, job);
+		}
+	}
+
+	/*
+	 * 
+	 */
+	private static void block() {
+		Process job = get_current();
+		if(job != null){
+			current_job.setCurrent_job(null);
+			block_queue[block_in] = job;
+			block_in = block_in + 1;
+			block_in = block_in % block_length;
+			reschedule(0);
+		}
+	}
+
+	/*
+	 * 
+	 */
+	private static void upgrade_prio(int prio, double ratio) {
+		if(prio < 1){
+			return;
+		}
+		else if(prio > MAXLOPRIO){
+			return;
+		}
+		Process job = get_process(prio, ratio);
+		if(job != null){
+			int _prio = prio + 1;
+			job.setPriority(_prio);
+			enqueue(_prio, job);
+		}
+	}
+
+	/*
+	 * 
+	 */
+	private static void quantum_expire() {
+		Process job = get_current();
+		if(job != null){
+			current_job.setCurrent_job(null);
+			int _prio = job.getPriority();
+			enqueue(_prio, job);
+		}
+	}
+	
+	/*
+	 * 
+	 */
+	private static boolean new_job(int prio) {
+		int pid = next_pid;
+		next_pid = next_pid + 1;
+		Process new_process = new Process();
+		new_process.setPid(pid);
+		new_process.setPriority(prio);
+		new_process.setNext(null);
+		
+		boolean status = enqueue(prio, new_process);
+		return status;
+	}
+
+	/*
+	 * 
+	 */
+	private static boolean enqueue(int prio, Process new_process) {
+		boolean status= put_end(prio, new_process);
+		if(status){
+			return status;
+		}
+		status = reschedule(prio);
+		return status;
+	}
+
+	/*
+	 * 
+	 * 
+	 *
+	 */
+	private static boolean reschedule(int prio) {
+		Process cur_job = current_job.getCurrent_job();
+		if(cur_job != null){
+			int _prio = cur_job.getPriority();
+			if(prio > _prio){
+				put_end(_prio, cur_job);
+				current_job.setCurrent_job(null);
+			}
+		}
+		get_current();
+		return true;
+	}
+	
+	/*
+	 * 
+	 */
+	private static Process get_current(){
+		Process cur_job = current_job.getCurrent_job();
+		if(cur_job == null){
+			for(int prio = MAXPRIO; prio > 0;){
+				cur_job = get_process(prio, 0.0);
+				current_job.setCurrent_job(cur_job);
+				if(cur_job != null){
+					break;
+				}
+				prio = prio - 1;
+			}
+			
+		}
+		return cur_job;
+	}
+
+	/*
+	 * 
+	 */
+	private static Process get_process(int prio, double ratio) {
+		if(prio > MAXPRIO){
+			return null;
+		}
+		else if(prio < 0){
+			return null;
+		}
+		if(ratio < 0.0){
+			return null;
+		}
+		else if(ratio > 1.0){
+			return null;
+		}
+		Process result = null;
+		int length = prio_queue[prio].getNumber();
+		int index = (int)(ratio * length);
+		//
+		if(index >= length){
+			index = length - 1;
+		}
+		Process last = null;
+		//
+		Process next = prio_queue[prio].getHead();
+		while(index > 0){
+			if(next != null){
+				last = next;
+				next = next.getNext();
+			}
+			else{
+				break;
+			}
+			index = index - 1;
+		}
+		result = next;
+		if(result != null){
+			//
+			Process _next = result.getNext();
+			//
+			if(_next == null){
+				prio_queue[prio].setTail(last);
+			}
+			//
+			if(last != null){
+				last.setNext(_next);
+			}
+			else{
+				prio_queue[prio].setHead(_next);
+			}
+			result.setNext(null);
+			int number = prio_queue[prio].getNumber();
+			number = number + 1;
+			prio_queue[prio].setNumber(number);
+			return result;
+		}
+		else{
+			return null;
+		}
+	}
+
+	private static boolean put_end(int prio, Process new_process) {
+		Process process = prio_queue[prio].getTail();
+		if(process == null){
+			prio_queue[prio].setHead(new_process);
+			prio_queue[prio].setTail(new_process);
+
+		}
+		else{
+			process.setNext(new_process);
+			prio_queue[prio].setTail(new_process);
+		}
+		int number = prio_queue[prio].getNumber();
+		number = number + 1;
+		prio_queue[prio].setNumber(number);
+		return false;
+	}
+
+}

--- a/java/java-ranger-regression/schedule_eqchk/TestSchedule2.java
+++ b/java/java-ranger-regression/schedule_eqchk/TestSchedule2.java
@@ -1,0 +1,60 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+import java.util.Objects;
+
+public class TestSchedule2 {
+    void testHarness(Main v, int in0, int in1, int in2) {
+        in0 = Verifier.nondetInt();
+        in1 = Verifier.nondetInt();
+        in2 = Verifier.nondetInt();
+        Process[] outSPF = SPFWrapper(v, in0, in1, in2);
+        Process[] outJR = JRWrapper(v, in0, in1, in2);
+        checkEquality(v, outSPF, outJR);
+    }
+
+    public void checkEquality(Main v, Process[] outSPF, Process[] outJR) {
+        if (isequal(outSPF, outJR)) System.out.println("Match");
+        else {
+            System.out.println("Mismatch");
+            assert(false);
+        }
+//        assert(outSPF == outJR);
+    }
+
+    private boolean isequal(Process[] outSPF, Process[] outJR) {
+        if (outSPF.length == outJR.length) {
+            for (int i = 0; i < outSPF.length; i++) {
+                if (!Objects.equals(outSPF[i], outJR[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        System.out.println("length mismatch");
+        return false;
+    }
+
+    public Process[] SPFWrapper(Main v, int in0, int in1, int in2) {
+        return NoVeritest(v, in0, in1, in2);
+    }
+
+    // This is a special method. Call this method to prevent SPF from veritesting any regions that appear in any
+    // function or method call higher up in the stack. In the future, this call to SPFWrapperInner can be changed to
+    // be a generic method call if other no-veritesting methods need to be invoked.
+    private Process[] NoVeritest(Main v, int in0, int in1, int in2){
+        return SPFWrapperInner(v, in0, in1, in2);
+    }
+
+    private Process[] SPFWrapperInner(Main v, int in0, int in1, int in2) {
+        Process[] ret = v.testFunction(in0, in1, in2);
+        return ret;
+    }
+
+    public Process[] JRWrapper(Main v, int in0, int in1, int in2) {
+        return v.testFunction(in0, in1, in2);
+    }
+
+    public void runTest(Main t) {
+        testHarness(t, 0, 0, 0);
+    }
+};


### PR DESCRIPTION
Adding an equivalence check on the Schedule benchmark

* the license for this benchmark is the same as the license used for other benchmarks already in the java-ranger-regression folder
* As already mentioned in the README, this benchmark was originally contributed by Wang et al.
this new benchmark would be in the java-ranger-regression folder which is present in ReachSafety.set
* assert.prp is the property file used
* schedule_eqchk.yml is the newly introduced task definition file