### PR TITLE
aws-c-common: Replace all uses of nondet_pointer by nondet_ulong

### DIFF
--- a/c/aws-c-common/aws_add_size_checked_harness.i
+++ b/c/aws-c-common/aws_add_size_checked_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_add_size_saturating_harness.i
+++ b/c/aws-c-common/aws_add_size_saturating_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_eq_harness.i
+++ b/c/aws-c-common/aws_array_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_back_harness.i
+++ b/c/aws-c-common/aws_array_list_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_capacity_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_clean_up_harness.i
+++ b/c/aws-c-common/aws_array_list_clean_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_clear_harness.i
+++ b/c/aws-c-common/aws_array_list_clear_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_comparator_string_harness.i
+++ b/c/aws-c-common/aws_array_list_comparator_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_copy_harness.i
+++ b/c/aws-c-common/aws_array_list_copy_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_erase_harness.i
+++ b/c/aws-c-common/aws_array_list_erase_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_front_harness.i
+++ b/c/aws-c-common/aws_array_list_front_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_get_at_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_array_list_init_dynamic_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_init_static_harness.i
+++ b/c/aws-c-common/aws_array_list_init_static_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_length_harness.i
+++ b/c/aws-c-common/aws_array_list_length_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_pop_front_n_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_n_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_push_back_harness.i
+++ b/c/aws-c-common/aws_array_list_push_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_set_at_harness.i
+++ b/c/aws-c-common/aws_array_list_set_at_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
+++ b/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_sort_harness.i
+++ b/c/aws-c-common/aws_array_list_sort_harness.i
@@ -223,7 +223,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -271,7 +270,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_contents_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_array_list_swap_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_advance_harness.i
+++ b/c/aws-c-common/aws_byte_buf_advance_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_append_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_cat_harness.i
+++ b/c/aws-c-common/aws_byte_buf_cat_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_clean_up_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_eq_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_array_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_init_copy_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_init_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_reserve_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_reset_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reset_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
+++ b/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_be16_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be16_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_be32_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be32_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_be64_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be64_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_buf_write_u8_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_u8_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_advance_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_array_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_from_string_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_array_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_array_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_c_string_harness.i
+++ b/c/aws-c-common/aws_hash_c_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_callback_string_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_iter_begin_harness.i
+++ b/c/aws-c-common/aws_hash_iter_begin_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_iter_delete_harness.i
+++ b/c/aws-c-common/aws_hash_iter_delete_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_iter_done_harness.i
+++ b/c/aws-c-common/aws_hash_iter_done_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_iter_next_harness.i
+++ b/c/aws-c-common/aws_hash_iter_next_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_ptr_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_string_harness.i
+++ b/c/aws-c-common/aws_hash_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_clean_up_harness.i
+++ b/c/aws-c-common/aws_hash_table_clean_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_clear_harness.i
+++ b/c/aws-c-common/aws_hash_table_clear_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_create_harness.i
+++ b/c/aws-c-common/aws_hash_table_create_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_eq_harness.i
+++ b/c/aws-c-common/aws_hash_table_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_find_harness.i
+++ b/c/aws-c-common/aws_hash_table_find_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_foreach_harness.i
+++ b/c/aws-c-common/aws_hash_table_foreach_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
+++ b/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_init_bounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_bounded_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_move_harness.i
+++ b/c/aws-c-common/aws_hash_table_move_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_put_harness.i
+++ b/c/aws-c-common/aws_hash_table_put_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_remove_harness.i
+++ b/c/aws-c-common/aws_hash_table_remove_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_hash_table_swap_harness.i
+++ b/c/aws-c-common/aws_hash_table_swap_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_is_power_of_two_harness.i
+++ b/c/aws-c-common/aws_is_power_of_two_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_begin_harness.i
+++ b/c/aws-c-common/aws_linked_list_begin_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_end_harness.i
+++ b/c/aws-c-common/aws_linked_list_end_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_front_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_init_harness.i
+++ b/c/aws-c-common/aws_linked_list_init_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_insert_after_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_after_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_insert_before_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_before_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_next_harness.i
+++ b/c/aws-c-common/aws_linked_list_next_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_node_reset_harness.i
+++ b/c/aws-c-common/aws_linked_list_node_reset_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_front_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_prev_harness.i
+++ b/c/aws-c-common/aws_linked_list_prev_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_push_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_back_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_push_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_front_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_rbegin_harness.i
+++ b/c/aws-c-common/aws_linked_list_rbegin_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_remove_harness.i
+++ b/c/aws-c-common/aws_linked_list_remove_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_rend_harness.i
+++ b/c/aws-c-common/aws_linked_list_rend_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_linked_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_linked_list_swap_contents_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_mul_size_checked_harness.i
+++ b/c/aws-c-common/aws_mul_size_checked_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
+++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_nospec_mask_harness.i
+++ b/c/aws-c-common/aws_nospec_mask_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_capacity_harness.i
+++ b/c/aws-c-common/aws_priority_queue_capacity_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_clean_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_clean_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_init_static_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_static_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_pop_harness.i
+++ b/c/aws-c-common/aws_priority_queue_pop_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_push_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_push_ref_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_ref_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_remove_harness.i
+++ b/c/aws-c-common/aws_priority_queue_remove_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_size_harness.i
+++ b/c/aws-c-common/aws_priority_queue_size_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_priority_queue_top_harness.i
+++ b/c/aws-c-common/aws_priority_queue_top_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ptr_eq_harness.i
+++ b/c/aws-c-common/aws_ptr_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_buf_belongs_to_pool_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_buf_belongs_to_pool_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_init_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_init_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_ring_buffer_release_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_release_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
+++ b/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_bytes_harness.i
+++ b/c/aws-c-common/aws_string_bytes_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_compare_harness.i
+++ b/c/aws-c-common/aws_string_compare_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_destroy_harness.i
+++ b/c/aws-c-common/aws_string_destroy_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_destroy_secure_harness.i
+++ b/c/aws-c-common/aws_string_destroy_secure_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_harness.i
+++ b/c/aws-c-common/aws_string_eq_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_ignore_case_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_new_from_array_harness.i
+++ b/c/aws-c-common/aws_string_new_from_array_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_new_from_c_str_harness.i
+++ b/c/aws-c-common/aws_string_new_from_c_str_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/aws_string_new_from_string_harness.i
+++ b/c/aws-c-common/aws_string_new_from_string_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/memcpy_using_uint64_harness.i
+++ b/c/aws-c-common/memcpy_using_uint64_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/memset_override_0_harness.i
+++ b/c/aws-c-common/memset_override_0_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/memset_using_uint64_harness.i
+++ b/c/aws-c-common/memset_using_uint64_harness.i
@@ -222,7 +222,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -270,7 +269,7 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short(); }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint(); }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong(); }
 uint8_t nondet_uint8_t() { return __VERIFIER_nondet_uchar(); }
-void *nondet_voidp() { return __VERIFIER_nondet_pointer(); }
+void *nondet_voidp() { return (void *)__VERIFIER_nondet_ulong(); }
 
 typedef char static_assertion_at_line_48[(!!(1 == 1)) * 2 - 1];
 typedef char static_assertion_at_line_49[(!!(2 == 2)) * 2 - 1];

--- a/c/aws-c-common/prelude.h
+++ b/c/aws-c-common/prelude.h
@@ -12,7 +12,6 @@ extern short __VERIFIER_nondet_short();
 extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
-extern void *__VERIFIER_nondet_pointer();
 
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error(); 
@@ -69,5 +68,5 @@ uint16_t nondet_uint16_t() { return __VERIFIER_nondet_short();   }
 uint32_t nondet_uint32_t() { return __VERIFIER_nondet_uint();    }
 uint64_t nondet_uint64_t() { return __VERIFIER_nondet_ulong();   }
 uint8_t  nondet_uint8_t()  { return __VERIFIER_nondet_uchar();   }
-void    *nondet_voidp()    { return __VERIFIER_nondet_pointer(); }
+void    *nondet_voidp()    { return (void *)__VERIFIER_nondet_ulong(); }
 


### PR DESCRIPTION
The semantics of __VERIFIER_nondet_pointer, particular whether it does
or does not perform memory allocation, have never been clarified (see
issue #767). To avoid any such ambiguity, just cast a non-deterministic
unsigned long to a void* instead, making clear that no memory allocation
is performed. Any dereferencing of the resulting pointer could be
undefined behaviour, which would expose a bug as the only use of
non-deterministic pointers is to model the behaviour of realloc. This
error case is explicitly called out in comments in the source code.

The changes were applied as follows:
```
perl -p -i -e \
  's/return __VERIFIER_nondet_pointer\(\);/return (void *)__VERIFIER_nondet_ulong();/' \
  c/aws-c-common/*.[chi]
sed -i \
  '/^extern void \*__VERIFIER_nondet_pointer();/d' \
  c/aws-c-common/*.[chi]
```
