### PR TITLE
CI Speedup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ preprocessing-consistency:
   script:
     - "goto-diff --version"
     - "cd c"
-    - "./compare.sh --keep-going --skip-large"
+    - "./compare.py --keep-going --skip-large"
 
 java:
   stage: checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   matrix:
     - NAME="Sanity checks" DOCKER_IMAGE=sanity-checks COMMAND="c/check.py"
-    - NAME="Preprocessing consistency checks" DOCKER_IMAGE=preprocessing-consistency COMMAND="cd c; ./compare.sh --keep-going --skip-large"
+    - NAME="Preprocessing consistency checks" DOCKER_IMAGE=preprocessing-consistency COMMAND="cd c; ./compare.py --keep-going --skip-large"
     - NAME="gcc-5" DOCKER_IMAGE=gcc:5 COMMAND="gcc-5 -v --version; cd c; make -j2 CC=gcc-5"
     - NAME="clang-3.9" DOCKER_IMAGE=clang:3.9 COMMAND="clang-3.9 -v --version; cd c; make -j2 CC=clang-3.9"
     - NAME="java" DOCKER_IMAGE=java COMMAND="java/check-compile.sh"

--- a/c/compare.py
+++ b/c/compare.py
@@ -6,12 +6,18 @@
 # and compare the goto-cc programs with goto-diff.
 # Finding a difference implies a wrong preprocessing.
 
+import argparse
+import fnmatch
 import glob
 import yaml
 import os
 import shutil
 import subprocess
-from optparse import OptionParser
+
+# files where preprocessed files are different
+BLACKLIST = ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]
+
+CBMC_GIT_PATH = "../cbmc.git/"
 
 
 def expand(s):
@@ -30,35 +36,41 @@ def getArchitecture(cfgfile):
 def getTasksFromSet(setFile):
     with open(setFile, "r") as fp:
         for line in fp:
-            if not line.startswith("#"):
+            if not line.startswith("#"): # ignore comments
                 for task in expand(line.strip()):
                     yield task
 
 
-BLACKLIST = set()
-for f in ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]:
-    BLACKLIST.update(expand(f))
+def buildGotoCC():
+  """ build goto-cc and goto-diff if not available, and then set PATH to find it """
+  if not shutil.which("goto-cc") or not shutil.which("goto-diff"):
+    if not os.path.exists(CBMC_GIT_PATH + "src/goto-cc/goto-cc"):
+      subprocess.check_call(["git", "clone", "--depth=1", "http://github.com/diffblue/cbmc.git", CBMC_GIT_PATH])
+      subprocess.check_call(["make", "-j2", "minisat2-download"], cwd=CBMC_GIT_PATH + "src")
+      subprocess.check_call(["make", "-j2", "CXX=g++-5", "goto-diff.dir", "goto-cc.dir"], cwd=CBMC_GIT_PATH + "src")
+    cwd = os.getcwd()
+    os.environ['PATH'] = ":".join([
+        cwd + "/" + CBMC_GIT_PATH + "src/goto-cc",
+        cwd + "/" + CBMC_GIT_PATH + "src/goto-diff",
+        os.environ['PATH']
+    ])
+
 
 # parse comand line options and set default values
-parser = OptionParser()
-parser.add_option("-k", "--keep-going", dest="KEEP_GOING", default=False, action="store_true")
-parser.add_option("-v", "--diff", action="store_true", default=False, dest="SHOW_DIFF")
-parser.add_option("--skip-large", action="store_true", default=False, dest="SKIP_LARGE")
-(options, args) = parser.parse_args()
+parser = argparse.ArgumentParser()
+parser.add_argument("-k", "--keep-going", dest="KEEP_GOING", action="store_true",
+                    help="do not exit after error")
+parser.add_argument("-v", "--diff", dest="SHOW_DIFF", action="store_true",
+                    help="show the changes for the preprocessed files")
+parser.add_argument("--skip-large", dest="SKIP_LARGE", action="store_true",
+                    help="ignore large benchmark sets (see internal blacklist)")
+parser.add_argument(dest="SETS", type=str, nargs='*', default=["*.set"],
+                    help='set files to be analysed')
+args = parser.parse_args()
 
-# if the user did not directly specify sets, we select all sets
-SETS=[]
-for arg in (args if args else ["*.set"]):
-    SETS.extend(expand(arg))
+SETS = [s for arg in args.SETS for s in expand(arg)]
 
-# build goto-cc and goto-diff if not available, and then set PATH to find it
-if not shutil.which("goto-cc") or not shutil.which("goto-diff"):
-  if not os.path.exists("../cbmc.git/src/goto-cc/goto-cc"):
-    subprocess.call(["git", "clone" "--depth=1" "http://github.com/diffblue/cbmc.git" "../cbmc.git"])
-    subprocess.call(["make", "minisat2-download"], cwd="../cbmc.git/src")
-    subprocess.call(["make", "CXX=g++-5", "goto-diff.dir", "goto-cc.dir"], cwd="../cbmc.git/src")
-  cwd = os.getcwd()
-  os.environ['PATH'] = cwd + "/../cbmc.git/src/goto-cc:" + cwd + "/../cbmc.git/src/goto-diff:" + os.environ['PATH']
+buildGotoCC()
 
 EC=0
 
@@ -74,7 +86,7 @@ for f in SETS:
   if setf == "ConcurrencySafety-Main":
     print("Skipping category", setf, "(platform-dependent types)")
     continue
-  elif options.SKIP_LARGE and setf.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
+  elif args.SKIP_LARGE and setf.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
     print("Skipping category", setf, "(only custom includes, no system headers, checking takes too much time)")
     continue
   elif setf == "Systems_OpenBSD_MemSafety":
@@ -147,23 +159,23 @@ for f in SETS:
 
     # now we have found all required files and start with the actual check:
     # convert both files into goto-cc intermediate language and compare them.
-    subprocess.call(["goto-cc", "-m" + bits, orig])
-    subprocess.call(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
+    subprocess.check_call(["goto-cc", "-m" + bits, orig])
+    subprocess.check_call(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
     p = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if len(stderr) > 0:
         print(stderr.decode('utf-8').strip())
     if len(stdout) > 0:
-      if options.SHOW_DIFF:
+      if args.SHOW_DIFF:
         subprocess.call(["goto-diff", "-u", "a.out", "b.out"])
       shutil.rmtree("a.out", ignore_errors=True)
       shutil.rmtree("b.out", ignore_errors=True)
 
-      if ff in BLACKLIST:
+      if any(fnmatch.fnmatch(f, pattern) for pattern in BLACKLIST):
         print("WARNING: Difference on", ff, "detected (blacklisted)")
       else:
         print("ERROR: Difference on", ff, "detected")
-        if options.KEEP_GOING:
+        if args.KEEP_GOING:
           EC = 1
         else:
           exit(1)

--- a/c/compare.py
+++ b/c/compare.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+
+# This script iterates over all tasks and performs the following check:
+# For each file with existing ".c"- and ".i"-file
+# we generate the goto-cc program (i.e., intermediate representation of cbmc)
+# and compare the goto-cc programs with goto-diff.
+# Finding a difference implies a wrong preprocessing.
+
+import glob
+import yaml
+import os
+import shutil
+import subprocess
+from optparse import OptionParser
+
+
+def expand(s):
+    return sorted(glob.glob(s))
+
+
+def getArchitecture(cfgfile):
+    with open(cfgfile, "r") as fp:
+        for line in fp:
+            if line.startswith("Architecture"):
+                return line.split()[1]
+    print("Invalid configuration file", cfgFile)
+    exit(1)
+
+
+def getTasksFromSet(setFile):
+    with open(setFile, "r") as fp:
+        for line in fp:
+            if not line.startswith("#"):
+                for task in expand(line.strip()):
+                    yield task
+
+
+BLACKLIST = set()
+for f in ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]:
+    BLACKLIST.update(expand(f))
+
+# parse comand line options and set default values
+parser = OptionParser()
+parser.add_option("-k", "--keep-going", dest="KEEP_GOING", default=False, action="store_true")
+parser.add_option("-v", "--diff", action="store_true", default=False, dest="SHOW_DIFF")
+parser.add_option("--skip-large", action="store_true", default=False, dest="SKIP_LARGE")
+(options, args) = parser.parse_args()
+
+# if the user did not directly specify sets, we select all sets
+SETS=[]
+for arg in (args if args else ["*.set"]):
+    SETS.extend(expand(arg))
+
+# build goto-cc and goto-diff if not available, and then set PATH to find it
+if not shutil.which("goto-cc") or not shutil.which("goto-diff"):
+  if not os.path.exists("../cbmc.git/src/goto-cc/goto-cc"):
+    subprocess.run(["git", "clone" "--depth=1" "http://github.com/diffblue/cbmc.git" "../cbmc.git"])
+    subprocess.run(["make", "minisat2-download"], cwd="../cbmc.git/src")
+    subprocess.run(["make", "CXX=g++-5", "goto-diff.dir", "goto-cc.dir"], cwd="../cbmc.git/src")
+  cwd = os.getcwd()
+  os.environ['PATH'] = cwd + "/../cbmc.git/src/goto-cc:" + cwd + "/../cbmc.git/src/goto-diff:" + os.environ['PATH']
+
+EC=0
+
+# iterate over all sets
+for f in SETS:
+  if not os.path.exists(f):
+    print("Invalid set", f)
+    exit(1)
+
+  setf=os.path.basename(f)[:-4] # remove ending ".set"
+
+  # skip some sets, like LDV (too big) or Concurrency (pthread headers are very platform dependent)
+  if setf == "ConcurrencySafety-Main":
+    print("Skipping category", setf, "(platform-dependent types)")
+    continue
+  elif options.SKIP_LARGE and setf.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
+    print("Skipping category", setf, "(only custom includes, no system headers, checking takes too much time)")
+    continue
+  elif setf == "Systems_OpenBSD_MemSafety":
+    print("Skipping category", setf, "(only custom includes, no system headers, complicated build process)")
+    continue
+  elif setf == "Systems_SQLite_MemSafety":
+    print("Skipping category", setf, "(complicated build process, requires patched version of cilly)")
+    continue
+
+  if not os.path.exists(setf + ".cfg"):
+    print("Skipping category", setf, "(no .cfg file present)")
+    continue
+
+  print("Processing category", setf)
+  bits=getArchitecture(setf + ".cfg")
+  if bits not in ["32", "64"]:
+    print("Invalid bit width in file", setf + ".cfg")
+    exit(1)
+
+  # iterate over all files in the set
+  i=0
+  for ff in getTasksFromSet(f):
+    orig=ff
+
+    if ff.endswith(".yml"):
+      with open(ff, 'r') as yamlfile:
+        yml = yaml.safe_load(yamlfile)
+
+      # check whether the input_basename exists (nobody should ever use "null" as a filename!)
+      inputFiles = yml['input_files']
+      if not inputFiles:
+        print("No input files defined in", ff)
+        exit(1)
+
+      # check whether there is exactly one input file, either directly or nested in a list
+      if isinstance(inputFiles, list):
+        print("ignoring task consisting of multiple sourcefiles")
+        continue
+      ff = os.path.join(os.path.dirname(ff), inputFiles)
+
+    if not os.path.exists(ff):
+      print("No task file", ff, "found")
+      exit(1)
+
+    # no original source available
+    if ff.startswith(('ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'ldv-regression/')):
+      # for LDV: there is a related .cil.c file, but it doesn't necessarily match at all
+      continue
+    if ff == "loops/s3.i":
+      continue
+
+    # try to find a matching source file for a preprocessed task
+    if ff.endswith('.c'):
+      continue
+    elif ff.endswith('.c.i'):
+      orig = ff[:-2] # remove ending ".i"
+    elif ff.startswith('ldv-memsafety/memleaks'):
+      orig = ff.replace('memleaks', 'memleaks-notpreprocessed/memleaks')
+      orig = orig[:-2] + ".c" # replace .i with .c
+    else:
+      orig = ff[:-2] + ".c" # replace .i with .c
+
+    if not os.path.exists(orig):
+      print("No original source of", ff, "found")
+      exit(1)
+
+    i += 1
+    if i % 10 == 0:
+      print("Processing file", i, "of category", setf)
+
+    # now we have found all required files and start with the actual check:
+    # convert both files into goto-cc intermediate language and compare them.
+    subprocess.run(["goto-cc", "-m" + bits, orig])
+    subprocess.run(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
+    p = subprocess.run(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if len(p.stderr) > 0:
+        print(p.stderr.decode('utf-8').strip())
+    if len(p.stdout) > 0:
+      if options.SHOW_DIFF:
+        subprocess.run(["goto-diff", "-u", "a.out", "b.out"])
+      shutil.rmtree("a.out", ignore_errors=True)
+      shutil.rmtree("b.out", ignore_errors=True)
+
+      if ff in BLACKLIST:
+        print("WARNING: Difference on", ff, "detected (blacklisted)")
+      else:
+        print("ERROR: Difference on", ff, "detected")
+        if options.KEEP_GOING:
+          EC = 1
+        else:
+          exit(1)
+
+    shutil.rmtree("a.out", ignore_errors=True)
+    shutil.rmtree("b.out", ignore_errors=True)
+
+exit(EC)

--- a/c/compare.py
+++ b/c/compare.py
@@ -37,21 +37,28 @@ TASKS_ONLY_PREPROCESSED = ['ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'l
 CBMC_GIT_PATH = "../cbmc.git/"
 
 
+def fail(*msg):
+  print("CRITICAL ERROR:", *msg)
+  exit(1)
+
+
 def expand(s):
     return sorted(glob.glob(s))
 
 
-def get_architecture(cfgfile):
+def get_architecture(setname):
+    cfgfile = setname + ".cfg"
+    if not os.path.exists(cfgfile):
+      fail("No .cfg file present for category", setname)
+
     with open(cfgfile, "r") as fp:
         for line in fp:
             if line.startswith("Architecture"):
                 bits = line.split()[1]
                 if bits in ["32", "64"]:
                   return bits
-                print("Invalid bit width in file", setname + ".cfg")
-                exit(1)
-    print("Invalid configuration file", cfgFile)
-    exit(1)
+                fail("Invalid bit width in file", setname + ".cfg")
+    fail("Invalid configuration file", cfgFile)
 
 
 def get_tasks_from_set(setFile):
@@ -111,8 +118,7 @@ def get_setfiles(args):
       for setfile in setfiles:
         yield setfile
     else:
-      print("Could not find a matching set file for", setfileWildcard)
-      exit(1)
+      fail("Could not find a matching set file for", setfileWildcard)
 
 
 def get_inputfile_from_yml(taskfile):
@@ -122,12 +128,25 @@ def get_inputfile_from_yml(taskfile):
     # check whether the input_basename exists (nobody should ever use "null" as a filename!)
     inputFiles = yml['input_files']
     if not inputFiles:
-      print("No input files defined in", taskfile)
-      exit(1)
+      fail("No input files defined in", taskfile)
     elif isinstance(inputFiles, list):
         return inputFiles
     else:
         return [inputFiles] # always wrap as list
+
+
+def get_orig_filename(taskfile):
+  """ try to find a matching source file (.c) for a preprocessed task """
+  if taskfile.endswith('.c.i'):
+    orig = taskfile[:-2] # remove ending ".i"
+  if taskfile.startswith('ldv-memsafety/memleaks'):
+    taskfile = taskfile.replace('memleaks', 'memleaks-notpreprocessed/memleaks')
+  orig = taskfile[:-2] + ".c" # replace .i with .c (or .c with .c)
+
+  if os.path.exists(orig):
+      return orig
+  else:
+    fail("No original source of", taskfile, "found at", orig)
 
 
 # parse comand line options and set default values
@@ -157,16 +176,11 @@ for setfile in get_setfiles(args):
     print("Skipping category", setname, LARGE_CATEGORY_BLACKLIST[setname])
     continue
 
-  if not os.path.exists(setname + ".cfg"):
-    print("Skipping category", setname, "(no .cfg file present)")
-    continue
-
   print("Processing category", setname)
-  bits = get_architecture(setname + ".cfg")
+  bits = get_architecture(setname)
 
   i = 0
   for taskfile in get_tasks_from_set(setfile):
-    orig = taskfile
 
     if taskfile.endswith(".yml"):
       inputFiles = get_inputfile_from_yml(taskfile)
@@ -178,27 +192,16 @@ for setfile in get_setfiles(args):
         continue
 
     if not os.path.exists(taskfile):
-      print("No task file", taskfile, "found")
-      exit(1)
+      fail("No task file", taskfile, "found")
 
     # no original source available
     if taskfile.startswith(tuple(TASKS_ONLY_PREPROCESSED)):
       continue
 
     # try to find a matching source file for a preprocessed task
-    if taskfile.endswith('.c'):
-      continue
-    elif taskfile.endswith('.c.i'):
-      orig = taskfile[:-2] # remove ending ".i"
-    elif taskfile.startswith('ldv-memsafety/memleaks'):
-      orig = taskfile.replace('memleaks', 'memleaks-notpreprocessed/memleaks')
-      orig = orig[:-2] + ".c" # replace .i with .c
-    else:
-      orig = taskfile[:-2] + ".c" # replace .i with .c
-
-    if not os.path.exists(orig):
-      print("No original source of", taskfile, "found")
-      exit(1)
+    orig = get_orig_filename(taskfile)
+    if orig == taskfile:
+      continue # taskfile was already a .c-file
 
     i += 1
     if i % 10 == 0:

--- a/c/compare.py
+++ b/c/compare.py
@@ -75,92 +75,92 @@ buildGotoCC()
 EC=0
 
 # iterate over all sets
-for f in SETS:
-  if not os.path.exists(f):
-    print("Invalid set", f)
+for setfile in SETS:
+  if not os.path.exists(setfile):
+    print("Invalid set", setfile)
     exit(1)
 
-  setf=os.path.basename(f)[:-4] # remove ending ".set"
+  setname=os.path.basename(setfile)[:-4] # remove ending ".set"
 
   # skip some sets, like LDV (too big) or Concurrency (pthread headers are very platform dependent)
-  if setf == "ConcurrencySafety-Main":
-    print("Skipping category", setf, "(platform-dependent types)")
+  if setname == "ConcurrencySafety-Main":
+    print("Skipping category", setname, "(platform-dependent types)")
     continue
-  elif args.SKIP_LARGE and setf.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
-    print("Skipping category", setf, "(only custom includes, no system headers, checking takes too much time)")
+  elif args.SKIP_LARGE and setname.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
+    print("Skipping category", setname, "(only custom includes, no system headers, checking takes too much time)")
     continue
-  elif setf == "Systems_OpenBSD_MemSafety":
-    print("Skipping category", setf, "(only custom includes, no system headers, complicated build process)")
+  elif setname == "Systems_OpenBSD_MemSafety":
+    print("Skipping category", setname, "(only custom includes, no system headers, complicated build process)")
     continue
-  elif setf == "Systems_SQLite_MemSafety":
-    print("Skipping category", setf, "(complicated build process, requires patched version of cilly)")
-    continue
-
-  if not os.path.exists(setf + ".cfg"):
-    print("Skipping category", setf, "(no .cfg file present)")
+  elif setname == "Systems_SQLite_MemSafety":
+    print("Skipping category", setname, "(complicated build process, requires patched version of cilly)")
     continue
 
-  print("Processing category", setf)
-  bits=getArchitecture(setf + ".cfg")
+  if not os.path.exists(setname + ".cfg"):
+    print("Skipping category", setname, "(no .cfg file present)")
+    continue
+
+  print("Processing category", setname)
+  bits=getArchitecture(setname + ".cfg")
   if bits not in ["32", "64"]:
-    print("Invalid bit width in file", setf + ".cfg")
+    print("Invalid bit width in file", setname + ".cfg")
     exit(1)
 
   # iterate over all files in the set
   i=0
-  for ff in getTasksFromSet(f):
-    orig=ff
+  for taskfile in getTasksFromSet(setfile):
+    orig=taskfile
 
-    if ff.endswith(".yml"):
-      with open(ff, 'r') as yamlfile:
+    if taskfile.endswith(".yml"):
+      with open(taskfile, 'r') as yamlfile:
         yml = yaml.safe_load(yamlfile)
 
       # check whether the input_basename exists (nobody should ever use "null" as a filename!)
       inputFiles = yml['input_files']
       if not inputFiles:
-        print("No input files defined in", ff)
+        print("No input files defined in", taskfile)
         exit(1)
 
       # check whether there is exactly one input file, either directly or nested in a list
       if isinstance(inputFiles, list):
         print("ignoring task consisting of multiple sourcefiles")
         continue
-      ff = os.path.join(os.path.dirname(ff), inputFiles)
+      taskfile = os.path.join(os.path.dirname(taskfile), inputFiles)
 
-    if not os.path.exists(ff):
-      print("No task file", ff, "found")
+    if not os.path.exists(taskfile):
+      print("No task file", taskfile, "found")
       exit(1)
 
     # no original source available
-    if ff.startswith(('ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'ldv-regression/')):
+    if taskfile.startswith(('ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'ldv-regression/')):
       # for LDV: there is a related .cil.c file, but it doesn't necessarily match at all
       continue
-    if ff == "loops/s3.i":
+    if taskfile == "loops/s3.i":
       continue
 
     # try to find a matching source file for a preprocessed task
-    if ff.endswith('.c'):
+    if taskfile.endswith('.c'):
       continue
-    elif ff.endswith('.c.i'):
-      orig = ff[:-2] # remove ending ".i"
-    elif ff.startswith('ldv-memsafety/memleaks'):
-      orig = ff.replace('memleaks', 'memleaks-notpreprocessed/memleaks')
+    elif taskfile.endswith('.c.i'):
+      orig = taskfile[:-2] # remove ending ".i"
+    elif taskfile.startswith('ldv-memsafety/memleaks'):
+      orig = taskfile.replace('memleaks', 'memleaks-notpreprocessed/memleaks')
       orig = orig[:-2] + ".c" # replace .i with .c
     else:
-      orig = ff[:-2] + ".c" # replace .i with .c
+      orig = taskfile[:-2] + ".c" # replace .i with .c
 
     if not os.path.exists(orig):
-      print("No original source of", ff, "found")
+      print("No original source of", taskfile, "found")
       exit(1)
 
     i += 1
     if i % 10 == 0:
-      print("Processing file", i, "of category", setf)
+      print("Processing file", i, "of category", setname)
 
     # now we have found all required files and start with the actual check:
     # convert both files into goto-cc intermediate language and compare them.
     subprocess.check_call(["goto-cc", "-m" + bits, orig])
-    subprocess.check_call(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
+    subprocess.check_call(["goto-cc", "-m" + bits, taskfile, "-o", "b.out"])
     p = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if len(stderr) > 0:
@@ -171,10 +171,10 @@ for f in SETS:
       shutil.rmtree("a.out", ignore_errors=True)
       shutil.rmtree("b.out", ignore_errors=True)
 
-      if any(fnmatch.fnmatch(f, pattern) for pattern in BLACKLIST):
-        print("WARNING: Difference on", ff, "detected (blacklisted)")
+      if any(fnmatch.fnmatch(setfile, pattern) for pattern in BLACKLIST):
+        print("WARNING: Difference on", taskfile, "detected (blacklisted)")
       else:
-        print("ERROR: Difference on", ff, "detected")
+        print("ERROR: Difference on", taskfile, "detected")
         if args.KEEP_GOING:
           EC = 1
         else:

--- a/c/compare.py
+++ b/c/compare.py
@@ -21,13 +21,13 @@ BLACKLIST = ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]
 # categories to be excluded ... (with reason and debug information)
 CATEGORY_BLACKLIST = {
   "ConcurrencySafety-Main": "(platform-dependent types)",
-  "Systems_OpenBSD_MemSafety": "(only custom includes, no system headers, complicated build process)",
-  "Systems_SQLite_MemSafety": "(complicated build process, requires patched version of cilly)",
+  "Systems-OpenBSD-MemSafety": "(only custom includes, no system headers, complicated build process)",
+  "Systems-SQLite-MemSafety": "(complicated build process, requires patched version of cilly)",
 }
 
 # categories to be excluded, if option "skip-large" is used ... (with reason and debug information)
 LARGE_CATEGORY_BLACKLIST = {
-  "Systems_DeviceDriversLinux64_ReachSafety": "(only custom includes, no system headers, checking takes too much time)",
+  "SoftwareSystems-DeviceDriversLinux64-ReachSafety": "(only custom includes, no system headers, checking takes too much time)",
 }
 
 # no original source available, there are only preprocessed files.

--- a/c/compare.py
+++ b/c/compare.py
@@ -13,6 +13,7 @@ import yaml
 import os
 import shutil
 import subprocess
+import tempfile
 
 # files where preprocessed files are different
 BLACKLIST = ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]
@@ -86,29 +87,32 @@ def build_goto_cc():
 
 def execute_goto_cc(args, setfile, bits, orig, taskfile):
   """ convert both preprocessed and non-preprocessed files into goto-cc intermediate language and compare them """
-  subprocess.check_call(["goto-cc", "-m" + bits, orig, "-o", "a.out"])
-  subprocess.check_call(["goto-cc", "-m" + bits, taskfile, "-o", "b.out"])
-  stdout, stderr = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"],
+  origoutfile = tempfile.NamedTemporaryFile(prefix="compare_orig_", suffix=".out")
+  taskoutfile = tempfile.NamedTemporaryFile(prefix="compare_task_", suffix=".out")
+  origout = origoutfile.name
+  taskout = taskoutfile.name
+
+  try:
+    subprocess.check_call(["goto-cc", "-m" + bits, orig, "-o", origout])
+    subprocess.check_call(["goto-cc", "-m" + bits, taskfile, "-o", taskout])
+    stdout, stderr = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", origout, taskout],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-  if len(stderr) > 0:
-    print(stderr.decode('utf-8').strip())
-  if len(stdout) > 0:
-    if args.SHOW_DIFF:
-      subprocess.call(["goto-diff", "-u", "a.out", "b.out"])
-    shutil.rmtree("a.out", ignore_errors=True)
-    shutil.rmtree("b.out", ignore_errors=True)
-
-    if any(fnmatch.fnmatch(setfile, pattern) for pattern in BLACKLIST):
-      print("WARNING: Difference on", taskfile, "detected (blacklisted)")
-    else:
-      print("ERROR: Difference on", taskfile, "detected")
-      if args.KEEP_GOING:
-        EC = 1
+    if len(stderr) > 0:
+      print(stderr.decode('utf-8').strip())
+    if len(stdout) > 0:
+      if args.SHOW_DIFF:
+        subprocess.call(["goto-diff", "-u", origout, taskout])
+      if any(fnmatch.fnmatch(setfile, pattern) for pattern in BLACKLIST):
+        print("WARNING: Difference on", taskfile, "detected (blacklisted)")
       else:
-        exit(1)
-
-  shutil.rmtree("a.out", ignore_errors=True)
-  shutil.rmtree("b.out", ignore_errors=True)
+        print("ERROR: Difference on", taskfile, "detected")
+        if args.KEEP_GOING:
+          EC = 1
+        else:
+          exit(1)
+  finally:
+    origoutfile.close()
+    taskoutfile.close()
 
 
 def get_setfiles(args):

--- a/c/compare.py
+++ b/c/compare.py
@@ -17,6 +17,23 @@ import subprocess
 # files where preprocessed files are different
 BLACKLIST = ["floats-esbmc-regression/trunc_nondet_2.i", "*pthread*/*"]
 
+# categories to be excluded ... (with reason and debug information)
+CATEGORY_BLACKLIST = {
+  "ConcurrencySafety-Main": "(platform-dependent types)",
+  "Systems_OpenBSD_MemSafety": "(only custom includes, no system headers, complicated build process)",
+  "Systems_SQLite_MemSafety": "(complicated build process, requires patched version of cilly)",
+}
+
+# categories to be excluded, if option "skip-large" is used ... (with reason and debug information)
+LARGE_CATEGORY_BLACKLIST = {
+  "Systems_DeviceDriversLinux64_ReachSafety": "(only custom includes, no system headers, checking takes too much time)",
+}
+
+# no original source available, there are only preprocessed files.
+# for LDV: there is a related .cil.c file, but it doesn't necessarily match at all
+# for loops/s3.i: this single file is special
+TASKS_ONLY_PREPROCESSED = ['ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'ldv-regression/', 'loops/s3.i']
+
 CBMC_GIT_PATH = "../cbmc.git/"
 
 
@@ -56,6 +73,17 @@ def buildGotoCC():
     ])
 
 
+def getSetfiles(args):
+  for setfileWildcard in args.setfiles:
+    setfiles = expand(setfileWildcard)
+    if setfiles:
+      for setfile in setfiles:
+        yield setfile
+    else:
+      print("Could not find a matching set file for", setfileWildcard)
+      exit(1)
+
+
 # parse comand line options and set default values
 parser = argparse.ArgumentParser()
 parser.add_argument("-k", "--keep-going", dest="KEEP_GOING", action="store_true",
@@ -64,36 +92,23 @@ parser.add_argument("-v", "--diff", dest="SHOW_DIFF", action="store_true",
                     help="show the changes for the preprocessed files")
 parser.add_argument("--skip-large", dest="SKIP_LARGE", action="store_true",
                     help="ignore large benchmark sets (see internal blacklist)")
-parser.add_argument(dest="SETS", type=str, nargs='*', default=["*.set"],
+parser.add_argument(dest="setfiles", type=str, nargs='*', default=["*.set"],
                     help='set files to be analysed')
 args = parser.parse_args()
-
-SETS = [s for arg in args.SETS for s in expand(arg)]
 
 buildGotoCC()
 
 EC=0
 
-# iterate over all sets
-for setfile in SETS:
-  if not os.path.exists(setfile):
-    print("Invalid set", setfile)
-    exit(1)
-
-  setname=os.path.basename(setfile)[:-4] # remove ending ".set"
+for setfile in getSetfiles(args):
+  setname = os.path.basename(setfile)[:-4] # remove ending ".set"
 
   # skip some sets, like LDV (too big) or Concurrency (pthread headers are very platform dependent)
-  if setname == "ConcurrencySafety-Main":
-    print("Skipping category", setname, "(platform-dependent types)")
+  if setname in CATEGORY_BLACKLIST:
+    print("Skipping category", setname, CATEGORY_BLACKLIST[setname])
     continue
-  elif args.SKIP_LARGE and setname.startswith("Systems_DeviceDriversLinux64_ReachSafety"):
-    print("Skipping category", setname, "(only custom includes, no system headers, checking takes too much time)")
-    continue
-  elif setname == "Systems_OpenBSD_MemSafety":
-    print("Skipping category", setname, "(only custom includes, no system headers, complicated build process)")
-    continue
-  elif setname == "Systems_SQLite_MemSafety":
-    print("Skipping category", setname, "(complicated build process, requires patched version of cilly)")
+  if args.SKIP_LARGE and setname in LARGE_CATEGORY_BLACKLIST:
+    print("Skipping category", setname, LARGE_CATEGORY_BLACKLIST[setname])
     continue
 
   if not os.path.exists(setname + ".cfg"):
@@ -106,8 +121,7 @@ for setfile in SETS:
     print("Invalid bit width in file", setname + ".cfg")
     exit(1)
 
-  # iterate over all files in the set
-  i=0
+  i = 0
   for taskfile in getTasksFromSet(setfile):
     orig=taskfile
 
@@ -132,10 +146,7 @@ for setfile in SETS:
       exit(1)
 
     # no original source available
-    if taskfile.startswith(('ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'ldv-regression/')):
-      # for LDV: there is a related .cil.c file, but it doesn't necessarily match at all
-      continue
-    if taskfile == "loops/s3.i":
+    if taskfile.startswith(tuple(TASKS_ONLY_PREPROCESSED)):
       continue
 
     # try to find a matching source file for a preprocessed task

--- a/c/compare.py
+++ b/c/compare.py
@@ -41,16 +41,20 @@ def expand(s):
     return sorted(glob.glob(s))
 
 
-def getArchitecture(cfgfile):
+def get_architecture(cfgfile):
     with open(cfgfile, "r") as fp:
         for line in fp:
             if line.startswith("Architecture"):
-                return line.split()[1]
+                bits = line.split()[1]
+                if bits in ["32", "64"]:
+                  return bits
+                print("Invalid bit width in file", setname + ".cfg")
+                exit(1)
     print("Invalid configuration file", cfgFile)
     exit(1)
 
 
-def getTasksFromSet(setFile):
+def get_tasks_from_set(setFile):
     with open(setFile, "r") as fp:
         for line in fp:
             if not line.startswith("#"): # ignore comments
@@ -58,7 +62,7 @@ def getTasksFromSet(setFile):
                     yield task
 
 
-def buildGotoCC():
+def build_goto_cc():
   """ build goto-cc and goto-diff if not available, and then set PATH to find it """
   if not shutil.which("goto-cc") or not shutil.which("goto-diff"):
     if not os.path.exists(CBMC_GIT_PATH + "src/goto-cc/goto-cc"):
@@ -73,7 +77,34 @@ def buildGotoCC():
     ])
 
 
-def getSetfiles(args):
+def execute_goto_cc(args, setfile, bits, orig, taskfile):
+  """ convert both preprocessed and non-preprocessed files into goto-cc intermediate language and compare them """
+  subprocess.check_call(["goto-cc", "-m" + bits, orig, "-o", "a.out"])
+  subprocess.check_call(["goto-cc", "-m" + bits, taskfile, "-o", "b.out"])
+  stdout, stderr = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+  if len(stderr) > 0:
+    print(stderr.decode('utf-8').strip())
+  if len(stdout) > 0:
+    if args.SHOW_DIFF:
+      subprocess.call(["goto-diff", "-u", "a.out", "b.out"])
+    shutil.rmtree("a.out", ignore_errors=True)
+    shutil.rmtree("b.out", ignore_errors=True)
+
+    if any(fnmatch.fnmatch(setfile, pattern) for pattern in BLACKLIST):
+      print("WARNING: Difference on", taskfile, "detected (blacklisted)")
+    else:
+      print("ERROR: Difference on", taskfile, "detected")
+      if args.KEEP_GOING:
+        EC = 1
+      else:
+        exit(1)
+
+  shutil.rmtree("a.out", ignore_errors=True)
+  shutil.rmtree("b.out", ignore_errors=True)
+
+
+def get_setfiles(args):
   for setfileWildcard in args.setfiles:
     setfiles = expand(setfileWildcard)
     if setfiles:
@@ -82,6 +113,21 @@ def getSetfiles(args):
     else:
       print("Could not find a matching set file for", setfileWildcard)
       exit(1)
+
+
+def get_inputfile_from_yml(taskfile):
+  with open(taskfile, 'r') as yamlfile:
+    yml = yaml.safe_load(yamlfile)
+
+    # check whether the input_basename exists (nobody should ever use "null" as a filename!)
+    inputFiles = yml['input_files']
+    if not inputFiles:
+      print("No input files defined in", taskfile)
+      exit(1)
+    elif isinstance(inputFiles, list):
+        return inputFiles
+    else:
+        return [inputFiles] # always wrap as list
 
 
 # parse comand line options and set default values
@@ -96,11 +142,11 @@ parser.add_argument(dest="setfiles", type=str, nargs='*', default=["*.set"],
                     help='set files to be analysed')
 args = parser.parse_args()
 
-buildGotoCC()
+build_goto_cc()
 
 EC=0
 
-for setfile in getSetfiles(args):
+for setfile in get_setfiles(args):
   setname = os.path.basename(setfile)[:-4] # remove ending ".set"
 
   # skip some sets, like LDV (too big) or Concurrency (pthread headers are very platform dependent)
@@ -116,30 +162,20 @@ for setfile in getSetfiles(args):
     continue
 
   print("Processing category", setname)
-  bits=getArchitecture(setname + ".cfg")
-  if bits not in ["32", "64"]:
-    print("Invalid bit width in file", setname + ".cfg")
-    exit(1)
+  bits = get_architecture(setname + ".cfg")
 
   i = 0
-  for taskfile in getTasksFromSet(setfile):
-    orig=taskfile
+  for taskfile in get_tasks_from_set(setfile):
+    orig = taskfile
 
     if taskfile.endswith(".yml"):
-      with open(taskfile, 'r') as yamlfile:
-        yml = yaml.safe_load(yamlfile)
-
-      # check whether the input_basename exists (nobody should ever use "null" as a filename!)
-      inputFiles = yml['input_files']
-      if not inputFiles:
-        print("No input files defined in", taskfile)
-        exit(1)
-
+      inputFiles = get_inputfile_from_yml(taskfile)
       # check whether there is exactly one input file, either directly or nested in a list
-      if isinstance(inputFiles, list):
-        print("ignoring task consisting of multiple sourcefiles")
+      if len(inputFiles) == 1:
+        taskfile = os.path.join(os.path.dirname(taskfile), inputFiles[0])
+      else:
+        print("ignoring task consisting of multiple sourcefiles", inputFiles)
         continue
-      taskfile = os.path.join(os.path.dirname(taskfile), inputFiles)
 
     if not os.path.exists(taskfile):
       print("No task file", taskfile, "found")
@@ -169,29 +205,6 @@ for setfile in getSetfiles(args):
       print("Processing file", i, "of category", setname)
 
     # now we have found all required files and start with the actual check:
-    # convert both files into goto-cc intermediate language and compare them.
-    subprocess.check_call(["goto-cc", "-m" + bits, orig])
-    subprocess.check_call(["goto-cc", "-m" + bits, taskfile, "-o", "b.out"])
-    p = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = p.communicate()
-    if len(stderr) > 0:
-        print(stderr.decode('utf-8').strip())
-    if len(stdout) > 0:
-      if args.SHOW_DIFF:
-        subprocess.call(["goto-diff", "-u", "a.out", "b.out"])
-      shutil.rmtree("a.out", ignore_errors=True)
-      shutil.rmtree("b.out", ignore_errors=True)
-
-      if any(fnmatch.fnmatch(setfile, pattern) for pattern in BLACKLIST):
-        print("WARNING: Difference on", taskfile, "detected (blacklisted)")
-      else:
-        print("ERROR: Difference on", taskfile, "detected")
-        if args.KEEP_GOING:
-          EC = 1
-        else:
-          exit(1)
-
-    shutil.rmtree("a.out", ignore_errors=True)
-    shutil.rmtree("b.out", ignore_errors=True)
+    execute_goto_cc(args, setfile, bits, orig, taskfile)
 
 exit(EC)

--- a/c/compare.py
+++ b/c/compare.py
@@ -44,30 +44,30 @@ def fail(*msg):
 
 
 def expand(s):
-    return sorted(glob.glob(s))
+  return sorted(glob.glob(s))
 
 
 def get_architecture(setname):
-    cfgfile = setname + ".cfg"
-    if not os.path.exists(cfgfile):
-      fail("No .cfg file present for category", setname)
+  cfgfile = setname + ".cfg"
+  if not os.path.exists(cfgfile):
+    fail("No .cfg file present for category", setname)
 
-    with open(cfgfile, "r") as fp:
-        for line in fp:
-            if line.startswith("Architecture"):
-                bits = line.split()[1]
-                if bits in ["32", "64"]:
-                  return bits
-                fail("Invalid bit width in file", setname + ".cfg")
-    fail("Invalid configuration file", cfgFile)
+  with open(cfgfile, "r") as fp:
+    for line in fp:
+      if line.startswith("Architecture"):
+        bits = line.split()[1]
+        if bits in ["32", "64"]:
+          return bits
+        fail("Invalid bit width in file", setname + ".cfg")
+  fail("Invalid configuration file", cfgFile)
 
 
 def get_tasks_from_set(setFile):
-    with open(setFile, "r") as fp:
-        for line in fp:
-            if not line.startswith("#"): # ignore comments
-                for task in expand(line.strip()):
-                    yield task
+  with open(setFile, "r") as fp:
+    for line in fp:
+      if not line.startswith("#"): # ignore comments
+        for task in expand(line.strip()):
+          yield task
 
 
 def build_goto_cc():
@@ -125,7 +125,7 @@ def get_setfiles(args):
       fail("Could not find a matching set file for", setfileWildcard)
 
 
-def get_inputfile_from_yml(taskfile):
+def get_inputfiles_from_yml(taskfile):
   with open(taskfile, 'r') as yamlfile:
     yml = yaml.safe_load(yamlfile)
 
@@ -187,8 +187,7 @@ for setfile in get_setfiles(args):
   for taskfile in get_tasks_from_set(setfile):
 
     if taskfile.endswith(".yml"):
-      inputFiles = get_inputfile_from_yml(taskfile)
-      # check whether there is exactly one input file, either directly or nested in a list
+      inputFiles = get_inputfiles_from_yml(taskfile)
       if len(inputFiles) == 1:
         taskfile = os.path.join(os.path.dirname(taskfile), inputFiles[0])
       else:

--- a/c/compare.py
+++ b/c/compare.py
@@ -54,9 +54,9 @@ for arg in (args if args else ["*.set"]):
 # build goto-cc and goto-diff if not available, and then set PATH to find it
 if not shutil.which("goto-cc") or not shutil.which("goto-diff"):
   if not os.path.exists("../cbmc.git/src/goto-cc/goto-cc"):
-    subprocess.run(["git", "clone" "--depth=1" "http://github.com/diffblue/cbmc.git" "../cbmc.git"])
-    subprocess.run(["make", "minisat2-download"], cwd="../cbmc.git/src")
-    subprocess.run(["make", "CXX=g++-5", "goto-diff.dir", "goto-cc.dir"], cwd="../cbmc.git/src")
+    subprocess.call(["git", "clone" "--depth=1" "http://github.com/diffblue/cbmc.git" "../cbmc.git"])
+    subprocess.call(["make", "minisat2-download"], cwd="../cbmc.git/src")
+    subprocess.call(["make", "CXX=g++-5", "goto-diff.dir", "goto-cc.dir"], cwd="../cbmc.git/src")
   cwd = os.getcwd()
   os.environ['PATH'] = cwd + "/../cbmc.git/src/goto-cc:" + cwd + "/../cbmc.git/src/goto-diff:" + os.environ['PATH']
 
@@ -147,14 +147,15 @@ for f in SETS:
 
     # now we have found all required files and start with the actual check:
     # convert both files into goto-cc intermediate language and compare them.
-    subprocess.run(["goto-cc", "-m" + bits, orig])
-    subprocess.run(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
-    p = subprocess.run(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if len(p.stderr) > 0:
-        print(p.stderr.decode('utf-8').strip())
-    if len(p.stdout) > 0:
+    subprocess.call(["goto-cc", "-m" + bits, orig])
+    subprocess.call(["goto-cc", "-m" + bits, ff, "-o", "b.out"])
+    p = subprocess.Popen(["goto-diff", "--verbosity", "2", "-u", "a.out", "b.out"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    if len(stderr) > 0:
+        print(stderr.decode('utf-8').strip())
+    if len(stdout) > 0:
       if options.SHOW_DIFF:
-        subprocess.run(["goto-diff", "-u", "a.out", "b.out"])
+        subprocess.call(["goto-diff", "-u", "a.out", "b.out"])
       shutil.rmtree("a.out", ignore_errors=True)
       shutil.rmtree("b.out", ignore_errors=True)
 


### PR DESCRIPTION
This is a first step towards an faster CI.
Replacing the Bash script for preprocessing files by a Python-based implementation seems to have a large benefit. The runtime seems to be **more than four times faster**. For details see [old](https://travis-ci.org/sosy-lab/sv-benchmarks/builds/609000272?utm_source=github_status&utm_medium=notification) (>45min) vs [new](https://travis-ci.org/sosy-lab/sv-benchmarks/builds/609156991?utm_source=github_status&utm_medium=notification) (11min) runtime.

I would keep the old Bash script for backwards compatibility testing, except some reviewer proves functional equivalence between both scripts.