### PR TITLE
ntdrivers-simplified: Remove unused declaration of __VERIFIER_nondet_pointer

### DIFF
--- a/c/ntdrivers-simplified/cdaudio_simpl1.cil-1.c
+++ b/c/ntdrivers-simplified/cdaudio_simpl1.cil-1.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int SendSrbSynchronous(int Extension , int Srb , int Buffer , int BufferLength );
 int CdAudioSignalCompletion(int DeviceObject , int Irp , int Event );

--- a/c/ntdrivers-simplified/cdaudio_simpl1.cil-2.c
+++ b/c/ntdrivers-simplified/cdaudio_simpl1.cil-2.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int SendSrbSynchronous(int Extension , int Srb , int Buffer , int BufferLength );
 int CdAudioSignalCompletion(int DeviceObject , int Irp , int Event );

--- a/c/ntdrivers-simplified/diskperf_simpl1.cil.c
+++ b/c/ntdrivers-simplified/diskperf_simpl1.cil.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int DiskPerfDispatchPnp(int DeviceObject , int Irp );
 int DiskPerfIrpCompletion(int DeviceObject , int Irp , int Context );

--- a/c/ntdrivers-simplified/floppy_simpl3.cil-1.c
+++ b/c/ntdrivers-simplified/floppy_simpl3.cil-1.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int FlAcpiConfigureFloppy(int DisketteExtension , int FdcInfo );
 int FlQueueIrpToThread(int Irp , int DisketteExtension );

--- a/c/ntdrivers-simplified/floppy_simpl3.cil-2.c
+++ b/c/ntdrivers-simplified/floppy_simpl3.cil-2.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int FlAcpiConfigureFloppy(int DisketteExtension , int FdcInfo );
 int FlQueueIrpToThread(int Irp , int DisketteExtension );

--- a/c/ntdrivers-simplified/floppy_simpl4.cil-1.c
+++ b/c/ntdrivers-simplified/floppy_simpl4.cil-1.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int FlAcpiConfigureFloppy(int DisketteExtension , int FdcInfo );
 int FlQueueIrpToThread(int Irp , int DisketteExtension );

--- a/c/ntdrivers-simplified/floppy_simpl4.cil-2.c
+++ b/c/ntdrivers-simplified/floppy_simpl4.cil-2.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int FlAcpiConfigureFloppy(int DisketteExtension , int FdcInfo );
 int FlQueueIrpToThread(int Irp , int DisketteExtension );

--- a/c/ntdrivers-simplified/kbfiltr_simpl1.cil.c
+++ b/c/ntdrivers-simplified/kbfiltr_simpl1.cil.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 extern int __VERIFIER_nondet_int();
 int KbFilter_PnP(int DeviceObject , int Irp );
 int IofCallDriver(int DeviceObject , int Irp );

--- a/c/ntdrivers-simplified/kbfiltr_simpl2.cil-1.c
+++ b/c/ntdrivers-simplified/kbfiltr_simpl2.cil-1.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 extern int __VERIFIER_nondet_int();
 
 int PoCallDriver(int DeviceObject , int Irp );

--- a/c/ntdrivers-simplified/kbfiltr_simpl2.cil-2.c
+++ b/c/ntdrivers-simplified/kbfiltr_simpl2.cil-2.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);
-extern void *__VERIFIER_nondet_pointer(void);
 
 int KbFilter_PnP(int DeviceObject , int Irp );
 int IofCallDriver(int DeviceObject , int Irp );


### PR DESCRIPTION
The semantics of __VERIFIER_nondet_pointer, particular whether it does
or does not perform memory allocation, have never been clarified (see
issue #767). In ntdrivers-simplified, however, just the declaration was
present, without any actual use. Thus remove the declaration to avoid
risk of ambiguity.

The changes were applied as follows:
```
sed -i \
  '/^extern void \*__VERIFIER_nondet_pointer();/d' \
  c/ntdrivers-simplified/*.c
```
