### PR TITLE
change MemSafety sub-categories #841

### DIFF
--- a/c/MemSafety-Arrays.set
+++ b/c/MemSafety-Arrays.set
@@ -1,3 +1,6 @@
 array-memsafety/*.yml
 array-examples/*.yml
 array-memsafety-realloc/*.yml
+termination-crafted/Arrays*.yml
+termination-crafted/LexIndexValue*.yml
+termination-crafted/NonTermination3-1.yml

--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -6,3 +6,5 @@ locks/*.yml
 memsafety-ext3/*.yml
 pthread-memsafety/*.yml
 memsafety-bftpd/*.yml
+termination-crafted/4BitCounterPointer.yml
+termination-crafted/SyntaxSupportPointer*.yml

--- a/c/MemSafety-TerminCrafted.cfg
+++ b/c/MemSafety-TerminCrafted.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of array-based programs.
-Architecture: 64 bit
-

--- a/c/MemSafety-TerminCrafted.set
+++ b/c/MemSafety-TerminCrafted.set
@@ -1,1 +1,0 @@
-termination-crafted/*.yml


### PR DESCRIPTION
I merged these benchmarks into `Arrays` and `Other` sub-category of `MemSafety`.

This solves the problem with description in `MemSafety-TerminCrafted.cfg`. Otherwise it would be a very small sub-category as @viktormalik mentioned.

I don't see a problem with benchmarks in 64bit arch, but the suggested sub-categories are in a different architecture. Could this be a problem? I briefly checked these files and I don't think so.

@Heizmann: Just for sure. Please, could you have a look at these few benchmarks (for 32bit arch)?

[termination-crafted/Arrays01-EquivalentConstantIndices-1.c](../blob/master/c/termination-crafted/Arrays01-EquivalentConstantIndices-1.c)
[termination-crafted/Arrays02-EquivalentConstantIndices.c](../blob/master/c/termination-crafted/Arrays02-EquivalentConstantIndices.c)
[termination-crafted/Arrays03-ValueRestictsIndex-2.c](../blob/master/c/termination-crafted/Arrays03-ValueRestictsIndex-2.c)
[termination-crafted/LexIndexValue-Array-1.c](../blob/master/c/termination-crafted/LexIndexValue-Array-1.c)
[termination-crafted/LexIndexValue-Pointer-2.c](../blob/master/c/termination-crafted/LexIndexValue-Pointer-2.c)
[termination-crafted/LexIndexValue-Pointer-3.c](../blob/master/c/termination-crafted/LexIndexValue-Pointer-3.c)
[termination-crafted/NonTermination3-1.c](../blob/master/c/termination-crafted/NonTermination3-1.c)
[termination-crafted/4BitCounterPointer.c](../blob/master/c/termination-crafted/4BitCounterPointer.c)
[termination-crafted/SyntaxSupportPointer01-1.c](../blob/master/c/termination-crafted/SyntaxSupportPointer01-1.c)
[termination-crafted/SyntaxSupportPointer01-3.c](../blob/master/c/termination-crafted/SyntaxSupportPointer01-3.c)