### PR TITLE
Specialise kmem_cache_zalloc to the desired allocation size

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -26644,6 +26644,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags ) 
 { 
   void *tmp ;
@@ -26651,7 +26652,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct stripe_head));
   }
   return (tmp);
 }
@@ -27831,7 +27832,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -24845,13 +24845,14 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct stripe_head));
   }
   return (tmp);
 }
@@ -25881,7 +25882,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -18397,6 +18397,7 @@ int oz_are_elts_available(struct oz_elt_buf *buf )
   return (tmp == 0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags ) 
 { 
   void *tmp ;
@@ -18404,7 +18405,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct oz_elt_info));
   }
   return (tmp);
 }
@@ -22971,7 +22972,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -17282,13 +17282,14 @@ int oz_are_elts_available(struct oz_elt_buf *buf )
   return (tmp == 0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct oz_elt_info));
   }
   return (tmp);
 }
@@ -21408,7 +21409,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -26644,6 +26644,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags ) 
 { 
   void *tmp ;
@@ -26651,7 +26652,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct stripe_head));
   }
   return (tmp);
 }
@@ -27831,7 +27832,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -18397,6 +18397,7 @@ int oz_are_elts_available(struct oz_elt_buf *buf )
   return (tmp == 0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags ) 
 { 
   void *tmp ;
@@ -18404,7 +18405,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_zalloc_unknown_size();
+  tmp = ldv_zalloc(sizeof(struct oz_elt_info));
   }
   return (tmp);
 }
@@ -22971,7 +22972,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;


### PR DESCRIPTION
kmem_cache_zalloc should allocate (from a cache) memory of the size
confirmed when the cache was created (via kmem_cache_create). Since none
of the benchmarks provide a definition of kmem_cache_create (or struct
kmem_cache), this information cannot be communicated. Instead, hard-code
the allocation size as used in the specific device driver in
kmem_cache_zalloc and use ldv_zalloc instead of ldv_zalloc_unknown_size.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).
