### PR TITLE
seq-pthread: Replace all uses of nondet_pointer by nondet_ulong

### DIFF
--- a/c/seq-pthread/cs_dekker.c
+++ b/c/seq-pthread/cs_dekker.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -440,7 +440,7 @@ int main()
 		__CS_cp_x[i] = __VERIFIER_nondet_int();
 		for (j = 0; j < 3; j++) {
 			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-			__CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)__VERIFIER_nondet_pointer();
+			__CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)(void *)__VERIFIER_nondet_ulong();
 		}
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_dekker.i
+++ b/c/seq-pthread/cs_dekker.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -790,7 +790,7 @@ int main()
   __CS_cp_x[i] = __VERIFIER_nondet_int();
   for (j = 0; j < 3; j++) {
    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-   __CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)__VERIFIER_nondet_pointer();
+   __CS_cp___CS_thread_lockedon[i][j] = (unsigned char*)(void *)__VERIFIER_nondet_ulong();
   }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_fib-1.c
+++ b/c/seq-pthread/cs_fib-1.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
 	  __CS_cp_j[k] = __VERIFIER_nondet_int();
 	  for(l = 0; l < 3; l++) {
 	    __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_fib-1.i
+++ b/c/seq-pthread/cs_fib-1.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -733,7 +733,7 @@ int main(int argc, char **argv)
    __CS_cp_j[k] = __VERIFIER_nondet_int();
    for(l = 0; l < 3; l++) {
      __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_fib-2.c
+++ b/c/seq-pthread/cs_fib-2.c
@@ -82,7 +82,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 
 void __CS_cs(void)
 {
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
 	for (int i = 0; i < __CS_ROUNDS; ++i) {
 		for (int j = 0; j < __CS_THREADS+1; ++j) {
 			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+			__CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
 		}
 		__CS_cp_i[i] = __VERIFIER_nondet_int();
 		__CS_cp_j[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_fib-2.i
+++ b/c/seq-pthread/cs_fib-2.i
@@ -553,7 +553,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[6][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -745,7 +745,7 @@ int main(int argc, char **argv)
  for (int i = 0; i < 6; ++i) {
   for (int j = 0; j < 2 +1; ++j) {
    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+   __CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
   }
   __CS_cp_i[i] = __VERIFIER_nondet_int();
   __CS_cp_j[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_fib_longer-1.c
+++ b/c/seq-pthread/cs_fib_longer-1.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
 		__CS_cp_j[k] = __VERIFIER_nondet_int();
 		for(l = 0; l < 3; l++) {
 		  __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-		  __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+		  __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 		}
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_fib_longer-1.i
+++ b/c/seq-pthread/cs_fib_longer-1.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -733,7 +733,7 @@ int main(int argc, char **argv)
   __CS_cp_j[k] = __VERIFIER_nondet_int();
   for(l = 0; l < 3; l++) {
     __CS_cp___CS_thread_status[k][l] = __VERIFIER_nondet_uchar();
-    __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) __VERIFIER_nondet_pointer();
+    __CS_cp___CS_thread_lockedon[k][l] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
   }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_fib_longer-2.c
+++ b/c/seq-pthread/cs_fib_longer-2.c
@@ -83,7 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 
 void __CS_cs(void)
 {
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
 	for (int i = 0; i < __CS_ROUNDS; ++i) {
 		for (int j = 0; j < __CS_THREADS+1; ++j) {
 			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+			__CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
 		}
 		__CS_cp_i[i] = __VERIFIER_nondet_int();
 		__CS_cp_j[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_fib_longer-2.i
+++ b/c/seq-pthread/cs_fib_longer-2.i
@@ -543,7 +543,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[7][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -729,7 +729,7 @@ int main(int argc, char **argv)
  for (int i = 0; i < 7; ++i) {
   for (int j = 0; j < 2 +1; ++j) {
    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+   __CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
   }
   __CS_cp_i[i] = __VERIFIER_nondet_int();
   __CS_cp_j[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_lamport.c
+++ b/c/seq-pthread/cs_lamport.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -512,7 +512,7 @@ int main()
 	  __CS_cp_X[i] = __VERIFIER_nondet_int();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_lamport.i
+++ b/c/seq-pthread/cs_lamport.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -860,7 +860,7 @@ int main()
    __CS_cp_X[i] = __VERIFIER_nondet_int();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_lazy.c
+++ b/c/seq-pthread/cs_lazy.c
@@ -83,7 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar(void);
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 
 void __CS_cs(void)
 {
@@ -386,7 +386,7 @@ int main()
 	for (int i = 0; i < __CS_ROUNDS; ++i) {
 		for (int j = 0; j < __CS_THREADS+1; ++j) {
 			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+			__CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
 		}
 		__CS_cp_mutex[i] = __VERIFIER_nondet_uchar();
 		__CS_cp_data[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_lazy.i
+++ b/c/seq-pthread/cs_lazy.i
@@ -543,7 +543,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][3 +1];
 int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar(void);
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -736,7 +736,7 @@ int main()
  for (int i = 0; i < 2; ++i) {
   for (int j = 0; j < 3 +1; ++j) {
    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+   __CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
   }
   __CS_cp_mutex[i] = __VERIFIER_nondet_uchar();
   __CS_cp_data[i] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_peterson.c
+++ b/c/seq-pthread/cs_peterson.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -412,7 +412,7 @@ int main()
 	  __CS_cp_x[i] = __VERIFIER_nondet_int();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_peterson.i
+++ b/c/seq-pthread/cs_peterson.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -760,7 +760,7 @@ int main()
    __CS_cp_x[i] = __VERIFIER_nondet_int();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_queue-1.c
+++ b/c/seq-pthread/cs_queue-1.c
@@ -1,6 +1,6 @@
 extern _Bool __VERIFIER_nondet_bool(void);
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -555,7 +555,7 @@ int main(void)
 	  }
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 
 	  for (j = 0; j < 20; j++) {

--- a/c/seq-pthread/cs_queue-1.i
+++ b/c/seq-pthread/cs_queue-1.i
@@ -1,6 +1,6 @@
 extern _Bool __VERIFIER_nondet_bool(void);
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -1148,7 +1148,7 @@ int main(void)
    }
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
    for (j = 0; j < 20; j++) {
      __CS_cp_stored_elements[i][j] = __VERIFIER_nondet_int();

--- a/c/seq-pthread/cs_read_write_lock-1.c
+++ b/c/seq-pthread/cs_read_write_lock-1.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -421,7 +421,7 @@ int main()
 	  __CS_cp_y[i] = __VERIFIER_nondet_int();
  	 for(j = 0; j < 5; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_read_write_lock-1.i
+++ b/c/seq-pthread/cs_read_write_lock-1.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -765,7 +765,7 @@ int main()
    __CS_cp_y[i] = __VERIFIER_nondet_int();
    for(j = 0; j < 5; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_stack-1.c
+++ b/c/seq-pthread/cs_stack-1.c
@@ -1,6 +1,6 @@
 extern _Bool __VERIFIER_nondet_bool(void);
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -496,7 +496,7 @@ int main(void)
 
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 
 	  for(j = 0; j < 5; j++) {

--- a/c/seq-pthread/cs_stack-1.i
+++ b/c/seq-pthread/cs_stack-1.i
@@ -1,6 +1,6 @@
 extern _Bool __VERIFIER_nondet_bool(void);
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -1072,7 +1072,7 @@ int main(void)
    __CS_cp_flag[i] = __VERIFIER_nondet_bool();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
    for(j = 0; j < 5; j++) {
      __CS_cp_arr[i][j] = __VERIFIER_nondet_uint();

--- a/c/seq-pthread/cs_stateful-1.c
+++ b/c/seq-pthread/cs_stateful-1.c
@@ -83,7 +83,7 @@ unsigned int __CS_SwitchDone;
 //cseq: function declarations
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 
 void __CS_cs(void)
 {
@@ -396,7 +396,7 @@ int main()
 	for (int i = 0; i < __CS_ROUNDS; ++i) {
 		for (int j = 0; j < __CS_THREADS+1; ++j) {
 			__CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-			__CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+			__CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
 		}
 		__CS_cp_ma[i] = __VERIFIER_nondet_uchar();
 		__CS_cp_mb[i] = __VERIFIER_nondet_uchar();

--- a/c/seq-pthread/cs_stateful-1.i
+++ b/c/seq-pthread/cs_stateful-1.i
@@ -543,7 +543,7 @@ const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][2 +1];
 extern int __VERIFIER_nondet_int();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 void __CS_cs(void)
 {
  unsigned char k = __VERIFIER_nondet_uchar();
@@ -747,7 +747,7 @@ int main()
  for (int i = 0; i < 2; ++i) {
   for (int j = 0; j < 2 +1; ++j) {
    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-   __CS_cp___CS_thread_lockedon[i][j] = __VERIFIER_nondet_pointer();
+   __CS_cp___CS_thread_lockedon[i][j] = (void *)__VERIFIER_nondet_ulong();
   }
   __CS_cp_ma[i] = __VERIFIER_nondet_uchar();
   __CS_cp_mb[i] = __VERIFIER_nondet_uchar();

--- a/c/seq-pthread/cs_stateful-2.c
+++ b/c/seq-pthread/cs_stateful-2.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -402,7 +402,7 @@ int main()
 	  __CS_cp_data2[i] = __VERIFIER_nondet_int();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_stateful-2.i
+++ b/c/seq-pthread/cs_stateful-2.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -753,7 +753,7 @@ int main()
    __CS_cp_data2[i] = __VERIFIER_nondet_int();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_sync.c
+++ b/c/seq-pthread/cs_sync.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -409,7 +409,7 @@ int main()
 	  __CS_cp_full[i] = __VERIFIER_nondet_uchar();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_sync.i
+++ b/c/seq-pthread/cs_sync.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -994,7 +994,7 @@ int main()
    __CS_cp_full[i] = __VERIFIER_nondet_uchar();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_szymanski.c
+++ b/c/seq-pthread/cs_szymanski.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -468,7 +468,7 @@ int main()
 	  __CS_cp_x[i] = __VERIFIER_nondet_int();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_szymanski.i
+++ b/c/seq-pthread/cs_szymanski.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -808,7 +808,7 @@ int main()
    __CS_cp_x[i] = __VERIFIER_nondet_int();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];

--- a/c/seq-pthread/cs_time_var_mutex.c
+++ b/c/seq-pthread/cs_time_var_mutex.c
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -430,7 +430,7 @@ int main()
 	  __CS_cp_m_busy[i] = __VERIFIER_nondet_uchar();
 	  for(j = 0; j < 3; j++) {
 	    __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+	    __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
 	  }
 	}
 	//cseq: Copy statements for global variables:

--- a/c/seq-pthread/cs_time_var_mutex.i
+++ b/c/seq-pthread/cs_time_var_mutex.i
@@ -1,5 +1,5 @@
 extern int __VERIFIER_nondet_int(void);
-extern void * __VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 extern unsigned char __VERIFIER_nondet_uchar(void);
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
@@ -778,7 +778,7 @@ int main()
    __CS_cp_m_busy[i] = __VERIFIER_nondet_uchar();
    for(j = 0; j < 3; j++) {
      __CS_cp___CS_thread_status[i][j] = __VERIFIER_nondet_uchar();
-     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) __VERIFIER_nondet_pointer();
+     __CS_cp___CS_thread_lockedon[i][j] = (unsigned char *) (void *)__VERIFIER_nondet_ulong();
    }
  }
  __CS_thread_status[1][0] = __CS_cp___CS_thread_status[1][0];


### PR DESCRIPTION
The semantics of __VERIFIER_nondet_pointer, particular whether it does
or does not perform memory allocation, have never been clarified (see
issue #767). To avoid any such ambiguity, just cast a non-deterministic
unsigned long to a void* instead, making clear that no memory allocation
is performed. Indeed, these benchmarks just perform equality tests on
the pointer values, but never attempt to deference them.

The changes were applied as follows:
```
perl -p -i -e \
  's/extern void \* ?__VERIFIER_nondet_pointer\(void\);/extern unsigned long __VERIFIER_nondet_ulong(void);/' \
  c/seq-pthread/*
perl -p -i -e \
  's/__VERIFIER_nondet_pointer\(\);/(void *)__VERIFIER_nondet_ulong();/' c/seq-pthread/*
```

This is a first follow-up to #745. Other directories will follow using the same approach where possible. For benchmarks that actually do dereference the pointers returned a different approach will be taken.