### PR TITLE
Replace ldv_xmalloc_unknown_size(0UL) by ldv_xmalloc(0UL)

### DIFF
--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
@@ -6348,7 +6348,7 @@ void *ldv_pci_scenario_3(void *arg0 )
   }
   if (tmp___5 != 0) {
     {
-    tmp___3 = ldv_xmalloc_unknown_size(0UL);
+    tmp___3 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___3;
     ldv_pre_probe();
     ldv_3_ret_default = ldv_pci_scenario_probe_3_17((int (*)(struct pci_dev * , struct pci_device_id * ))ldv_3_container_pci_driver->probe,
@@ -9912,7 +9912,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   ldv_4_resource_file = (struct file *)tmp___8;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___9 = ldv_xmalloc_unknown_size(0UL);
+  tmp___9 = ldv_xmalloc(0UL);
   ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___9;
   tmp___10 = ldv_xmalloc(520UL);
   ldv_4_resource_file = (struct file *)tmp___10;
@@ -9961,7 +9961,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_main_4;
   } else {
     {
-    tmp___13 = ldv_xmalloc_unknown_size(0UL);
+    tmp___13 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___13;
     tmp___14 = ldv_undef_int();
     }
@@ -9991,9 +9991,9 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_2:
     {
-    tmp___15 = ldv_xmalloc_unknown_size(0UL);
+    tmp___15 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_1_default = (char *)tmp___15;
-    tmp___16 = ldv_xmalloc_unknown_size(0UL);
+    tmp___16 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_3_default = (long long *)tmp___16;
     ldv_partially_ordered_scenario_callback_4_22(ldv_4_callback_read, ldv_4_resource_file,
                                                  ldv_4_ldv_param_22_1_default, ldv_4_ldv_param_22_2_default,
@@ -10004,7 +10004,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_3:
     {
-    tmp___17 = ldv_xmalloc_unknown_size(0UL);
+    tmp___17 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___17;
     ldv_partially_ordered_scenario_callback_4_19(ldv_4_callback_poll, ldv_4_resource_file,
                                                  ldv_4_ldv_param_19_1_default);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.c
@@ -6408,7 +6408,7 @@ void *ldv_pci_scenario_3(void *arg0 )
   }
   if (tmp___5 != 0) {
     {
-    tmp___3 = ldv_xmalloc_unknown_size(0UL);
+    tmp___3 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___3;
     ldv_pre_probe();
     ldv_3_ret_default = ldv_pci_scenario_probe_3_17((int (*)(struct pci_dev * , struct pci_device_id * ))ldv_3_container_pci_driver->probe,
@@ -10323,7 +10323,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   ldv_4_resource_file = (struct file *)tmp___8;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___9 = ldv_xmalloc_unknown_size(0UL);
+  tmp___9 = ldv_xmalloc(0UL);
   ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___9;
   tmp___10 = ldv_xmalloc(520UL);
   ldv_4_resource_file = (struct file *)tmp___10;
@@ -10372,7 +10372,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_main_4;
   } else {
     {
-    tmp___13 = ldv_xmalloc_unknown_size(0UL);
+    tmp___13 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___13;
     tmp___14 = ldv_undef_int();
     }
@@ -10406,9 +10406,9 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_2: /* CIL Label */ 
     {
-    tmp___15 = ldv_xmalloc_unknown_size(0UL);
+    tmp___15 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_1_default = (char *)tmp___15;
-    tmp___16 = ldv_xmalloc_unknown_size(0UL);
+    tmp___16 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_3_default = (long long *)tmp___16;
     ldv_partially_ordered_scenario_callback_4_22(ldv_4_callback_read, ldv_4_resource_file,
                                                  ldv_4_ldv_param_22_1_default, ldv_4_ldv_param_22_2_default,
@@ -10419,7 +10419,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_3: /* CIL Label */ 
     {
-    tmp___17 = ldv_xmalloc_unknown_size(0UL);
+    tmp___17 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___17;
     ldv_partially_ordered_scenario_callback_4_19(ldv_4_callback_poll, ldv_4_resource_file,
                                                  ldv_4_ldv_param_19_1_default);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
@@ -6350,7 +6350,7 @@ void *ldv_pci_scenario_3(void *arg0 )
   }
   if (tmp___5 != 0) {
     {
-    tmp___3 = ldv_xmalloc_unknown_size(0UL);
+    tmp___3 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___3;
     ldv_pre_probe();
     ldv_3_ret_default = ldv_pci_scenario_probe_3_17((int (*)(struct pci_dev * , struct pci_device_id * ))ldv_3_container_pci_driver->probe,
@@ -9913,7 +9913,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   ldv_4_resource_file = (struct file *)tmp___8;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___9 = ldv_xmalloc_unknown_size(0UL);
+  tmp___9 = ldv_xmalloc(0UL);
   ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___9;
   tmp___10 = ldv_xmalloc(520UL);
   ldv_4_resource_file = (struct file *)tmp___10;
@@ -9962,7 +9962,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_main_4;
   } else {
     {
-    tmp___13 = ldv_xmalloc_unknown_size(0UL);
+    tmp___13 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___13;
     tmp___14 = ldv_undef_int();
     }
@@ -9992,9 +9992,9 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_2:
     {
-    tmp___15 = ldv_xmalloc_unknown_size(0UL);
+    tmp___15 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_1_default = (char *)tmp___15;
-    tmp___16 = ldv_xmalloc_unknown_size(0UL);
+    tmp___16 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_22_3_default = (long long *)tmp___16;
     ldv_partially_ordered_scenario_callback_4_22(ldv_4_callback_read, ldv_4_resource_file,
                                                  ldv_4_ldv_param_22_1_default, ldv_4_ldv_param_22_2_default,
@@ -10005,7 +10005,7 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
     goto ldv_36587;
     case_3:
     {
-    tmp___17 = ldv_xmalloc_unknown_size(0UL);
+    tmp___17 = ldv_xmalloc(0UL);
     ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___17;
     ldv_partially_ordered_scenario_callback_4_19(ldv_4_callback_poll, ldv_4_resource_file,
                                                  ldv_4_ldv_param_19_1_default);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
@@ -10659,7 +10659,7 @@ void *ldv_platform_instance_4(void *arg0 )
   goto switch_default;
   case_1: /* CIL Label */ 
   {
-  tmp___8 = ldv_xmalloc_unknown_size(0UL);
+  tmp___8 = ldv_xmalloc(0UL);
   ldv_4_ldv_param_18_1_default = (struct pm_message *)tmp___8;
   ldv_platform_instance_callback_4_18(ldv_4_callback_suspend, ldv_4_resource_platform_device,
                                       ldv_4_ldv_param_18_1_default);
@@ -10868,13 +10868,13 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   }
   if (tmp___7 != 0) {
     {
-    tmp___4 = ldv_xmalloc_unknown_size(0UL);
+    tmp___4 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___4;
     tmp___6 = ldv_undef_int();
     }
     if (tmp___6 != 0) {
       {
-      tmp___5 = ldv_xmalloc_unknown_size(0UL);
+      tmp___5 = ldv_xmalloc(0UL);
       ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___5;
       ldv_random_allocationless_scenario_callback_3_8(ldv_3_callback_ndo_start_xmit,
                                                       ldv_3_ldv_param_8_0_default,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
@@ -10310,7 +10310,7 @@ void *ldv_platform_instance_4(void *arg0 )
   goto switch_default;
   case_1:
   {
-  tmp___8 = ldv_xmalloc_unknown_size(0UL);
+  tmp___8 = ldv_xmalloc(0UL);
   ldv_4_ldv_param_18_1_default = (struct pm_message *)tmp___8;
   ldv_platform_instance_callback_4_18(ldv_4_callback_suspend, ldv_4_resource_platform_device,
                                       ldv_4_ldv_param_18_1_default);
@@ -10505,13 +10505,13 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   }
   if (tmp___7 != 0) {
     {
-    tmp___4 = ldv_xmalloc_unknown_size(0UL);
+    tmp___4 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___4;
     tmp___6 = ldv_undef_int();
     }
     if (tmp___6 != 0) {
       {
-      tmp___5 = ldv_xmalloc_unknown_size(0UL);
+      tmp___5 = ldv_xmalloc(0UL);
       ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___5;
       ldv_random_allocationless_scenario_callback_3_8(ldv_3_callback_ndo_start_xmit,
                                                       ldv_3_ldv_param_8_0_default,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
@@ -8144,13 +8144,13 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   }
   if (tmp___7 != 0) {
     {
-    tmp___4 = ldv_xmalloc_unknown_size(0UL);
+    tmp___4 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___4;
     tmp___6 = ldv_undef_int();
     }
     if (tmp___6 != 0) {
       {
-      tmp___5 = ldv_xmalloc_unknown_size(0UL);
+      tmp___5 = ldv_xmalloc(0UL);
       ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___5;
       ldv_random_allocationless_scenario_callback_3_8(ldv_3_callback_ndo_start_xmit,
                                                       ldv_3_ldv_param_8_0_default,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
@@ -7982,13 +7982,13 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   }
   if (tmp___7 != 0) {
     {
-    tmp___4 = ldv_xmalloc_unknown_size(0UL);
+    tmp___4 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___4;
     tmp___6 = ldv_undef_int();
     }
     if (tmp___6 != 0) {
       {
-      tmp___5 = ldv_xmalloc_unknown_size(0UL);
+      tmp___5 = ldv_xmalloc(0UL);
       ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___5;
       ldv_random_allocationless_scenario_callback_3_8(ldv_3_callback_ndo_start_xmit,
                                                       ldv_3_ldv_param_8_0_default,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.c
@@ -5895,7 +5895,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   ldv_2_resource_inode = (struct inode *)tmp___7;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___8 = ldv_xmalloc_unknown_size(0UL);
+  tmp___8 = ldv_xmalloc(0UL);
   ldv_2_container_file_operations = (struct file_operations *)tmp___8;
   tmp___9 = ldv_xmalloc(520UL);
   ldv_2_resource_file = (struct file *)tmp___9;
@@ -5961,9 +5961,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto switch_default;
   case_1: /* CIL Label */ 
   {
-  tmp___15 = ldv_xmalloc_unknown_size(0UL);
+  tmp___15 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_1_default = (char *)tmp___15;
-  tmp___16 = ldv_xmalloc_unknown_size(0UL);
+  tmp___16 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_3_default = (long long *)tmp___16;
   __VERIFIER_assume(ldv_2_size_cnt_write_size <= 2147479552UL);
   ldv_character_driver_scenario_write_2_4((ssize_t (*)(struct file * , char * , size_t  ,
@@ -5986,9 +5986,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   }
   if (tmp___19 != 0) {
     {
-    tmp___17 = ldv_xmalloc_unknown_size(0UL);
+    tmp___17 = ldv_xmalloc(0UL);
     ldv_2_ldv_param_22_1_default = (char *)tmp___17;
-    tmp___18 = ldv_xmalloc_unknown_size(0UL);
+    tmp___18 = ldv_xmalloc(0UL);
     ldv_2_ldv_param_22_3_default = (long long *)tmp___18;
     ldv_character_driver_scenario_callback_2_22(ldv_2_callback_read, ldv_2_resource_file,
                                                 ldv_2_ldv_param_22_1_default, ldv_2_size_cnt_write_size,
@@ -6369,7 +6369,7 @@ void *ldv_usb_scenario_3(void *arg0 )
   }
   if (tmp___9 != 0) {
     {
-    tmp___6 = ldv_xmalloc_unknown_size(0UL);
+    tmp___6 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___6;
     ldv_pre_probe();
     ldv_3_probe_retval_default = ldv_usb_scenario_probe_3_14((int (*)(struct usb_interface * ,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.i
@@ -5784,7 +5784,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   ldv_2_resource_inode = (struct inode *)tmp___7;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___8 = ldv_xmalloc_unknown_size(0UL);
+  tmp___8 = ldv_xmalloc(0UL);
   ldv_2_container_file_operations = (struct file_operations *)tmp___8;
   tmp___9 = ldv_xmalloc(520UL);
   ldv_2_resource_file = (struct file *)tmp___9;
@@ -5847,9 +5847,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto switch_default;
   case_1:
   {
-  tmp___15 = ldv_xmalloc_unknown_size(0UL);
+  tmp___15 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_1_default = (char *)tmp___15;
-  tmp___16 = ldv_xmalloc_unknown_size(0UL);
+  tmp___16 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_3_default = (long long *)tmp___16;
   __VERIFIER_assume(ldv_2_size_cnt_write_size <= 2147479552UL);
   ldv_character_driver_scenario_write_2_4((ssize_t (*)(struct file * , char * , size_t ,
@@ -5872,9 +5872,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   }
   if (tmp___19 != 0) {
     {
-    tmp___17 = ldv_xmalloc_unknown_size(0UL);
+    tmp___17 = ldv_xmalloc(0UL);
     ldv_2_ldv_param_22_1_default = (char *)tmp___17;
-    tmp___18 = ldv_xmalloc_unknown_size(0UL);
+    tmp___18 = ldv_xmalloc(0UL);
     ldv_2_ldv_param_22_3_default = (long long *)tmp___18;
     ldv_character_driver_scenario_callback_2_22(ldv_2_callback_read, ldv_2_resource_file,
                                                 ldv_2_ldv_param_22_1_default, ldv_2_size_cnt_write_size,
@@ -6228,7 +6228,7 @@ void *ldv_usb_scenario_3(void *arg0 )
   }
   if (tmp___9 != 0) {
     {
-    tmp___6 = ldv_xmalloc_unknown_size(0UL);
+    tmp___6 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___6;
     ldv_pre_probe();
     ldv_3_probe_retval_default = ldv_usb_scenario_probe_3_14((int (*)(struct usb_interface * ,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.c
@@ -5321,7 +5321,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   ldv_2_resource_inode = (struct inode *)tmp___10;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___11 = ldv_xmalloc_unknown_size(0UL);
+  tmp___11 = ldv_xmalloc(0UL);
   ldv_2_container_file_operations = (struct file_operations *)tmp___11;
   tmp___12 = ldv_xmalloc(520UL);
   ldv_2_resource_file = (struct file *)tmp___12;
@@ -5387,9 +5387,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto switch_default___0;
   case_1: /* CIL Label */ 
   {
-  tmp___18 = ldv_xmalloc_unknown_size(0UL);
+  tmp___18 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_1_default = (char *)tmp___18;
-  tmp___19 = ldv_xmalloc_unknown_size(0UL);
+  tmp___19 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_3_default = (long long *)tmp___19;
   __VERIFIER_assume(ldv_2_size_cnt_write_size <= 2147479552UL);
   ldv_character_driver_scenario_write_2_4((ssize_t (*)(struct file * , char * , size_t  ,
@@ -5440,9 +5440,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto ldv_30874;
   case_2___0: /* CIL Label */ 
   {
-  tmp___21 = ldv_xmalloc_unknown_size(0UL);
+  tmp___21 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_25_1_default = (char *)tmp___21;
-  tmp___22 = ldv_xmalloc_unknown_size(0UL);
+  tmp___22 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_25_3_default = (long long *)tmp___22;
   ldv_character_driver_scenario_callback_2_25(ldv_2_callback_read, ldv_2_resource_file,
                                               ldv_2_ldv_param_25_1_default, ldv_2_size_cnt_write_size,
@@ -5453,7 +5453,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto ldv_30874;
   case_3___0: /* CIL Label */ 
   {
-  tmp___23 = ldv_xmalloc_unknown_size(0UL);
+  tmp___23 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_22_1_default = (struct poll_table_struct *)tmp___23;
   ldv_character_driver_scenario_callback_2_22(ldv_2_callback_poll, ldv_2_resource_file,
                                               ldv_2_ldv_param_22_1_default);
@@ -5865,7 +5865,7 @@ void *ldv_usb_scenario_3(void *arg0 )
   }
   if (tmp___9 != 0) {
     {
-    tmp___6 = ldv_xmalloc_unknown_size(0UL);
+    tmp___6 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___6;
     ldv_pre_probe();
     ldv_3_probe_retval_default = ldv_usb_scenario_probe_3_14((int (*)(struct usb_interface * ,

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.i
@@ -5218,7 +5218,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   ldv_2_resource_inode = (struct inode *)tmp___10;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
-  tmp___11 = ldv_xmalloc_unknown_size(0UL);
+  tmp___11 = ldv_xmalloc(0UL);
   ldv_2_container_file_operations = (struct file_operations *)tmp___11;
   tmp___12 = ldv_xmalloc(520UL);
   ldv_2_resource_file = (struct file *)tmp___12;
@@ -5281,9 +5281,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto switch_default___0;
   case_1:
   {
-  tmp___18 = ldv_xmalloc_unknown_size(0UL);
+  tmp___18 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_1_default = (char *)tmp___18;
-  tmp___19 = ldv_xmalloc_unknown_size(0UL);
+  tmp___19 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_4_3_default = (long long *)tmp___19;
   __VERIFIER_assume(ldv_2_size_cnt_write_size <= 2147479552UL);
   ldv_character_driver_scenario_write_2_4((ssize_t (*)(struct file * , char * , size_t ,
@@ -5330,9 +5330,9 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto ldv_30874;
   case_2___0:
   {
-  tmp___21 = ldv_xmalloc_unknown_size(0UL);
+  tmp___21 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_25_1_default = (char *)tmp___21;
-  tmp___22 = ldv_xmalloc_unknown_size(0UL);
+  tmp___22 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_25_3_default = (long long *)tmp___22;
   ldv_character_driver_scenario_callback_2_25(ldv_2_callback_read, ldv_2_resource_file,
                                               ldv_2_ldv_param_25_1_default, ldv_2_size_cnt_write_size,
@@ -5343,7 +5343,7 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   goto ldv_30874;
   case_3___0:
   {
-  tmp___23 = ldv_xmalloc_unknown_size(0UL);
+  tmp___23 = ldv_xmalloc(0UL);
   ldv_2_ldv_param_22_1_default = (struct poll_table_struct *)tmp___23;
   ldv_character_driver_scenario_callback_2_22(ldv_2_callback_poll, ldv_2_resource_file,
                                               ldv_2_ldv_param_22_1_default);
@@ -5724,7 +5724,7 @@ void *ldv_usb_scenario_3(void *arg0 )
   }
   if (tmp___9 != 0) {
     {
-    tmp___6 = ldv_xmalloc_unknown_size(0UL);
+    tmp___6 = ldv_xmalloc(0UL);
     ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___6;
     ldv_pre_probe();
     ldv_3_probe_retval_default = ldv_usb_scenario_probe_3_14((int (*)(struct usb_interface * ,


### PR DESCRIPTION
The size of the desired allocation is perfectly known, there is no need
to use the _unknown_size variant. This is in preparation of removing
uses of __VERIFIER_nondet_pointer (see #767).

Changes were made as follows:
```
perl -p -i -e \
  's/ldv_xmalloc_unknown_size\(0UL\);/ldv_xmalloc(0UL);/' \
  c/ldv-*/*.[ci]
```
