### PR TITLE
loops/s3.i: Replace use of nondet_pointer by nondet_ulong

### DIFF
--- a/c/loops/s3.i
+++ b/c/loops/s3.i
@@ -5,7 +5,7 @@ extern void *malloc(unsigned int sz);
 
 
 extern int __VERIFIER_nondet_int(void);
-extern void *__VERIFIER_nondet_pointer(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
 
 typedef unsigned int size_t;
 typedef long __time_t;
@@ -1074,7 +1074,7 @@ int main(void)
 }
 }
 int ssl3_connect(SSL *s )
-{ BUF_MEM *buf = __VERIFIER_nondet_pointer();
+{ BUF_MEM *buf = (BUF_MEM *)__VERIFIER_nondet_ulong();
   unsigned long tmp ;
   unsigned long l ;
   long num1 ;


### PR DESCRIPTION
The semantics of __VERIFIER_nondet_pointer, particular whether it does or does
not perform memory allocation, have never been clarified (see issue #767). To
avoid any such ambiguity, just cast a non-deterministic unsigned long to a
pointer. As the benchmark just performs equality tests on the pointer value and
never attempts to dereference, this is a sufficient replacement.