### PR TITLE
Implement dma_zalloc_coherent using ldv_zalloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
@@ -6697,6 +6697,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -13599,7 +13600,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -16819,7 +16820,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
@@ -6628,6 +6628,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -12875,7 +12876,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -15818,7 +15819,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7924,6 +7924,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -46060,7 +46061,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -46618,7 +46619,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7800,6 +7800,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -42521,7 +42522,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -43010,7 +43011,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8477,6 +8477,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -22119,7 +22120,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31347,7 +31348,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8377,6 +8377,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -20838,7 +20839,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -29307,7 +29308,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30696,6 +30696,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -34544,7 +34545,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -35625,7 +35626,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28633,6 +28633,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -32132,7 +32133,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -33160,7 +33161,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -8932,6 +8932,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int u64_stats_fetch_begin_bh(struct u64_stats_sync  const  *syncp ) 
@@ -24860,7 +24861,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -47216,7 +47217,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8836,6 +8836,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int u64_stats_fetch_begin_bh(struct u64_stats_sync const *syncp )
@@ -23370,7 +23371,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -43860,7 +43861,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6889,6 +6889,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -12994,7 +12995,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17954,7 +17955,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6815,6 +6815,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -12419,7 +12420,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17045,7 +17046,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7316,6 +7316,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -17659,7 +17660,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -18097,7 +18098,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7194,6 +7194,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -16681,7 +16682,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17069,7 +17070,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -27558,6 +27558,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern int request_threaded_irq(unsigned int  , irqreturn_t (*)(int  , void * ) ,
@@ -28447,7 +28448,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -102529,7 +102530,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -25697,6 +25697,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern int request_threaded_irq(unsigned int , irqreturn_t (*)(int , void * ) ,
@@ -26502,7 +26503,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -93413,7 +93414,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7585,6 +7585,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -17832,7 +17833,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19668,7 +19669,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7463,6 +7463,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -16851,7 +16852,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -18506,7 +18507,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7562,6 +7562,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19319,7 +19320,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7439,6 +7439,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -18207,7 +18208,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7916,6 +7916,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -27104,7 +27105,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7774,6 +7774,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -25282,7 +25283,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8493,6 +8493,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31673,7 +31674,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8390,6 +8390,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29577,7 +29578,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -9046,6 +9046,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -47843,7 +47844,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8937,6 +8937,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -44420,7 +44421,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.c
@@ -27812,6 +27812,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -102753,7 +102754,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.i
@@ -25910,6 +25910,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -93561,7 +93562,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7563,6 +7563,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19320,7 +19321,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7440,6 +7440,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -18208,7 +18209,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -30305,6 +30305,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -34221,7 +34222,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28490,6 +28490,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32069,7 +32070,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
@@ -6804,6 +6804,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -16867,7 +16868,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
@@ -6722,6 +6722,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -15858,7 +15859,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7924,6 +7924,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -46517,7 +46518,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7800,6 +7800,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42917,7 +42918,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8504,6 +8504,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31330,7 +31331,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8401,6 +8401,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29291,7 +29292,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -9039,6 +9039,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -47142,7 +47143,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8930,6 +8930,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -43791,7 +43792,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -9827,6 +9827,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19056,7 +19057,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -9520,6 +9520,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -17961,7 +17962,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -27649,6 +27649,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -102441,7 +102442,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -25776,6 +25776,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -93330,7 +93331,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7596,6 +7596,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19593,7 +19594,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7473,6 +7473,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -18437,7 +18438,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -30133,6 +30133,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -34119,7 +34120,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28350,6 +28350,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -31991,7 +31992,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-atheros-alx-alx.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-atheros-alx-alx.cil.c
@@ -6794,6 +6794,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -16842,7 +16843,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-atheros-alx-alx.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-atheros-alx-alx.cil.i
@@ -6712,6 +6712,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -15830,7 +15831,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7880,6 +7880,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -46458,7 +46459,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7756,6 +7756,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42859,7 +42860,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30474,6 +30474,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35475,7 +35476,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28439,6 +28439,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -33018,7 +33019,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -9040,6 +9040,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -47444,7 +47445,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8931,6 +8931,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -44061,7 +44062,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6892,6 +6892,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -17976,7 +17977,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6818,6 +6818,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -17051,7 +17052,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.c
@@ -27561,6 +27561,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -101466,7 +101467,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.i
@@ -25702,6 +25702,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -92458,7 +92459,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7550,6 +7550,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19458,7 +19459,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7432,6 +7432,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -18323,7 +18324,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7953,6 +7953,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -45300,7 +45301,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -45858,7 +45859,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7829,6 +7829,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -41967,7 +41968,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -42456,7 +42457,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8502,6 +8502,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -21978,7 +21979,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31178,7 +31179,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8402,6 +8402,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -20817,7 +20818,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -29258,7 +29259,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30549,6 +30549,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -34327,7 +34328,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -35408,7 +35409,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28587,6 +28587,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -32024,7 +32025,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -33052,7 +33053,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6907,6 +6907,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -12718,7 +12719,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17658,7 +17659,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6833,6 +6833,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -12230,7 +12231,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -16836,7 +16837,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8518,6 +8518,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31504,7 +31505,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8415,6 +8415,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29528,7 +29529,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7953,6 +7953,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -45757,7 +45758,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7829,6 +7829,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42363,7 +42364,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8529,6 +8529,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31161,7 +31162,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8426,6 +8426,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29242,7 +29243,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30460,6 +30460,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35286,7 +35287,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28501,6 +28501,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32936,7 +32937,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -29034,6 +29034,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -33020,7 +33021,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27385,6 +27385,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -31026,7 +31027,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7909,6 +7909,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -45698,7 +45699,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7785,6 +7785,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42305,7 +42306,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.c
@@ -13442,6 +13442,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { void *ret ;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.i
@@ -12855,6 +12855,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 { void *ret ;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
@@ -6146,6 +6146,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -11286,7 +11287,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
@@ -6146,6 +6146,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -10865,7 +10866,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
@@ -5914,6 +5914,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -8366,7 +8367,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
@@ -5921,6 +5921,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -8175,7 +8176,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7955,6 +7955,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -26754,7 +26755,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -27270,7 +27271,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7814,6 +7814,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -24976,7 +24977,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -25437,7 +25438,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
@@ -17156,6 +17156,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 int mlx5_db_alloc(struct mlx5_core_dev *dev , struct mlx5_db *db ) ;
@@ -17546,7 +17547,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -18967,7 +18968,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
@@ -16026,6 +16026,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 int mlx5_db_alloc(struct mlx5_core_dev *dev , struct mlx5_db *db ) ;
@@ -16386,7 +16387,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17703,7 +17704,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -9738,6 +9738,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;
@@ -18634,7 +18635,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19050,7 +19051,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -9442,6 +9442,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;
@@ -17588,7 +17589,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17959,7 +17960,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -5992,6 +5992,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
@@ -10765,7 +10766,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -11072,7 +11073,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5960,6 +5960,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
@@ -10351,7 +10352,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -10619,7 +10620,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -30056,6 +30056,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -32585,7 +32586,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -34104,7 +34105,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28284,6 +28284,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -30597,7 +30598,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31982,7 +31983,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7907,6 +7907,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -27007,7 +27008,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7765,6 +7765,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -25201,7 +25202,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7876,6 +7876,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -46325,7 +46326,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7752,6 +7752,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42751,7 +42752,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8492,6 +8492,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31069,7 +31070,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8389,6 +8389,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29054,7 +29055,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30454,6 +30454,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35348,7 +35349,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28420,6 +28420,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32915,7 +32916,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -9037,6 +9037,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -47066,7 +47067,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8928,6 +8928,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -43727,7 +43728,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.c
@@ -27529,6 +27529,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -101316,7 +101317,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.i
@@ -25672,6 +25672,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -92331,7 +92332,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -29800,6 +29800,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -33716,7 +33717,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28069,6 +28069,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -31648,7 +31649,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7877,6 +7877,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -46326,7 +46327,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7753,6 +7753,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42752,7 +42753,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30455,6 +30455,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35351,7 +35352,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28421,6 +28421,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32918,7 +32919,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7964,6 +7964,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -27184,7 +27185,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7822,6 +7822,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -25358,7 +25359,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30607,6 +30607,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35503,7 +35504,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28547,6 +28547,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -33044,7 +33045,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7352,6 +7352,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -18036,7 +18037,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7226,6 +7226,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -17012,7 +17013,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -6069,6 +6069,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -11103,7 +11104,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -6027,6 +6027,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -10644,7 +10645,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7895,6 +7895,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -27146,7 +27147,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7758,6 +7758,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -25317,7 +25318,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8467,6 +8467,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31209,7 +31210,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8372,6 +8372,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29170,7 +29171,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -9881,6 +9881,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -19190,7 +19191,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -9574,6 +9574,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -18082,7 +18083,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-irda-via-ircc.cil.c
@@ -6064,6 +6064,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -11149,7 +11150,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-irda-via-ircc.cil.i
@@ -6022,6 +6022,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -10678,7 +10679,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -29803,6 +29803,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -33824,7 +33825,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28074,6 +28074,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -31735,7 +31736,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7980,6 +7980,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -26051,7 +26052,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -26567,7 +26568,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7839,6 +7839,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -24425,7 +24426,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -24886,7 +24887,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -8957,6 +8957,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int u64_stats_fetch_begin_bh(struct u64_stats_sync  const  *syncp ) 
@@ -25137,7 +25138,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -47113,7 +47114,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8861,6 +8861,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int u64_stats_fetch_begin_bh(struct u64_stats_sync const *syncp )
@@ -23759,7 +23760,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -43905,7 +43906,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7342,6 +7342,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -17148,7 +17149,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17586,7 +17587,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7220,6 +7220,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -16256,7 +16257,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -16644,7 +16645,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -6010,6 +6010,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
@@ -10359,7 +10360,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -10666,7 +10667,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5978,6 +5978,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
@@ -9994,7 +9995,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -10262,7 +10263,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -28957,6 +28957,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -31486,7 +31487,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -33005,7 +33006,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27319,6 +27319,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
@@ -29632,7 +29633,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31017,7 +31018,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7932,6 +7932,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -26304,7 +26305,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7790,6 +7790,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -24650,7 +24651,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7905,6 +7905,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -45565,7 +45566,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7781,6 +7781,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42197,7 +42198,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8517,6 +8517,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -30900,7 +30901,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8414,6 +8414,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29005,7 +29006,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30307,6 +30307,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35131,7 +35132,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28374,6 +28374,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32807,7 +32808,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -9062,6 +9062,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -46963,7 +46964,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8953,6 +8953,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -43772,7 +43773,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -28701,6 +28701,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -32617,7 +32618,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27104,6 +27104,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -30683,7 +30684,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7941,6 +7941,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -26401,7 +26402,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7799,6 +7799,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -24731,7 +24732,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7906,6 +7906,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -45566,7 +45567,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7782,6 +7782,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -42198,7 +42199,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30308,6 +30308,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35134,7 +35135,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28375,6 +28375,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32810,7 +32811,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -29202,6 +29202,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -33118,7 +33119,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27521,6 +27521,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -31100,7 +31101,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7989,6 +7989,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -26481,7 +26482,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7847,6 +7847,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -24807,7 +24808,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7378,6 +7378,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -17525,7 +17526,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7252,6 +7252,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -16587,7 +16588,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -6087,6 +6087,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -10697,7 +10698,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -6045,6 +6045,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -10287,7 +10288,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7617,6 +7617,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -18526,7 +18527,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7494,6 +7494,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -17515,7 +17516,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -7920,6 +7920,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -26443,7 +26444,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7783,6 +7783,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -24766,7 +24767,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8492,6 +8492,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -31040,7 +31041,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8397,6 +8397,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -29121,7 +29122,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -30327,6 +30327,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -35258,7 +35259,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -28393,6 +28393,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -32910,7 +32911,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-irda-via-ircc.cil.c
@@ -6082,6 +6082,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -10743,7 +10744,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-irda-via-ircc.cil.i
@@ -6040,6 +6040,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -10321,7 +10322,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -28704,6 +28704,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 
@@ -32725,7 +32726,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27109,6 +27109,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {
@@ -30770,7 +30771,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
@@ -6864,6 +6864,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
@@ -6787,6 +6787,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.c
@@ -9749,6 +9749,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.i
@@ -9407,6 +9407,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
@@ -17158,6 +17158,7 @@ __inline static void *ldv_dma_zalloc_coherent_435(struct device *dev , size_t si
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_440(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -16218,6 +16218,7 @@ __inline static void *ldv_dma_zalloc_coherent_435(struct device *dev , size_t si
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_440(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.c
@@ -8855,6 +8855,7 @@ __inline static void *ldv_dma_zalloc_coherent_19(struct device *dev , size_t siz
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev ) 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
@@ -8730,6 +8730,7 @@ __inline static void *ldv_dma_zalloc_coherent_19(struct device *dev , size_t siz
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev )

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlcnic--qlcnic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlcnic--qlcnic.ko-entry_point.cil.out.c
@@ -27304,6 +27304,7 @@ __inline static void *ldv_dma_zalloc_coherent_213(struct device *dev , size_t si
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_218(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlcnic--qlcnic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlcnic--qlcnic.ko-entry_point.cil.out.i
@@ -25455,6 +25455,7 @@ __inline static void *ldv_dma_zalloc_coherent_213(struct device *dev , size_t si
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_218(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
@@ -6614,6 +6614,7 @@ __inline static void *ldv_dma_zalloc_coherent_19(struct device *dev , size_t siz
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int eisa_driver_register(struct eisa_driver *edrv ) 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
@@ -6537,6 +6537,7 @@ __inline static void *ldv_dma_zalloc_coherent_19(struct device *dev , size_t siz
   return (ret);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int eisa_driver_register(struct eisa_driver *edrv )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -6866,6 +6866,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev ) 
@@ -15510,7 +15511,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -20804,7 +20805,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -6703,6 +6703,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev )
@@ -14622,7 +14623,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19410,7 +19411,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -6134,6 +6134,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 
@@ -18356,7 +18357,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19558,7 +19559,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -6023,6 +6023,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )
@@ -17306,7 +17307,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -18346,7 +18347,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -7659,6 +7659,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -11183,7 +11184,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -12161,7 +12162,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -7631,6 +7631,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -10879,7 +10880,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -11731,7 +11732,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -7718,6 +7718,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -13412,7 +13413,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17483,7 +17484,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -7638,6 +7638,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -12813,7 +12814,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -16490,7 +16491,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -7881,6 +7881,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -14326,7 +14327,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17254,7 +17255,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -7791,6 +7791,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -13729,7 +13730,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -16345,7 +16346,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -9037,6 +9037,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -46581,7 +46582,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -48048,7 +48049,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -8888,6 +8888,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -43210,7 +43211,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -44479,7 +44480,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -8454,6 +8454,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -17342,7 +17343,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -25087,7 +25088,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -8354,6 +8354,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -16541,7 +16542,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -23574,7 +23575,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -28714,6 +28714,7 @@ void ldv_dummy_resourceless_instance_callback_1_9(int (*arg0)(struct net_device 
 }
 }
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -29812,7 +29813,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -30446,7 +30447,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -26892,6 +26892,7 @@ void ldv_dummy_resourceless_instance_callback_1_9(int (*arg0)(struct net_device 
 }
 }
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -27906,7 +27907,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -28454,7 +28455,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -8529,6 +8529,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -20080,7 +20081,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -26564,7 +26565,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -8414,6 +8414,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
@@ -18929,7 +18930,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -24742,7 +24743,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -8214,6 +8214,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -15173,7 +15174,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -20876,7 +20877,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -8155,6 +8155,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -14576,7 +14577,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19818,7 +19819,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -12533,6 +12533,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -25593,7 +25594,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31554,7 +31555,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -12171,6 +12171,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -24227,7 +24228,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -29686,7 +29687,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -13602,6 +13602,7 @@ __inline static void dma_unmap_sg_attrs(struct device *dev , struct scatterlist 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -15813,7 +15814,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -40561,7 +40562,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -13132,6 +13132,7 @@ __inline static void dma_unmap_sg_attrs(struct device *dev , struct scatterlist 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -15158,7 +15159,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -37771,7 +37772,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -4516,6 +4516,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 
@@ -7957,7 +7958,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -9083,7 +9084,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -4465,6 +4465,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )
@@ -7625,7 +7626,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -8593,7 +8594,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
@@ -10765,6 +10765,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -10134,6 +10134,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
@@ -8137,6 +8137,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -8008,6 +8008,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.c
@@ -11796,6 +11796,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
@@ -11658,6 +11658,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.c
@@ -8220,6 +8220,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
@@ -8090,6 +8090,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.c
@@ -9092,6 +9092,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
@@ -8982,6 +8982,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -24811,6 +24811,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -23130,6 +23130,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.c
@@ -10277,6 +10277,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.i
@@ -10176,6 +10176,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -10614,6 +10614,7 @@ extern void *dma_pool_alloc(struct dma_pool * , gfp_t  , dma_addr_t * ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -10360,6 +10360,7 @@ extern void *dma_pool_alloc(struct dma_pool * , gfp_t , dma_addr_t * ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
@@ -7911,6 +7911,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -7804,6 +7804,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -18940,6 +18940,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int  ,
 extern void free_irq(unsigned int  , void * ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -17746,6 +17746,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int , 
 extern void free_irq(unsigned int , void * ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.c
@@ -63826,6 +63826,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
@@ -60233,6 +60233,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -27522,6 +27522,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -25830,6 +25830,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
@@ -8170,6 +8170,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -8097,6 +8097,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
@@ -19047,6 +19047,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -18035,6 +18035,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -11169,6 +11169,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -10898,6 +10898,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.c
@@ -29266,6 +29266,7 @@ extern void pci_clear_mwi(struct pci_dev * ) ;
 extern int pcix_set_mmrbc(struct pci_dev * , int  ) ;
 extern int pcie_set_readrq(struct pci_dev * , int  ) ;
 extern void pci_disable_rom(struct pci_dev * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
@@ -27599,6 +27599,7 @@ extern void pci_clear_mwi(struct pci_dev * ) ;
 extern int pcix_set_mmrbc(struct pci_dev * , int ) ;
 extern int pcie_set_readrq(struct pci_dev * , int ) ;
 extern void pci_disable_rom(struct pci_dev * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
@@ -11598,6 +11598,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -10833,6 +10833,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko-entry_point.cil.out.c
@@ -7131,6 +7131,7 @@ extern void dvb_dmx_release(struct dvb_demux * ) ;
 extern void dvb_dmx_swfilter_packets(struct dvb_demux * , u8 const   * , size_t  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko-entry_point.cil.out.i
@@ -7098,6 +7098,7 @@ extern void dvb_dmx_release(struct dvb_demux * ) ;
 extern void dvb_dmx_swfilter_packets(struct dvb_demux * , u8 const * , size_t ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
@@ -8155,6 +8155,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -8026,6 +8026,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.c
@@ -11820,6 +11820,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
@@ -11682,6 +11682,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.c
@@ -8230,6 +8230,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
@@ -8100,6 +8100,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -24983,6 +24983,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -23276,6 +23276,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.c
@@ -10292,6 +10292,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point.cil.out.i
@@ -10191,6 +10191,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -10793,6 +10793,7 @@ extern void *dma_pool_alloc(struct dma_pool * , gfp_t  , dma_addr_t * ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -10510,6 +10510,7 @@ extern void *dma_pool_alloc(struct dma_pool * , gfp_t , dma_addr_t * ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
@@ -7921,6 +7921,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -7814,6 +7814,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -19299,6 +19299,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int  ,
 extern void free_irq(unsigned int  , void * ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -18044,6 +18044,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int , 
 extern void free_irq(unsigned int , void * ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.c
@@ -66068,6 +66068,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
@@ -62106,6 +62106,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -28723,6 +28723,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -26830,6 +26830,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
@@ -8238,6 +8238,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -8165,6 +8165,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.c
@@ -19822,6 +19822,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -18679,6 +18679,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
@@ -8539,6 +8539,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -8433,6 +8433,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -11257,6 +11257,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -10973,6 +10973,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
@@ -21455,6 +21455,7 @@ __inline static unsigned long copy_to_user(void *to , void const   *from , unsig
 extern size_t sg_copy_from_buffer(struct scatterlist * , unsigned int  , void const   * ,
                                   size_t  ) ;
 extern size_t sg_copy_to_buffer(struct scatterlist * , unsigned int  , void * , size_t  ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -20450,6 +20450,7 @@ __inline static unsigned long copy_to_user(void *to , void const *from , unsigne
 extern size_t sg_copy_from_buffer(struct scatterlist * , unsigned int , void const * ,
                                   size_t ) ;
 extern size_t sg_copy_to_buffer(struct scatterlist * , unsigned int , void * , size_t ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--megaraid--megaraid_sas.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--megaraid--megaraid_sas.ko-entry_point.cil.out.c
@@ -6771,6 +6771,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--megaraid--megaraid_sas.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--megaraid--megaraid_sas.ko-entry_point.cil.out.i
@@ -6696,6 +6696,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.c
@@ -29430,6 +29430,7 @@ extern void pci_clear_mwi(struct pci_dev * ) ;
 extern int pcix_set_mmrbc(struct pci_dev * , int  ) ;
 extern int pcie_set_readrq(struct pci_dev * , int  ) ;
 extern void pci_disable_rom(struct pci_dev * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag ) 
 { 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
@@ -27734,6 +27734,7 @@ extern void pci_clear_mwi(struct pci_dev * ) ;
 extern int pcix_set_mmrbc(struct pci_dev * , int ) ;
 extern int pcie_set_readrq(struct pci_dev * , int ) ;
 extern void pci_disable_rom(struct pci_dev * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flag )
 {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.c
@@ -7068,6 +7068,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static char const   *pci_name(struct pci_dev  const  *pdev ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.i
@@ -6988,6 +6988,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static char const *pci_name(struct pci_dev const *pdev )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
@@ -6576,6 +6576,7 @@ __inline static void dma_unmap_sg_attrs(struct device *dev , struct scatterlist 
 extern int dma_set_mask(struct device * , u64  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern int request_threaded_irq(unsigned int  , irqreturn_t (*)(int  , void * ) ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
@@ -6506,6 +6506,7 @@ __inline static void dma_unmap_sg_attrs(struct device *dev , struct scatterlist 
 extern int dma_set_mask(struct device * , u64 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern int request_threaded_irq(unsigned int , irqreturn_t (*)(int , void * ) ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
@@ -5728,6 +5728,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
@@ -5634,6 +5634,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
@@ -10873,6 +10873,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_309(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -10231,6 +10231,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
   return (dma_addr == 0ULL);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 struct sk_buff *ldv_skb_clone_309(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.c
@@ -12927,6 +12927,7 @@ __inline static void dma_unmap_page(struct device *dev , dma_addr_t addr , size_
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
@@ -12503,6 +12503,7 @@ __inline static void dma_unmap_page(struct device *dev , dma_addr_t addr , size_
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.c
@@ -6179,6 +6179,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 extern int dma_supported(struct device * , u64  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int pci_dma_supported(struct pci_dev *hwdev , u64 mask ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.i
@@ -6110,6 +6110,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 extern int dma_supported(struct device * , u64 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int pci_dma_supported(struct pci_dev *hwdev , u64 mask )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.c
@@ -7073,6 +7073,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.i
@@ -7001,6 +7001,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.c
@@ -7302,6 +7302,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
@@ -7218,6 +7218,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
@@ -8119,6 +8119,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int pci_set_dma_mask(struct pci_dev *dev , u64 mask ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -7993,6 +7993,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int pci_set_dma_mask(struct pci_dev *dev , u64 mask )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.c
@@ -7866,6 +7866,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
@@ -7784,6 +7784,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -25108,6 +25108,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern unsigned long msleep_interruptible(unsigned int  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -23400,6 +23400,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern unsigned long msleep_interruptible(unsigned int ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
@@ -7137,6 +7137,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
@@ -7071,6 +7071,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -10675,6 +10675,7 @@ extern void dma_pool_destroy(struct dma_pool * ) ;
 void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void usleep_range(unsigned long  , unsigned long  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -10412,6 +10412,7 @@ extern void dma_pool_destroy(struct dma_pool * ) ;
 void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void usleep_range(unsigned long , unsigned long ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
@@ -7895,6 +7895,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -7791,6 +7791,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -19104,6 +19104,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int  ,
 }
 extern void free_irq(unsigned int  , void * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern struct cpu_rmap *alloc_cpu_rmap(unsigned int  , gfp_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -17894,6 +17894,7 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int , 
 }
 extern void free_irq(unsigned int , void * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern struct cpu_rmap *alloc_cpu_rmap(unsigned int , gfp_t ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
@@ -6704,6 +6704,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 }
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int eisa_driver_register(struct eisa_driver *edrv ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
@@ -6644,6 +6644,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 }
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static int eisa_driver_register(struct eisa_driver *edrv )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.c
@@ -6459,6 +6459,7 @@ __inline static void *dev_get_drvdata(struct device  const  *dev )
 }
 }
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.i
@@ -6402,6 +6402,7 @@ __inline static void *dev_get_drvdata(struct device const *dev )
 }
 }
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.c
@@ -6568,6 +6568,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 }
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.i
@@ -6515,6 +6515,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 }
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
@@ -6644,6 +6644,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 }
 extern int dma_set_mask(struct device * , u64  ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
@@ -6573,6 +6573,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 }
 extern int dma_set_mask(struct device * , u64 ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
@@ -7812,6 +7812,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
@@ -7710,6 +7710,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const *frag )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -28576,6 +28576,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -26790,6 +26790,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
@@ -8162,6 +8162,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64  ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -8091,6 +8091,7 @@ __inline static void dma_sync_single_for_device(struct device *dev , dma_addr_t 
 extern int dma_set_mask(struct device * , u64 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
@@ -8494,6 +8494,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -8393,6 +8393,7 @@ __inline static int dma_mapping_error(struct device *dev , dma_addr_t dma_addr )
 }
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.c
@@ -7763,6 +7763,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
@@ -7707,6 +7707,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -11257,6 +11257,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -10981,6 +10981,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
@@ -21548,6 +21548,7 @@ __inline static unsigned long copy_to_user(void *to , void const   *from , unsig
 extern size_t sg_copy_from_buffer(struct scatterlist * , unsigned int  , void const   * ,
                                   size_t  ) ;
 extern size_t sg_copy_to_buffer(struct scatterlist * , unsigned int  , void * , size_t  ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void blk_queue_max_segments(struct request_queue * , unsigned short  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -20576,6 +20576,7 @@ __inline static unsigned long copy_to_user(void *to , void const *from , unsigne
 extern size_t sg_copy_from_buffer(struct scatterlist * , unsigned int , void const * ,
                                   size_t ) ;
 extern size_t sg_copy_to_buffer(struct scatterlist * , unsigned int , void * , size_t ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern void blk_queue_max_segments(struct request_queue * , unsigned short ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
@@ -6651,6 +6651,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
@@ -6595,6 +6595,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
@@ -6571,6 +6571,7 @@ extern void pci_unregister_driver(struct pci_driver * ) ;
 void ldv_pci_unregister_driver_52(struct pci_driver *ldv_func_arg1 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t  , dma_addr_t * , gfp_t  , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t  , void * , dma_addr_t  , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
@@ -6514,6 +6514,7 @@ extern void pci_unregister_driver(struct pci_driver * ) ;
 void ldv_pci_unregister_driver_52(struct pci_driver *ldv_func_arg1 ) ;
 extern void *dma_alloc_attrs(struct device * , size_t , dma_addr_t * , gfp_t , struct dma_attrs * ) ;
 extern void dma_free_attrs(struct device * , size_t , void * , dma_addr_t , struct dma_attrs * ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle )

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
@@ -3777,6 +3777,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
@@ -3743,6 +3743,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -6866,6 +6866,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_get_drvdata(struct pci_dev *pdev ) 
@@ -15510,7 +15511,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -20804,7 +20805,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -6134,6 +6134,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 
@@ -18356,7 +18357,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -19558,7 +19559,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -7659,6 +7659,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -11183,7 +11184,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -12161,7 +12162,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -7718,6 +7718,7 @@ __inline static int dma_set_mask_and_coherent(struct device *dev , u64 mask )
   return (rc);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -13412,7 +13413,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17483,7 +17484,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7881,6 +7881,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -14326,7 +14327,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -17254,7 +17255,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -9037,6 +9037,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -46581,7 +46582,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -48048,7 +48049,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -8454,6 +8454,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -17342,7 +17343,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -25087,7 +25088,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -28714,6 +28714,7 @@ void ldv_dummy_resourceless_instance_callback_1_9(int (*arg0)(struct net_device 
 }
 }
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -29812,7 +29813,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -30446,7 +30447,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -8529,6 +8529,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static unsigned int skb_frag_size(skb_frag_t const   *frag ) 
@@ -20080,7 +20081,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -26564,7 +26565,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8214,6 +8214,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -15173,7 +15174,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -20876,7 +20877,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -12533,6 +12533,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
   return (0);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -25593,7 +25594,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -31554,7 +31555,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -13602,6 +13602,7 @@ __inline static void dma_unmap_sg_attrs(struct device *dev , struct scatterlist 
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_zalloc_consistent(struct pci_dev *hwdev , size_t size ,
@@ -15813,7 +15814,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -40561,7 +40562,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4516,6 +4516,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma_addr_t *dma_handle ,
                                           gfp_t flags ) ;
 __inline static void *pci_alloc_consistent(struct pci_dev *hwdev , size_t size , dma_addr_t *dma_handle ) 
@@ -7957,7 +7958,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(size);
   }
   return (tmp);
 }
@@ -9083,7 +9084,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (the second parameter
of the function, size), thus using ldv_zalloc is perfectly safe, and
also more consistent as it will ensure zero-initialisation.

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^__inline static void \*dma_zalloc_coherent\(struct device \*dev , size_t size , dma_addr_t \*dma_handle , ?$/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_zalloc(size);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  c/ldv-*/*.[ci]
```
