### PR TITLE
Implement ldv___netdev_alloc_skb_* using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.c
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.c
@@ -5704,6 +5704,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10153,7 +10154,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10613,7 +10614,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
@@ -5649,6 +5649,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -9703,7 +9704,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10105,7 +10106,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.c
@@ -24121,6 +24121,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26952,7 +26953,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27935,7 +27936,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.i
@@ -22429,6 +22429,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -25018,7 +25019,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25910,7 +25911,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
@@ -6137,6 +6137,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -15592,7 +15593,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15605,7 +15606,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15799,7 +15800,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16397,7 +16398,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -6050,6 +6050,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -14674,7 +14675,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14686,7 +14687,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14857,7 +14858,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15375,7 +15376,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.c
@@ -5952,6 +5952,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14584,7 +14585,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15387,7 +15388,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.i
@@ -5878,6 +5878,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13737,7 +13738,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14428,7 +14429,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
@@ -6744,6 +6744,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const   *frag ) 
@@ -13658,7 +13659,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16987,7 +16988,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
@@ -6666,6 +6666,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const *frag )
@@ -12927,7 +12928,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15962,7 +15963,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -8054,6 +8054,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -46073,7 +46074,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46786,7 +46787,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7909,6 +7909,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -42533,7 +42534,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43154,7 +43155,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8676,6 +8676,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -22144,7 +22145,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31515,7 +31516,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8546,6 +8546,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -20861,7 +20862,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29451,7 +29452,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -8035,6 +8035,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -19737,7 +19738,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35793,7 +35794,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -7877,6 +7877,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -18599,7 +18600,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33304,7 +33305,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
@@ -43952,6 +43952,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -61152,7 +61153,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -62615,7 +62616,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -40459,6 +40459,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -56194,7 +56195,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -57511,7 +57512,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -39354,6 +39354,7 @@ __inline static int skb_inner_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -42131,7 +42132,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -47384,7 +47385,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -36649,6 +36649,7 @@ __inline static int skb_inner_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -39195,7 +39196,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -44004,7 +44005,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
@@ -8924,6 +8924,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -27810,7 +27811,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -51011,7 +51012,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -8718,6 +8718,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -25924,7 +25925,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -47115,7 +47116,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6996,6 +6996,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -13007,7 +13008,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18122,7 +18123,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6905,6 +6905,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -12431,7 +12432,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17189,7 +17190,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -9766,6 +9766,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -41379,7 +41380,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -81485,7 +81486,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -9546,6 +9546,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -38730,7 +38731,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -74961,7 +74962,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7436,6 +7436,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -17672,7 +17673,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18265,7 +18266,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7295,6 +7295,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -16693,7 +16694,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17213,7 +17214,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.c
@@ -5924,6 +5924,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13225,7 +13226,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13824,7 +13825,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.i
@@ -5850,6 +5850,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -12559,7 +12560,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13085,7 +13086,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -20391,6 +20391,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff  const  *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -31518,7 +31519,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32078,7 +32079,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -19398,6 +19398,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff const *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -29549,7 +29550,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -30049,7 +30050,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
@@ -6506,6 +6506,7 @@ __inline static int skb_tailroom(struct sk_buff  const  *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -21270,7 +21271,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22504,7 +22505,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
@@ -6397,6 +6397,7 @@ __inline static int skb_tailroom(struct sk_buff const *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -19970,7 +19971,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21056,7 +21057,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
@@ -5828,6 +5828,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -18465,7 +18466,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19038,7 +19039,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
@@ -5760,6 +5760,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -17203,7 +17204,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17701,7 +17702,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -78832,6 +78832,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -80421,7 +80422,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -102697,7 +102698,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -72022,6 +72022,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -73468,7 +73469,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -93557,7 +93558,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -6064,6 +6064,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11737,7 +11738,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12228,7 +12229,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -5972,6 +5972,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -11185,7 +11186,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11616,7 +11617,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
@@ -5943,6 +5943,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 extern int skb_pad(struct sk_buff * , int  ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -11562,7 +11563,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12122,7 +12123,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
@@ -5869,6 +5869,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 extern int skb_pad(struct sk_buff * , int ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -11028,7 +11029,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11515,7 +11516,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
@@ -7205,6 +7205,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff  const  *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -16712,7 +16713,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16725,7 +16726,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17335,7 +17336,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
@@ -7083,6 +7083,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff const *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -15733,7 +15734,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15745,7 +15746,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16277,7 +16278,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -7741,6 +7741,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -17845,7 +17846,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19836,7 +19837,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -7594,6 +7594,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -16863,7 +16864,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18650,7 +18651,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.c
@@ -7503,6 +7503,7 @@ __inline static int skb_tailroom(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_46(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14419,7 +14420,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_46(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16248,7 +16249,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -7413,6 +7413,7 @@ __inline static int skb_tailroom(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_46(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13745,7 +13746,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_46(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15416,7 +15417,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
@@ -13155,6 +13155,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14274,7 +14275,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18052,7 +18053,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23227,7 +23228,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___1(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -39492,7 +39493,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___2(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46336,7 +46337,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___3(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49109,7 +49110,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -12767,6 +12767,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13800,7 +13801,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17300,7 +17301,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22023,7 +22024,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___1(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -36943,7 +36944,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___2(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43246,7 +43247,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58___3(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -45792,7 +45793,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.c
@@ -7285,6 +7285,7 @@ __inline static unsigned char *skb_tail_pointer(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13399,7 +13400,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15662,7 +15663,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
@@ -7200,6 +7200,7 @@ __inline static unsigned char *skb_tail_pointer(struct sk_buff const *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -12778,7 +12779,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14887,7 +14888,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -11311,6 +11311,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13589,7 +13590,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -37272,7 +37273,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -11048,6 +11048,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13170,7 +13171,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34950,7 +34951,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
@@ -6882,6 +6882,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const   *frag ) 
@@ -13812,7 +13813,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14361,7 +14362,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
@@ -6783,6 +6783,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const *frag )
@@ -13147,7 +13148,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13625,7 +13626,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
@@ -6162,6 +6162,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -14673,7 +14674,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14686,7 +14687,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14880,7 +14881,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15478,7 +15479,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -6075,6 +6075,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -13891,7 +13892,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13903,7 +13904,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14074,7 +14075,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14592,7 +14593,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -8083,6 +8083,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -45313,7 +45314,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46026,7 +46027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7938,6 +7938,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -41979,7 +41980,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -42600,7 +42601,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -8701,6 +8701,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -22003,7 +22004,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31346,7 +31347,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -8571,6 +8571,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -20840,7 +20841,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29402,7 +29403,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -8060,6 +8060,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -19590,7 +19591,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35576,7 +35577,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -7902,6 +7902,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -18553,7 +18554,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33196,7 +33197,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -7014,6 +7014,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -12731,7 +12732,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17826,7 +17827,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6923,6 +6923,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -12242,7 +12243,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16980,7 +16981,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -20388,6 +20388,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff  const  *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -30837,7 +30838,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31397,7 +31398,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -19396,6 +19396,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff const *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -28992,7 +28993,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29492,7 +29493,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
@@ -6531,6 +6531,7 @@ __inline static int skb_tailroom(struct sk_buff  const  *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -20323,7 +20324,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21557,7 +21558,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
@@ -6422,6 +6422,7 @@ __inline static int skb_tailroom(struct sk_buff const *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -19180,7 +19181,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20266,7 +20267,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
@@ -7231,6 +7231,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff  const  *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -15869,7 +15870,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15882,7 +15883,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16492,7 +16493,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
@@ -7109,6 +7109,7 @@ __inline static unsigned char *skb_network_header(struct sk_buff const *skb )
   return ((unsigned char *)skb->head + (unsigned long )skb->network_header);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
@@ -15027,7 +15028,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15039,7 +15040,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15571,7 +15572,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -11318,6 +11318,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13596,7 +13597,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -36725,7 +36726,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -11055,6 +11055,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13177,7 +13178,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34552,7 +34553,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
@@ -6896,6 +6896,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const   *frag ) 
@@ -12924,7 +12925,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13473,7 +13474,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
@@ -6797,6 +6797,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const *frag )
@@ -12357,7 +12358,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_102(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12835,7 +12836,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.c
@@ -6026,6 +6026,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11592,7 +11593,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12028,7 +12029,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
@@ -5951,6 +5951,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -11062,7 +11063,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11444,7 +11445,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.c
@@ -6816,6 +6816,7 @@ __inline static unsigned int skb_headlen(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -12545,7 +12546,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12928,7 +12929,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.i
@@ -6731,6 +6731,7 @@ __inline static unsigned int skb_headlen(struct sk_buff const *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -12005,7 +12006,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12341,7 +12342,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.c
@@ -5962,6 +5962,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10927,7 +10928,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11483,7 +11484,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.i
@@ -5886,6 +5886,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10432,7 +10433,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10919,7 +10920,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
@@ -7328,6 +7328,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -15948,7 +15949,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19115,7 +19116,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
@@ -7196,6 +7196,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -15070,7 +15071,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17982,7 +17983,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
@@ -7187,6 +7187,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -13937,7 +13938,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16374,7 +16375,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
@@ -7061,6 +7061,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -13242,7 +13243,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15431,7 +15432,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -8086,6 +8086,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26767,7 +26768,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27438,7 +27439,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7923,6 +7923,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -24988,7 +24989,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25581,7 +25582,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.c
@@ -7296,6 +7296,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -15431,7 +15432,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21270,7 +21271,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -7198,6 +7198,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -14640,7 +14641,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19958,7 +19959,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.c
@@ -6161,6 +6161,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -17720,7 +17721,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18251,7 +18252,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.i
@@ -6070,6 +6070,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -16705,7 +16706,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17170,7 +17171,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.c
@@ -6157,6 +6157,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -7326,7 +7327,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15510,7 +15511,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17767,7 +17768,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
@@ -6080,6 +6080,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -7135,7 +7136,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14612,7 +14613,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16672,7 +16673,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.c
@@ -5879,6 +5879,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10807,7 +10808,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11311,7 +11312,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
@@ -5810,6 +5810,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10313,7 +10314,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10755,7 +10756,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.c
@@ -5840,6 +5840,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10330,7 +10331,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10878,7 +10879,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
@@ -5773,6 +5773,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -9878,7 +9879,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10355,7 +10356,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.c
@@ -5824,6 +5824,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10613,7 +10614,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11129,7 +11130,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.i
@@ -5750,6 +5750,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10160,7 +10161,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10607,7 +10608,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
@@ -9064,6 +9064,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -16625,7 +16626,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17179,7 +17180,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -8780,6 +8780,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -15717,7 +15718,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16213,7 +16214,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
@@ -7079,6 +7079,7 @@ __inline static void skb_set_network_header(struct sk_buff *skb , int const   of
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -16641,7 +16642,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17109,7 +17110,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
@@ -6959,6 +6959,7 @@ __inline static void skb_set_network_header(struct sk_buff *skb , int const offs
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -15653,7 +15654,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16061,7 +16062,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
@@ -6398,6 +6398,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg1 ,
@@ -19189,7 +19190,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19296,7 +19297,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19992,7 +19993,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
@@ -6279,6 +6279,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg1 ,
@@ -17953,7 +17954,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18045,7 +18046,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18654,7 +18655,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.c
@@ -7286,6 +7286,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_113(struct net_device *ldv_func_arg1 ,
@@ -22017,7 +22018,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22124,7 +22125,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_113(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22700,7 +22701,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.i
@@ -7149,6 +7149,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_113(struct net_device *ldv_func_arg1 ,
@@ -20575,7 +20576,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20667,7 +20668,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_113(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21176,7 +21177,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
@@ -6276,6 +6276,7 @@ __inline static void skb_set_network_header(struct sk_buff *skb , int const   of
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -16707,7 +16708,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17143,7 +17144,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
@@ -6181,6 +6181,7 @@ __inline static void skb_set_network_header(struct sk_buff *skb , int const offs
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -15627,7 +15628,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16009,7 +16010,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -9799,6 +9799,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -18647,7 +18648,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19218,7 +19219,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -9493,6 +9493,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -17600,7 +17601,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18103,7 +18104,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
@@ -23664,6 +23664,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26653,7 +26654,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29992,7 +29993,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
@@ -22150,6 +22150,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -24876,7 +24877,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27915,7 +27916,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
@@ -7667,6 +7667,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -19444,7 +19445,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25008,7 +25009,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25263,7 +25264,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -7535,6 +7535,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -18203,7 +18204,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23220,7 +23221,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57___0(struct net_device *ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23440,7 +23441,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
@@ -7375,6 +7375,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_arg1 ,
@@ -20515,7 +20516,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20648,7 +20649,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31561,7 +31562,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -7294,6 +7294,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_arg1 ,
@@ -19360,7 +19361,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19477,7 +19478,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_108(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29228,7 +29229,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.c
@@ -7252,6 +7252,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -17029,7 +17030,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17840,7 +17841,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -7106,6 +7106,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -16029,7 +16030,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16731,7 +16732,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.c
@@ -6940,6 +6940,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -12490,7 +12491,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12962,7 +12963,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.i
@@ -6853,6 +6853,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -11942,7 +11943,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12357,7 +12358,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -6016,6 +6016,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10778,7 +10779,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11241,7 +11242,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5980,6 +5980,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10363,7 +10364,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10764,7 +10765,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
@@ -10299,6 +10299,7 @@ __inline static int skb_tailroom(struct sk_buff  const  *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -11462,7 +11463,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14108,7 +14109,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
@@ -9894,6 +9894,7 @@ __inline static int skb_tailroom(struct sk_buff const *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10961,7 +10962,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13346,7 +13347,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -5751,6 +5751,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -9631,7 +9632,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10239,7 +10240,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -5704,6 +5704,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -9267,7 +9268,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -9802,7 +9803,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
@@ -5504,6 +5504,7 @@ extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10596,7 +10597,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11080,7 +11081,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
@@ -5486,6 +5486,7 @@ extern void kfree(void const * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 extern void consume_skb(struct sk_buff * ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10120,7 +10121,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10549,7 +10550,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.c
@@ -7856,6 +7856,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13182,7 +13183,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13977,7 +13978,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.i
@@ -7602,6 +7602,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -12478,7 +12479,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13172,7 +13173,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -30060,6 +30060,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__dev_alloc_skb(unsigned int length , gfp_t gfp_mask ) 
@@ -32610,7 +32611,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34029,7 +34030,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34273,7 +34274,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -28288,6 +28288,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__dev_alloc_skb(unsigned int length , gfp_t gfp_mask )
@@ -30620,7 +30621,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31916,7 +31917,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32127,7 +32128,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.c
@@ -7945,6 +7945,7 @@ __inline static int skb_tailroom(struct sk_buff  const  *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -27078,7 +27079,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27799,7 +27800,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -7864,6 +7864,7 @@ __inline static int skb_tailroom(struct sk_buff const *skb )
   return ((int )tmp ? 0 : (int )((unsigned int )skb->end - (unsigned int )skb->tail));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -25590,7 +25591,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -26220,7 +26221,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
@@ -10186,6 +10186,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -12389,7 +12390,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -38405,7 +38406,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -9984,6 +9984,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -12028,7 +12029,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35959,7 +35960,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -8111,6 +8111,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26064,7 +26065,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -26735,7 +26736,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -7948,6 +7948,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -24437,7 +24438,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25030,7 +25031,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
@@ -32850,6 +32850,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -37232,7 +37233,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -37659,7 +37660,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -30967,6 +30967,7 @@ __inline static void __skb_queue_purge(struct sk_buff_head *list )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -35007,7 +35008,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35382,7 +35383,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -39255,6 +39255,7 @@ __inline static int skb_inner_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -42032,7 +42033,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -47281,7 +47282,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -36698,6 +36698,7 @@ __inline static int skb_inner_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -39244,7 +39245,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -44049,7 +44050,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -9795,6 +9795,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -42171,7 +42172,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -81445,7 +81446,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -9575,6 +9575,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -39852,7 +39853,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -75282,7 +75283,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
@@ -6427,6 +6427,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg1 ,
@@ -18177,7 +18178,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18284,7 +18285,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18980,7 +18981,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
@@ -6308,6 +6308,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )skb->__annonCompField68.__annonCompField67.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg1 ,
@@ -17120,7 +17121,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17212,7 +17213,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_87(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17821,7 +17822,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -7462,6 +7462,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -17161,7 +17162,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17754,7 +17755,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -7321,6 +7321,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -16268,7 +16269,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16788,7 +16789,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -6089,6 +6089,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11154,7 +11155,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11645,7 +11646,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -5997,6 +5997,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10682,7 +10683,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11113,7 +11114,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
@@ -5965,6 +5965,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 extern int skb_pad(struct sk_buff * , int  ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -11040,7 +11041,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11600,7 +11601,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
@@ -5891,6 +5891,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 extern int skb_pad(struct sk_buff * , int ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10571,7 +10572,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11058,7 +11059,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -6034,6 +6034,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10372,7 +10373,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10835,7 +10836,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5998,6 +5998,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10006,7 +10007,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10407,7 +10408,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.c
@@ -6963,6 +6963,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -22594,7 +22595,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23136,7 +23137,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.i
@@ -6852,6 +6852,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
 }
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -21272,7 +21273,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21745,7 +21746,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -28961,6 +28961,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__dev_alloc_skb(unsigned int length , gfp_t gfp_mask ) 
@@ -31511,7 +31512,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32930,7 +32931,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33174,7 +33175,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27323,6 +27323,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
                                           gfp_t flags ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__dev_alloc_skb(unsigned int length , gfp_t gfp_mask )
@@ -29655,7 +29656,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_58(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -30951,7 +30952,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_57(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31162,7 +31163,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.c
@@ -12038,6 +12038,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14206,7 +14207,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32523,7 +32524,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -11703,6 +11703,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13717,7 +13718,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -30527,7 +30528,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
@@ -10193,6 +10193,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -12396,7 +12397,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -36996,7 +36997,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -9991,6 +9991,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -12035,7 +12036,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_44(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34704,7 +34705,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -25823,6 +25823,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -28890,7 +28891,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31840,7 +31841,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -23958,6 +23958,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -26790,7 +26791,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29376,7 +29377,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -6940,6 +6940,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11389,7 +11390,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13821,7 +13822,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -6853,6 +6853,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10960,7 +10961,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13065,7 +13066,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -7765,6 +7765,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField77.__annonCompField76.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const   *frag ) 
@@ -13449,7 +13450,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18868,7 +18869,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -7676,6 +7676,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )skb->__annonCompField77.__annonCompField76.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const *frag )
@@ -12845,7 +12846,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17680,7 +17681,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -8090,6 +8090,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -14339,7 +14340,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18639,7 +18640,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -7971,6 +7971,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -13741,7 +13742,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17535,7 +17536,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -9167,6 +9167,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -46594,7 +46595,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49432,7 +49433,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -8997,6 +8997,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -43222,7 +43223,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -45668,7 +45669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -8548,6 +8548,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -17355,7 +17356,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -26472,7 +26473,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -8430,6 +8430,7 @@ __inline static int skb_transport_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -16553,7 +16554,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24764,7 +24765,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -6716,6 +6716,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11158,7 +11159,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13494,7 +13495,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -6652,6 +6652,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -10728,7 +10729,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12748,7 +12749,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -6328,6 +6328,7 @@ __inline static unsigned char *skb_end_pointer(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10762,7 +10763,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13069,7 +13070,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -6271,6 +6271,7 @@ __inline static unsigned char *skb_end_pointer(struct sk_buff const *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10307,7 +10308,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12301,7 +12302,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -6750,6 +6750,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10923,7 +10924,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13355,7 +13356,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -6678,6 +6678,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10519,7 +10520,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12616,7 +12617,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -18541,6 +18541,7 @@ __inline static int skb_inner_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -21241,7 +21242,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24887,7 +24888,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -17593,6 +17593,7 @@ __inline static int skb_inner_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -20066,7 +20067,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23294,7 +23295,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -10076,6 +10076,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -17311,7 +17312,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19797,7 +19798,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -9778,6 +9778,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -16499,7 +16500,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18661,7 +18662,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -23684,6 +23684,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26678,7 +26679,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31830,7 +31831,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -22315,6 +22315,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -25047,7 +25048,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -29643,7 +29644,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -8715,6 +8715,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -20093,7 +20094,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25906,7 +25907,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103___0(struct net_device *ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27948,7 +27949,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -8574,6 +8574,7 @@ __inline static int skb_network_offset(struct sk_buff const *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -18941,7 +18942,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24174,7 +24175,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103___0(struct net_device *ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25931,7 +25932,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -7101,6 +7101,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11863,7 +11864,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14236,7 +14237,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -7047,6 +7047,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -11448,7 +11449,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13495,7 +13496,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -7718,6 +7718,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
 extern void skb_queue_purge(struct sk_buff_head * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13999,7 +14000,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16686,7 +16687,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -7618,6 +7618,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
 }
 extern void skb_trim(struct sk_buff * , unsigned int ) ;
 extern void skb_queue_purge(struct sk_buff_head * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -13369,7 +13370,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15678,7 +15679,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -6713,6 +6713,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10014,7 +10015,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -6658,6 +6658,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -9718,7 +9719,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12017,7 +12018,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -8472,6 +8472,7 @@ __inline static unsigned char *skb_tail_pointer(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -15186,7 +15187,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22263,7 +22264,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -8384,6 +8384,7 @@ __inline static unsigned char *skb_tail_pointer(struct sk_buff const *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -14588,7 +14589,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21010,7 +21011,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -12573,6 +12573,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14758,7 +14759,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -39691,7 +39692,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -12303,6 +12303,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length )
@@ -14337,7 +14338,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -37264,7 +37265,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -25823,6 +25823,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -28890,7 +28891,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31840,7 +31841,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6940,6 +6940,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11389,7 +11390,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13821,7 +13822,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -7765,6 +7765,7 @@ __inline static int skb_checksum_start_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )skb->__annonCompField77.__annonCompField76.csum_start - tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct page *skb_frag_page(skb_frag_t const   *frag ) 
@@ -13449,7 +13450,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_126(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18868,7 +18869,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8090,6 +8090,7 @@ __inline static int pskb_trim(struct sk_buff *skb , unsigned int len )
   return (tmp___0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -14339,7 +14340,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18639,7 +18640,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -9167,6 +9167,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
 }
 }
 extern void *netdev_alloc_frag(unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -46594,7 +46595,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49432,7 +49433,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -8548,6 +8548,7 @@ __inline static int skb_transport_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -17355,7 +17356,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -26472,7 +26473,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6716,6 +6716,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11158,7 +11159,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13494,7 +13495,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6328,6 +6328,7 @@ __inline static unsigned char *skb_end_pointer(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10762,7 +10763,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13069,7 +13070,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6750,6 +6750,7 @@ __inline static void dma_free_attrs(struct device *dev , size_t size , void *vad
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -10923,7 +10924,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13355,7 +13356,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -18541,6 +18541,7 @@ __inline static int skb_inner_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -21241,7 +21242,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24887,7 +24888,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -10076,6 +10076,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *__netdev_alloc_skb_ip_align(struct net_device *dev ,
@@ -17311,7 +17312,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -19797,7 +19798,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -23684,6 +23684,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -26678,7 +26679,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31830,7 +31831,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -8715,6 +8715,7 @@ __inline static int skb_network_offset(struct sk_buff  const  *skb )
   return ((int )((unsigned int )((long )tmp) - (unsigned int )((long )skb->data)));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -20093,7 +20094,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25906,7 +25907,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103___0(struct net_device *ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -27948,7 +27949,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -7101,6 +7101,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -11863,7 +11864,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14236,7 +14237,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -7718,6 +7718,7 @@ __inline static void skb_reset_mac_header(struct sk_buff *skb )
 }
 extern void skb_trim(struct sk_buff * , unsigned int  ) ;
 extern void skb_queue_purge(struct sk_buff_head * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -13999,7 +14000,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16686,7 +16687,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -6713,6 +6713,7 @@ __inline static void skb_reserve(struct sk_buff *skb , int len )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -10014,7 +10015,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8472,6 +8472,7 @@ __inline static unsigned char *skb_tail_pointer(struct sk_buff  const  *skb )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
                                                   unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -15186,7 +15187,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22263,7 +22264,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -12573,6 +12573,7 @@ __inline static struct sk_buff *__skb_dequeue(struct sk_buff_head *list )
 }
 }
 extern unsigned char *skb_put(struct sk_buff * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg1 ,
                                                  unsigned int ldv_func_arg2 , gfp_t flags ) ;
 __inline static struct sk_buff *netdev_alloc_skb(struct net_device *dev , unsigned int length ) 
@@ -14758,7 +14759,7 @@ static struct sk_buff *ldv___netdev_alloc_skb_91(struct net_device *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -39691,7 +39692,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct
sk_buff)), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^static struct sk_buff \*ldv___netdev_alloc_skb_\d+(___\d+)/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct sk_buff));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  c/ldv-*/*.[ci]
```
