### PR TITLE
Whitespace change only: fix preprocessing difference

### DIFF
--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4140,7 +4140,7 @@ static int stv090x_read_reg(struct stv090x_state *state , unsigned int reg )
   return ((int )buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int stv090x_write_regs(struct stv090x_state *state , unsigned int reg , u8 *data ,
                               u32 count )
 {

--- a/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.i
+++ b/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.i
@@ -2234,7 +2234,7 @@ static void ibmpex_bmc_gone(int iface )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void ibmpex_msg_handler(struct ipmi_recv_msg *msg , void *user_msg_data )
 {
   struct ibmpex_bmc_data *data ;

--- a/c/ldv-commit-tester/m0_drivers-net-slip-ko--108_1a--1b0b0ac-1.i
+++ b/c/ldv-commit-tester/m0_drivers-net-slip-ko--108_1a--1b0b0ac-1.i
@@ -5326,7 +5326,7 @@ static void sl_free_bufs(struct slip *sl )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sl_realloc_bufs(struct slip *sl , int mtu )
 {
   int err ;

--- a/c/ldv-commit-tester/m0_drivers-net-slip-ko--108_1a--1b0b0ac.i
+++ b/c/ldv-commit-tester/m0_drivers-net-slip-ko--108_1a--1b0b0ac.i
@@ -5326,7 +5326,7 @@ static void sl_free_bufs(struct slip *sl )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sl_realloc_bufs(struct slip *sl , int mtu )
 {
   int err ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-frontends--stv090x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4210,7 +4210,7 @@ static int stv090x_read_reg(struct stv090x_state *state , unsigned int reg )
   return ((int )buf);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int stv090x_write_regs(struct stv090x_state *state , unsigned int reg , u8 *data ,
                               u32 count )
 {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--arcnet--com90xx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--arcnet--com90xx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4641,7 +4641,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
 }
 }
 extern void iounmap(void volatile * ) ;
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 {
   size_t __len ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--usb--host--r8a66597-hcd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--usb--host--r8a66597-hcd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3629,7 +3629,7 @@ __inline static u16 r8a66597_read(struct r8a66597 *r8a66597 , unsigned long offs
   return ((u16 )tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void r8a66597_read_fifo(struct r8a66597 *r8a66597 , unsigned long offset ,
                                         u16 *buf , int len )
 {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.cil.out.i
@@ -4661,7 +4661,7 @@ static void pdc20230_set_piomode(struct ata_port *ap , struct ata_device *adev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static unsigned int pdc_data_xfer_vlb(struct ata_device *dev , unsigned char *buf ,
                                       unsigned int buflen , int rw )
 { int slop ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
@@ -9104,7 +9104,7 @@ void ldv_mutex_unlock_68(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern char *strcpy(char * , char const * ) ;
 int ldv_mutex_trylock_84(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_unlock_82(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.cil.out.i
@@ -5558,7 +5558,7 @@ __inline static struct sk_buff *mI_alloc_skb(unsigned int len , gfp_t gfp_mask )
   return (skb);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static struct sk_buff *_alloc_mISDN_skb(u_int prim , u_int id___0 , u_int len ,
                                                  void *dp , gfp_t gfp_mask )
 { struct sk_buff *skb ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--usb--b2c2--b2c2-flexcop-usb.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--usb--b2c2--b2c2-flexcop-usb.ko-main.cil.out.i
@@ -7082,7 +7082,7 @@ static int flexcop_usb_i2c_request(struct flexcop_i2c_adapter *i2c , flexcop_acc
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void flexcop_usb_process_frame(struct flexcop_usb *fc_usb , u8 *buffer , int buffer_length )
 { u8 *b ;
   int l ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.cil.out.i
@@ -6258,7 +6258,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 long ldv__builtin_expect(long exp , long c ) ;
 extern int printk(char const * , ...) ;
 extern int __dynamic_pr_debug(struct _ddebug * , char const * , ...) ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--usb--host--r8a66597-hcd.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--usb--host--r8a66597-hcd.ko-main.cil.out.i
@@ -3643,7 +3643,7 @@ __inline static u16 r8a66597_read(struct r8a66597 *r8a66597 , unsigned long offs
   return ((u16 )tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void r8a66597_read_fifo(struct r8a66597 *r8a66597 , unsigned long offset ,
                                         u16 *buf , int len )
 { void *fifoaddr ;

--- a/c/ldv-consumption/32_7a_newdeg_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_newdeg_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.cil.out.i
@@ -6259,7 +6259,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 long ldv__builtin_expect(long exp , long c ) ;
 extern int printk(char const * , ...) ;
 extern int __dynamic_pr_debug(struct _ddebug * , char const * , ...) ;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--media--usb--em28xx--em28xx.ko-ldv_main0.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--media--usb--em28xx--em28xx.ko-ldv_main0.cil.out.i
@@ -6274,7 +6274,7 @@ __inline static void finish_buffer(struct em28xx *dev , struct em28xx_buffer *bu
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void em28xx_copy_video(struct em28xx *dev , struct em28xx_buffer *buf , unsigned char *usb_buf ,
                               unsigned long len )
 {

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
@@ -8295,7 +8295,7 @@ static void ppp_push(struct ppp *ppp )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static bool mp_protocol_compress = (bool )1;
 static int ppp_mp_explode(struct ppp *ppp , struct sk_buff *skb )
 { int len ;

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-wan-farsync.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-wan-farsync.ko.cil.out.i
@@ -4651,7 +4651,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-net-can-usb-ems_usb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-net-can-usb-ems_usb.ko.cil.out.i
@@ -5763,7 +5763,7 @@ static void ems_usb_write_bulk_callback(struct urb *urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ems_usb_command_msg(struct ems_usb *dev , struct ems_cpc_msg *msg )
 { int actual_length ;
   size_t __len ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-net-usb-catc.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-net-usb-catc.ko.cil.out.i
@@ -4857,7 +4857,7 @@ __inline static void spin_unlock_irqrestore(spinlock_t *lock , unsigned long fla
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern unsigned long volatile jiffies __attribute__((__section__(".data"))) ;
 extern void init_timer_key(struct timer_list *timer , char const *name , struct lock_class_key *key ) ;
 extern int mod_timer(struct timer_list *timer , unsigned long expires ) ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko.cil.out.i
@@ -4126,7 +4126,7 @@ int i1480_mac_fw_upload(struct i1480 *i1480 )
   return (result);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void *s , int c , size_t n ) ;
 static int i1480_mpi_write(struct i1480 *i1480 , void const *data , size_t size )
 { int result ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
@@ -10430,7 +10430,7 @@ int comedi_buf_get(struct comedi_async *async , short *x )
   return (1);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 void comedi_buf_memcpy_to(struct comedi_async *async , unsigned int offset , void const *data ,
                           unsigned int num_bytes )
 {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified.cil.out.i
@@ -10130,7 +10130,7 @@ int comedi_buf_get(struct comedi_async *async , short *x )
   return (1);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 void comedi_buf_memcpy_to(struct comedi_async *async , unsigned int offset , void const *data ,
                           unsigned int num_bytes )
 {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
@@ -6714,7 +6714,7 @@ void st5481_release_isocpipes(struct urb **urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void usb_in_complete(struct urb *urb )
 {
   struct st5481_in *in ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
@@ -7416,7 +7416,7 @@ static int dib0700_set_usb_xfer_len(struct dvb_usb_device *d , u16 nb_ts_packets
   return (ret);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int dib0700_i2c_xfer_new(struct i2c_adapter *adap , struct i2c_msg *msg , int num )
 {
   struct dvb_usb_device *d ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
@@ -8195,7 +8195,7 @@ __inline static void stk1160_buffer_done(struct stk1160 *dev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void stk1160_copy_video(struct stk1160 *dev , u8 *src , int len )
 {
   int linesdone ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
@@ -5013,7 +5013,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
@@ -6187,7 +6187,7 @@ static void ems_usb_write_bulk_callback(struct urb *urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ems_usb_command_msg(struct ems_usb *dev , struct ems_cpc_msg *msg )
 {
   int actual_length ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
@@ -5145,7 +5145,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_virtio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_virtio.ko-entry_point.cil.out.i
@@ -5991,7 +5991,7 @@ static void cfv_release_used_buf(struct virtqueue *vq_tx )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static struct sk_buff *cfv_alloc_and_copy_skb(int *err , struct cfv_info *cfv , u8 *frm ,
                                               u32 frm_len )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point.cil.out.i
@@ -5481,7 +5481,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static struct sk_buff *ldv_netdev_alloc_skb_18(struct net_device *dev , unsigned int length ) ;
 __inline static void skb_copy_from_linear_data(struct sk_buff const *skb , void *to ,
                                                unsigned int const len )

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--smsc--smsc9420.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--smsc--smsc9420.ko-entry_point.cil.out.i
@@ -7145,7 +7145,7 @@ static int smsc9420_ethtool_get_eeprom_len(struct net_device *dev )
   return (11);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int smsc9420_ethtool_get_eeprom(struct net_device *dev , struct ethtool_eeprom *eeprom ,
                                        u8 *data )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point.cil.out.i
@@ -6946,7 +6946,7 @@ static void lapbeth_disconnected(struct net_device *dev , int reason )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int lapbeth_set_mac_address(struct net_device *dev , void *addr )
 {
   struct sockaddr *sa ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--x25_asy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--x25_asy.ko-entry_point.cil.out.i
@@ -5751,7 +5751,7 @@ static void x25_asy_free(struct x25_asy *sl )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int x25_asy_change_mtu(struct net_device *dev , int newmtu )
 {
   struct x25_asy *sl ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--8390--8390.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--8390--8390.ko-entry_point.cil.out.i
@@ -5744,7 +5744,7 @@ static void __ei_tx_timeout(struct net_device *dev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static netdev_tx_t __ei_start_xmit(struct sk_buff *skb , struct net_device *dev )
 {
   unsigned long e8390_base ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--micrel--ks8842.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--micrel--ks8842.ko-entry_point.cil.out.i
@@ -5640,7 +5640,7 @@ __inline static struct sk_buff *netdev_alloc_skb_ip_align(struct net_device *dev
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void skb_copy_from_linear_data(struct sk_buff const *skb , void *to ,
                                                unsigned int const len )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
@@ -8646,7 +8646,7 @@ static void ppp_push(struct ppp *ppp )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static bool mp_protocol_compress = 1;
 static int ppp_mp_explode(struct ppp *ppp , struct sk_buff *skb )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.i
@@ -5616,7 +5616,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int usbnet_probe(struct usb_interface * , struct usb_device_id const * ) ;
 extern int usbnet_suspend(struct usb_interface * , pm_message_t ) ;
 extern int usbnet_resume(struct usb_interface * ) ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.i
@@ -5684,7 +5684,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int usbnet_probe(struct usb_interface * , struct usb_device_id const * ) ;
 extern int usbnet_suspend(struct usb_interface * , pm_message_t ) ;
 extern int usbnet_resume(struct usb_interface * ) ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_cisco.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_cisco.ko-entry_point.cil.out.i
@@ -5955,7 +5955,7 @@ static void cisco_stop(struct net_device *dev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static struct hdlc_proto proto =
      {0, 0, & cisco_start, & cisco_stop, 0, & cisco_ioctl, & cisco_type_trans, & cisco_rx,
     0, & __this_module, 0};

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-entry_point.cil.out.i
@@ -7632,7 +7632,7 @@ static int ath6kl_usb_submit_ctrl_out(struct ath6kl_usb *ar_usb , u8 req , u16 v
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ath6kl_usb_submit_ctrl_in(struct ath6kl_usb *ar_usb , u8 req , u16 value ,
                                      u16 index , void *data , u32 size )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_sdio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_sdio.ko-entry_point.cil.out.i
@@ -8734,7 +8734,7 @@ static int mwifiex_check_fw_status(struct mwifiex_adapter *adapter , u32 poll_nu
   return (ret);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int mwifiex_decode_rx_packet(struct mwifiex_adapter *adapter , struct sk_buff *skb ,
                                     u32 upld_typ )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--atm--he.ko-entry_point.cil.out.i
@@ -8497,7 +8497,7 @@ static struct he_tpd *__alloc_tpd(struct he_dev *he_dev )
   return (tpd);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int he_service_rbrq(struct he_dev *he_dev , int group )
 {
   struct he_rbrq *rbrq_tail ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--gadget--pch_udc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--gadget--pch_udc.ko-entry_point.cil.out.i
@@ -3348,7 +3348,7 @@ static void pch_vbus_gpio_free(struct pch_udc_dev *dev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void complete_req(struct pch_udc_ep *ep , struct pch_udc_request *req , int status )
 {
   struct pch_udc_dev *dev ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point.cil.out.i
@@ -4889,7 +4889,7 @@ __inline static void writel(unsigned int val , void volatile *addr )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern unsigned int ioread8(void * ) ;
 __inline static void memcpy_toio(void volatile *dst , void const *src , size_t count )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
@@ -6314,7 +6314,7 @@ static int btmrvl_sdio_verify_fw_download(struct btmrvl_sdio_card *card , int po
   return (-110);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int btmrvl_sdio_download_helper(struct btmrvl_sdio_card *card )
 {
   struct firmware const *fw_helper ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--via--via.ko-entry_point.cil.out.i
@@ -6511,7 +6511,7 @@ static int via_dma_init(struct drm_device *dev , void *data , struct drm_file *f
   return (retcode);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int via_dispatch_cmdbuffer(struct drm_device *dev , drm_via_cmdbuffer_t *cmd )
 {
   drm_via_private_t *dev_priv ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
@@ -6049,7 +6049,7 @@ __inline static struct sk_buff *mI_alloc_skb(unsigned int len , gfp_t gfp_mask )
   return (skb);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static struct sk_buff *_alloc_mISDN_skb(u_int prim , u_int id , u_int len ,
                                                  void *dp , gfp_t gfp_mask )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--can--usb--kvaser_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--can--usb--kvaser_usb.ko-entry_point.cil.out.i
@@ -6345,7 +6345,7 @@ __inline static int kvaser_usb_send_msg(struct kvaser_usb const *dev , struct kv
   return (tmp___0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int kvaser_usb_wait_msg(struct kvaser_usb const *dev , u8 id , struct kvaser_msg *msg )
 {
   struct kvaser_msg *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
@@ -6294,7 +6294,7 @@ __inline static dma_addr_t skb_frag_dma_map(struct device *dev , skb_frag_t cons
   return (tmp___0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 __inline static void skb_copy_from_linear_data(struct sk_buff const *skb , void *to ,
                                                unsigned int const len )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
@@ -3410,7 +3410,7 @@ static int st21nfca_hci_i2c_repack(struct sk_buff *skb )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int st21nfca_hci_i2c_read(struct st21nfca_i2c_phy *phy , struct sk_buff *skb )
 {
   int r ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
@@ -5954,7 +5954,7 @@ static void pvscsi_process_completion_ring(struct pvscsi_adapter *adapter )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int pvscsi_queue_ring(struct pvscsi_adapter *adapter , struct pvscsi_ctx *ctx ,
                              struct scsi_cmnd *cmd )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--isicom.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--isicom.ko-entry_point.cil.out.i
@@ -5179,7 +5179,7 @@ static void isicom_close(struct tty_struct *tty , struct file *filp )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int isicom_write(struct tty_struct *tty , unsigned char const *buf , int count )
 {
   struct isi_port *port ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.i
@@ -6069,7 +6069,7 @@ static int rp_put_char(struct tty_struct *tty , unsigned char ch )
   return (1);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int rp_write(struct tty_struct *tty , unsigned char const *buf , int count )
 {
   struct r_port *info ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--dwc2--dwc2_gadget.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--dwc2--dwc2_gadget.ko-entry_point.cil.out.i
@@ -5234,7 +5234,7 @@ static struct s3c_hsotg_ep *ep_from_windex(struct s3c_hsotg *hsotg , u32 windex 
   return (ep);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int s3c_hsotg_send_reply(struct s3c_hsotg *hsotg , struct s3c_hsotg_ep *ep ,
                                 void *buff , int length )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_-test.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_-test.cil.out.i
@@ -4975,7 +4975,7 @@ __inline static int list_empty(struct list_head const *head )
   return ((unsigned long )((struct list_head const *)head->next) == (unsigned long )head);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void __bad_percpu_size(void) ;
 extern void warn_slowpath_null(char const * , int const ) ;
 extern void *__memcpy(void * , void const * , size_t ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--serial--sierra.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--serial--sierra.ko-entry_point.cil.out.i
@@ -4771,7 +4771,7 @@ static void sierra_outdat_callback(struct urb *urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sierra_write(struct tty_struct *tty , struct usb_serial_port *port , unsigned char const *buf ,
                         int count )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-aloop.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-aloop.ko-entry_point.cil.out.i
@@ -4546,7 +4546,7 @@ static void clear_capture_buf(struct loopback_pcm *dpcm , unsigned int bytes )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void copy_play_buf(struct loopback_pcm *play , struct loopback_pcm *capt ,
                           unsigned int bytes )
 {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2746,7 +2746,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void iounmap(void volatile *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count ) __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -965,7 +965,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ulong record_size = 4096UL;
 static char const __param_str_record_size[12] =
   { (char const )'r', (char const )'e', (char const )'c', (char const )'o',

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3269,7 +3269,7 @@ __inline static void spi_message_add_tail(struct spi_transfer *t , struct spi_me
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int spi_setup(struct spi_device *spi ) ;
 extern int spi_sync(struct spi_device *spi , struct spi_message *message ) ;
 static int cyttsp_spi_xfer(struct cyttsp *ts , u8 op , u8 reg , u8 *buf , int length ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-ce6230.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-ce6230.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6078,7 +6078,7 @@ __inline static void *( __attribute__((__always_inline__)) kmalloc)(size_t size 
   return (tmp___10);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int dvb_usb_device_init(struct usb_interface * , struct dvb_usb_device_properties * ,
                                struct module * , struct dvb_usb_device ** , short *adapter_nums ) ;
 extern void dvb_usb_device_exit(struct usb_interface * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6523,7 +6523,7 @@ int dibusb2_0_power_ctrl(struct dvb_usb_device *d , int onoff )
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void *__crc_dibusb2_0_power_ctrl __attribute__((__weak__)) ;
 static unsigned long const __kcrctab_dibusb2_0_power_ctrl __attribute__((__used__,
 __unused__, __section__("___kcrctab+dibusb2_0_power_ctrl"))) = (unsigned long const )((unsigned long )(& __crc_dibusb2_0_power_ctrl));

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6075,7 +6075,7 @@ __inline static int mt352_write(struct dvb_frontend *fe , u8 const *buf , int le
   return (r);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int dvb_usb_digitv_debug ;
 static char const __param_str_debug[6] = { (char const )'d', (char const )'e', (char const )'b', (char const )'u',
         (char const )'g', (char const )'\000'};

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5834,7 +5834,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 long ldv__builtin_expect(long val , long res ) ;
 extern int ( printk)(char const *fmt , ...) ;
 extern void *memset(void *s , int c , size_t n ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5834,7 +5834,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 long ldv__builtin_expect(long val , long res ) ;
 extern int ( printk)(char const *fmt , ...) ;
 extern void *memset(void *s , int c , size_t n ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6596,7 +6596,7 @@ static int stb6100_set_bandwidth(struct dvb_frontend *fe , u32 bandwidth )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int dvb_ca_en50221_init(struct dvb_adapter *dvb_adapter , struct dvb_ca_en50221 *ca ,
                                int flags , int slot_count ) ;
 extern void dvb_ca_en50221_release(struct dvb_ca_en50221 *ca ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-rtl28xxu.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-rtl28xxu.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6103,7 +6103,7 @@ __inline static void *( __attribute__((__always_inline__)) kmalloc)(size_t size 
   return (tmp___10);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int dvb_usb_device_init(struct usb_interface * , struct dvb_usb_device_properties * ,
                                struct module * , struct dvb_usb_device ** , short *adapter_nums ) ;
 extern void dvb_usb_device_exit(struct usb_interface * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6121,7 +6121,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp___7);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int dvb_usb_device_init(struct usb_interface * , struct dvb_usb_device_properties * ,
                                struct module * , struct dvb_usb_device ** , short *adapter_nums ) ;
 extern void dvb_usb_device_exit(struct usb_interface * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3773,7 +3773,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int gspca_dev_probe(struct usb_interface *intf , struct usb_device_id const *id ,
                            struct sd_desc const *sd_desc , int dev_size , struct module *module ) ;
 extern void gspca_disconnect(struct usb_interface *intf ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2260,7 +2260,7 @@ static int tps6507x_i2c_read_device(struct tps6507x_dev *tps6507x , char reg , i
   return (ret);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int tps6507x_i2c_write_device(struct tps6507x_dev *tps6507x , char reg , int bytes ,
                                      void *src )
 { struct i2c_client *i2c ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2340,7 +2340,7 @@ __inline static void i2c_set_clientdata(struct i2c_client *dev , void *data )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int i2c_register_driver(struct module * , struct i2c_driver * ) ;
 extern void i2c_del_driver(struct i2c_driver * ) ;
 extern int mfd_add_devices(struct device *parent , int id , struct mfd_cell *cells ,

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1044,7 +1044,7 @@ static unsigned long ram_get_unmapped_area(struct mtd_info *mtd , unsigned long 
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                     u_char *buf )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--phram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--phram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1013,7 +1013,7 @@ static int phram_unpoint(struct mtd_info *mtd , loff_t from , size_t len )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int phram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                       u_char *buf )
 { u_char *start ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--slram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--slram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3034,7 +3034,7 @@ static int slram_unpoint(struct mtd_info *mtd , loff_t from , size_t len )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int slram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                       u_char *buf )
 { slram_priv_t *priv ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -927,7 +927,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void iounmap(void volatile *addr ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count ) __attribute__((__no_instrument_function__)) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3725,7 +3725,7 @@ static void find_next_position(struct mtdoops_context *cxt )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mtdoops_do_dump(struct kmsg_dumper *dumper , enum kmsg_dump_reason reason ,
                             char const *s1 , unsigned long l1 , char const *s2 ,
                             unsigned long l2 )

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2539,7 +2539,7 @@ static int onenand_check_overwrite(void *dest , void *src , size_t count )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int pi_operation ;
 static void onenand_data_handle(struct onenand_chip *this , int cmd , int dataram ,
                                 unsigned int offset )

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2327,7 +2327,7 @@ static int write_eraseblock(int ebnum )
   return (err);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int verify_eraseblock(int ebnum )
 { uint32_t j ;
   size_t read ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5862,7 +5862,7 @@ static void ath6kl_usb_device_detached(struct usb_interface *interface )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ath6kl_usb_submit_ctrl_out(struct ath6kl_usb *ar_usb , u8 req , u16 value ,
                                       u16 index , void *data , u32 size )
 { u8 *buf ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--comedi--drivers--comedi_bond.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--comedi--drivers--comedi_bond.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2121,7 +2121,7 @@ static int bonding_dio_insn_config(struct comedi_device *dev , struct comedi_sub
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void *Realloc(void const *oldmem , size_t newlen , size_t oldlen )
 { void *newmem ;
   void *tmp ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--iio--ring_sw.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--staging--iio--ring_sw.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3143,7 +3143,7 @@ __inline static void __iio_free_sw_ring_buffer(struct iio_sw_ring_buffer *ring )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int iio_store_to_sw_ring(struct iio_sw_ring_buffer *ring , unsigned char *data ,
                                 s64 timestamp )
 { int ret ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--iuu_phoenix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--iuu_phoenix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6857,7 +6857,7 @@ static void read_buf_callback(struct urb *urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int iuu_bulk_write(struct usb_serial_port *port )
 { struct iuu_private *priv ;
   void *tmp___7 ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1301,7 +1301,7 @@ static int w1_f2d_write(struct w1_slave *sl , int addr , int len , u8 const *dat
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ssize_t w1_f2d_write_bin(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
                                 char *buf , loff_t off , size_t count )
 { struct w1_slave *sl ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1104,7 +1104,7 @@ static int w1_f23_refresh_block(struct w1_slave *sl , struct w1_f23_data *data ,
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ssize_t w1_f23_read_bin(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
                                char *buf , loff_t off , size_t count )
 { struct w1_slave *sl ;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dib0700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dib0700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7556,7 +7556,7 @@ static int dib0700_set_usb_xfer_len(struct dvb_usb_device *d , u16 nb_ts_packets
   return (ret);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int dib0700_i2c_xfer_new(struct i2c_adapter *adap , struct i2c_msg *msg , int num )
 { struct dvb_usb_device *d ;
   void *tmp___7 ;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--media--video--vivi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6054,7 +6054,7 @@ static void gen_text(struct vivi_dev *dev , char *basep , int y , int x , char *
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void vivi_fillbuff(struct vivi_dev *dev , struct vivi_buffer *buf )
 { int wmax ;
   int hmax ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_linux-43_1a-drivers--usb--gadget--pch_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_linux-43_1a-drivers--usb--gadget--pch_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4223,7 +4223,7 @@ static void pch_vbus_gpio_free(struct pch_udc_dev *dev )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void complete_req(struct pch_udc_ep *ep , struct pch_udc_request *req , int status )
 { struct pch_udc_dev *dev ;
   unsigned int halted ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2720,7 +2720,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -892,7 +892,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 extern struct module __this_module ;
 extern void kfree(void const * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3189,7 +3189,7 @@ __inline static void spi_message_add_tail(struct spi_transfer *t , struct spi_me
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int spi_setup(struct spi_device * ) ;
 extern int spi_sync(struct spi_device * , struct spi_message * ) ;
 static int cyttsp_spi_xfer(struct cyttsp *ts , u8 op , u8 reg , u8 *buf , int length )

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ce6230.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ce6230.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5900,7 +5900,7 @@ __inline static void *i2c_get_adapdata(struct i2c_adapter const *dev )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern struct sk_buff *skb_clone(struct sk_buff * , gfp_t ) ;
 struct sk_buff *ldv_skb_clone_22(struct sk_buff *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 extern struct sk_buff *skb_copy(struct sk_buff const * , gfp_t ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6277,7 +6277,7 @@ int dibusb2_0_power_ctrl(struct dvb_usb_device *d , int onoff )
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int dibusb_i2c_msg(struct dvb_usb_device *d , u8 addr , u8 *wbuf , u16 wlen ,
                           u8 *rbuf , u16 rlen )
 { u8 *sndbuf ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5904,7 +5904,7 @@ __inline static int mt352_write(struct dvb_frontend *fe , u8 const *buf , int le
   return (r);
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 static int dvb_usb_digitv_debug ;
 static short adapter_nr[8U] =
   { (short)-1, (short)-1, (short)-1, (short)-1,

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5803,7 +5803,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5803,7 +5803,7 @@ struct mxl_gpio_cfg {
    u8 dir ;
    u8 val ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 void ldv_spin_lock(void) ;
 void ldv_spin_unlock(void) ;
 int ldv_spin_trylock(void) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6525,7 +6525,7 @@ static int stb6100_set_bandwidth(struct dvb_frontend *fe , u32 bandwidth )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int dvb_ca_en50221_init(struct dvb_adapter * , struct dvb_ca_en50221 * , int ,
                                int ) ;
 extern void dvb_ca_en50221_release(struct dvb_ca_en50221 * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-rtl28xxu.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-rtl28xxu.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5943,7 +5943,7 @@ __inline static void *i2c_get_adapdata(struct i2c_adapter const *dev )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern struct sk_buff *skb_clone(struct sk_buff * , gfp_t ) ;
 struct sk_buff *ldv_skb_clone_22(struct sk_buff *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 extern struct sk_buff *skb_copy(struct sk_buff const * , gfp_t ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5903,7 +5903,7 @@ __inline static void *i2c_get_adapdata(struct i2c_adapter const *dev )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern struct sk_buff *skb_clone(struct sk_buff * , gfp_t ) ;
 struct sk_buff *ldv_skb_clone_22(struct sk_buff *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 extern struct sk_buff *skb_copy(struct sk_buff const * , gfp_t ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3701,7 +3701,7 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   }
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern int gspca_dev_probe(struct usb_interface * , struct usb_device_id const * ,
                            struct sd_desc const * , int , struct module * ) ;
 extern void gspca_frame_add(struct gspca_dev * , enum gspca_packet_type , u8 const * ,

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2219,7 +2219,7 @@ static int tps6507x_i2c_read_device(struct tps6507x_dev *tps6507x , char reg , i
   return (ret);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int tps6507x_i2c_write_device(struct tps6507x_dev *tps6507x , char reg , int bytes ,
                                      void *src )
 { struct i2c_client *i2c ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2305,7 +2305,7 @@ __inline static void i2c_set_clientdata(struct i2c_client *dev , void *data )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern int i2c_register_driver(struct module * , struct i2c_driver * ) ;
 extern void i2c_del_driver(struct i2c_driver * ) ;
 extern int mfd_add_devices(struct device * , int , struct mfd_cell * , int , struct resource * ,

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -991,7 +991,7 @@ static unsigned long ram_get_unmapped_area(struct mtd_info *mtd , unsigned long 
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                     u_char *buf )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--phram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--phram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1009,7 +1009,7 @@ static int phram_unpoint(struct mtd_info *mtd , loff_t from , size_t len )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int phram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                       u_char *buf )
 { u_char *start ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--slram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--slram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2963,7 +2963,7 @@ static int slram_unpoint(struct mtd_info *mtd , loff_t from , size_t len )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int slram_read(struct mtd_info *mtd , loff_t from , size_t len , size_t *retlen ,
                       u_char *buf )
 { slram_priv_t *priv ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -973,7 +973,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memmove(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3345,7 +3345,7 @@ static int write_cached_data(struct mtdblk_dev *mtdblk )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int do_cached_write(struct mtdblk_dev *mtdblk , unsigned long pos , int len ,
                            char const *buf )
 { struct mtd_info *mtd ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3536,7 +3536,7 @@ static void find_next_position(struct mtdoops_context *cxt )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void mtdoops_do_dump(struct kmsg_dumper *dumper , enum kmsg_dump_reason reason ,
                             char const *s1 , unsigned long l1 , char const *s2 ,
                             unsigned long l2 )

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2521,7 +2521,7 @@ static int onenand_check_overwrite(void *dest , void *src , size_t count )
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void onenand_data_handle(struct onenand_chip *this , int cmd , int dataram ,
                                 unsigned int offset )
 { struct mtd_info *mtd ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--tests--mtd_pagetest.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2284,7 +2284,7 @@ static int write_eraseblock(int ebnum )
   return (err);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int verify_eraseblock(int ebnum )
 { uint32_t j ;
   size_t read ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rimi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rimi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4377,7 +4377,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--com90xx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--com90xx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4380,7 +4380,7 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 extern void iounmap(void volatile * ) ;
 __inline static void memcpy_fromio(void *dst , void const volatile *src , size_t count )
 { size_t __len ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--ath--ath6kl--ath6kl_usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5710,7 +5710,7 @@ static void ath6kl_usb_device_detached(struct usb_interface *interface )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ath6kl_usb_submit_ctrl_out(struct ath6kl_usb *ar_usb , u8 req , u16 value ,
                                       u16 index , void *data , u32 size )
 { u8 *buf ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--staging--comedi--drivers--comedi_bond.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--staging--comedi--drivers--comedi_bond.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1989,7 +1989,7 @@ static int bonding_dio_insn_config(struct comedi_device *dev , struct comedi_sub
   }
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void *Realloc(void const *oldmem , size_t newlen , size_t oldlen )
 { void *newmem ;
   void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--staging--iio--ring_sw.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--staging--iio--ring_sw.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3076,7 +3076,7 @@ __inline static void __iio_free_sw_ring_buffer(struct iio_sw_ring_buffer *ring )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int iio_store_to_sw_ring(struct iio_sw_ring_buffer *ring , unsigned char *data ,
                                 s64 timestamp )
 { int ret ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--iuu_phoenix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--iuu_phoenix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6643,7 +6643,7 @@ static void read_buf_callback(struct urb *urb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int iuu_bulk_write(struct usb_serial_port *port )
 { struct iuu_private *priv ;
   void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1293,7 +1293,7 @@ static int w1_f2d_write(struct w1_slave *sl , int addr , int len , u8 const *dat
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ssize_t w1_f2d_write_bin(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
                                 char *buf , loff_t off , size_t count )
 { struct w1_slave *sl ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1009,7 +1009,7 @@ static int w1_f23_refresh_block(struct w1_slave *sl , struct w1_f23_data *data ,
   return (0);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static ssize_t w1_f23_read_bin(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
                                char *buf , loff_t off , size_t count )
 { struct w1_slave *sl ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
@@ -3918,7 +3918,7 @@ struct driver_attribute {
    ssize_t (*show)(struct device_driver * , char * ) ;
    ssize_t (*store)(struct device_driver * , char const * , size_t ) ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef struct device *ldv_func_ret_type___6;
 __inline static long ldv__builtin_expect(long exp , long c ) ;
 __inline static void __read_once_size(void const volatile *p , void *res , int size )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--vfio--vfio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--vfio--vfio.ko-entry_point.cil.out.i
@@ -3435,7 +3435,7 @@ struct vfio_device {
    struct list_head group_next ;
    void *device_data ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef int ldv_func_ret_type;
 typedef int ldv_func_ret_type___0;
 typedef int ldv_func_ret_type___1;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
@@ -3909,7 +3909,7 @@ struct driver_attribute {
    ssize_t (*show)(struct device_driver * , char * ) ;
    ssize_t (*store)(struct device_driver * , char const * , size_t ) ;
 };
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 typedef struct device *ldv_func_ret_type___7;
 __inline static long ldv__builtin_expect(long exp , long c ) ;
 __inline static void __read_once_size(void const volatile *p , void *res , int size )

--- a/c/ldv-validator-v0.6/linux-stable-1b0b0ac-1-108_1a-drivers--net--slip.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-1b0b0ac-1-108_1a-drivers--net--slip.ko-entry_point.cil.out.i
@@ -5441,7 +5441,7 @@ static void sl_free_bufs(struct slip *sl )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sl_realloc_bufs(struct slip *sl , int mtu )
 {
   int err ;

--- a/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.i
@@ -4920,7 +4920,7 @@ static void kobil_write_callback(struct urb *purb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int kobil_write(struct tty_struct *tty , struct usb_serial_port *port , unsigned char const *buf ,
                        int count )
 {

--- a/c/ldv-validator-v0.6/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point.cil.out.i
@@ -6136,7 +6136,7 @@ static int ti_do_download(struct usb_device *dev , int pipe , u8 *buffer , int s
   return (status);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ti_download_firmware(struct ti_device *tdev )
 {
   int status ;

--- a/c/ldv-validator-v0.8/linux-stable-1b0b0ac-1-108_1a-drivers--net--slip.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-1b0b0ac-1-108_1a-drivers--net--slip.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -5446,7 +5446,7 @@ static void sl_free_bufs(struct slip *sl )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int sl_realloc_bufs(struct slip *sl , int mtu )
 {
   int err ;

--- a/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -3891,7 +3891,7 @@ static void kobil_write_callback(struct urb *purb )
   return;
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int kobil_write(struct tty_struct *tty , struct usb_serial_port *port , unsigned char const *buf ,
                        int count )
 {

--- a/c/ldv-validator-v0.8/linux-stable-4ee267b-1-130_7a-drivers--hwmon--ibmaem.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-4ee267b-1-130_7a-drivers--hwmon--ibmaem.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -3107,7 +3107,7 @@ static int aem_send_message(struct aem_ipmi_data *data )
   return (err);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static void aem_msg_handler(struct ipmi_recv_msg *msg , void *user_msg_data )
 {
   unsigned short rx_len ;

--- a/c/ldv-validator-v0.8/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5742d35-1-136_1a-drivers--usb--serial--ti_usb_3410_5052.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -5889,7 +5889,7 @@ static int ti_do_download(struct usb_device *dev , int pipe , u8 *buffer , int s
   return (status);
 }
 }
-extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memcpy(void * , void const * , size_t ) ;
 static int ti_download_firmware(struct ti_device *tdev )
 {
   int status ;


### PR DESCRIPTION
Running gcc -E -P had resulted in files with whitespace differences. No changes
other than whitespace in memcpy declarations in this commit.

A first round of similar changes was already merged in #753, but for some
reason more of these crept in in the meantime.
