### PR TITLE
Implement ldv_malloc_array_* using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
@@ -18516,6 +18516,7 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -18523,7 +18524,7 @@ __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -19038,7 +19039,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
@@ -17248,13 +17248,14 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -17701,7 +17702,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
@@ -16910,6 +16910,7 @@ __inline static void ldv_spin_unlock_bh_80(spinlock_t *lock )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -16917,7 +16918,7 @@ __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -17191,7 +17192,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
@@ -16054,13 +16054,14 @@ __inline static void ldv_spin_unlock_bh_80(spinlock_t *lock )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_83(size_t n , size_t size , gfp_t flags )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -16299,7 +16300,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
@@ -20653,6 +20653,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_ar
   return ((struct sk_buff *)tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_109(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -20660,7 +20661,7 @@ __inline static void *ldv_kmalloc_array_109(size_t n , size_t size , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -31561,7 +31562,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -19482,13 +19482,14 @@ static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_ar
   return ((struct sk_buff *)tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_109(size_t n , size_t size , gfp_t flags )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -29228,7 +29229,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -12459,6 +12459,7 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_102(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -12466,7 +12467,7 @@ __inline static void *ldv_kmalloc_array_102(size_t n , size_t size , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -22601,7 +22602,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -11827,13 +11827,14 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_102(size_t n , size_t size , gfp_t flags )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -21015,7 +21016,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -17674,6 +17674,7 @@ __inline static void ldv_spin_unlock_bh_149(spinlock_t *lock )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_165(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -17681,7 +17682,7 @@ __inline static void *ldv_kmalloc_array_165(size_t n , size_t size , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -24359,7 +24360,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -16628,13 +16628,14 @@ __inline static void ldv_spin_unlock_bh_149(spinlock_t *lock )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_165(size_t n , size_t size , gfp_t flags )
 {
   void *res ;
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -22601,7 +22602,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -12459,6 +12459,7 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_102(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -12466,7 +12467,7 @@ __inline static void *ldv_kmalloc_array_102(size_t n , size_t size , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -22601,7 +22602,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -17674,6 +17674,7 @@ __inline static void ldv_spin_unlock_bh_149(spinlock_t *lock )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static void *ldv_kmalloc_array_165(size_t n , size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -17681,7 +17682,7 @@ __inline static void *ldv_kmalloc_array_165(size_t n , size_t size , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  res = ldv_malloc_unknown_size();
+  res = ldv_malloc(size * n);
   ldv_after_alloc(res);
   }
   return (res);
@@ -24359,7 +24360,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented using
__VERIFIER_nondet_pointer. The size is known, thus using ldv_malloc is
perfectly safe.

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^__inline static void \*ldv_kmalloc_array_\d+\(size_t n , size_t size , gfp_t flags \) ?$/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^  res = ldv_malloc_unknown_size\(\);/) {
         print "  res = ldv_malloc(size * n);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  c/ldv-*/*.[ci]
```
