### PR TITLE
aws-c-common: fix README

### DIFF
--- a/c/aws-c-common/README.txt
+++ b/c/aws-c-common/README.txt
@@ -29,4 +29,4 @@ Based on commit `816ec134472c4d0d5ad0d949bae3417617f1e63d` from
   Furthermore, a few fixes in the source tree are made.
 - Finally, create all the files with:
 
-    $SV/c/aws-c-common/makeall $SV $AWS
+    $SV/c/aws-c-common/makeall $AWS $SV


### PR DESCRIPTION
The order of arguments expected by makeall is different from what the
README claimed.

@gernst Which Linux distro and version thereof did you use when initially generating and submitting the benchmarks? The instructions (now) work for me, but I'm getting different preprocessing results, so I'm obviously using a different distro right now.