### PR TITLE
Replace ldv_zalloc_unknown_size by ldv_zalloc in kzalloc_node

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -74008,6 +74008,7 @@ void ixgbe_tx_ctxtdesc(struct ixgbe_ring *tx_ring , u32 vlan_macip_lens , u32 fc
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -74015,7 +74016,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -81317,7 +81318,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -68166,13 +68166,14 @@ void ixgbe_tx_ctxtdesc(struct ixgbe_ring *tx_ring , u32 vlan_macip_lens , u32 fc
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -74817,7 +74818,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
@@ -37211,6 +37211,7 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -37218,7 +37219,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -37491,7 +37492,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -34988,13 +34988,14 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -35238,7 +35239,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -74158,6 +74158,7 @@ void ixgbe_tx_ctxtdesc(struct ixgbe_ring *tx_ring , u32 vlan_macip_lens , u32 fc
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -74165,7 +74166,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -81277,7 +81278,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -68653,13 +68653,14 @@ void ixgbe_tx_ctxtdesc(struct ixgbe_ring *tx_ring , u32 vlan_macip_lens , u32 fc
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -75138,7 +75139,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -15555,6 +15555,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -15562,7 +15563,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -16674,7 +16675,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -14739,13 +14739,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -15704,7 +15705,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -15489,6 +15489,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -15496,7 +15497,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -20804,7 +20805,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -14603,13 +14603,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -19410,7 +19411,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -16537,6 +16537,7 @@ int ldv_request_irq(int arg0 , unsigned int arg1 , enum irqreturn (*arg2)(int  ,
   return (arg0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -16544,7 +16545,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -32976,7 +32977,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -15561,13 +15561,14 @@ int ldv_request_irq(int arg0 , unsigned int arg1 , enum irqreturn (*arg2)(int , 
   return (arg0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -30509,7 +30510,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -15555,6 +15555,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -15562,7 +15563,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -16674,7 +16675,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -15489,6 +15489,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -15496,7 +15497,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -20804,7 +20805,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -16537,6 +16537,7 @@ int ldv_request_irq(int arg0 , unsigned int arg1 , enum irqreturn (*arg2)(int  ,
   return (arg0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc_node(size_t size , gfp_t flags , int node ) 
 { 
   void *res ;
@@ -16544,7 +16545,7 @@ __inline static void *kzalloc_node(size_t size , gfp_t flags , int node )
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_zalloc_unknown_size();
+  res = ldv_zalloc(size);
   ldv_after_alloc(res);
   }
   return (res);
@@ -32976,7 +32977,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;


### PR DESCRIPTION
kzalloc_node provides size information, thus there is no need to use the
_unknown_size variant. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

Changes were made using:
```
perl -p -i -e \
  's/res = ldv_zalloc_unknown_size\(\);/res = ldv_zalloc(size);/' \
  c/ldv-*/*.[ci]
```
