### PR TITLE
Remove ldv_malloc_unknown_size call from ldv_usb_submit_urb*

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
@@ -10029,14 +10029,12 @@ static int ldv_dev_set_drvdata_52(struct device *dev , void *data )
 }
 static int ldv_usb_submit_urb_53(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_54(struct device  const  *dev ) 
@@ -10233,26 +10231,22 @@ static void ldv___ldv_spin_lock_79(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_81(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_82(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags ) 
@@ -10281,14 +10275,12 @@ static struct urb *ldv_usb_alloc_urb_84(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags ) 
@@ -10305,14 +10297,12 @@ static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_87(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_del_timer_sync_88(struct timer_list *ldv_func_arg1 ) 
@@ -10333,26 +10323,22 @@ static int ldv_del_timer_sync_88(struct timer_list *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_90(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_91(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
@@ -9554,13 +9554,11 @@ static int ldv_dev_set_drvdata_52(struct device *dev , void *data )
 }
 static int ldv_usb_submit_urb_53(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_54(struct device const *dev )
@@ -9730,24 +9728,20 @@ static void ldv___ldv_spin_lock_79(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_81(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_82(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
@@ -9774,13 +9768,11 @@ static struct urb *ldv_usb_alloc_urb_84(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags )
@@ -9796,13 +9788,11 @@ static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_87(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_del_timer_sync_88(struct timer_list *ldv_func_arg1 )
@@ -9822,24 +9812,20 @@ static int ldv_del_timer_sync_88(struct timer_list *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_90(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_91(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
@@ -19466,14 +19466,12 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags ) 
@@ -19490,14 +19488,12 @@ static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_91(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_92(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
@@ -18518,13 +18518,11 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
@@ -18540,13 +18538,11 @@ static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_91(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_92(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
@@ -17862,14 +17862,12 @@ __inline static void ldv_spin_unlock_62(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_63(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_64(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -17899,14 +17897,12 @@ static struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_66(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_67(spinlock_t *ldv_func_arg1 ) 
@@ -19433,26 +19429,22 @@ int tm6000_ir_fini(struct tm6000_core *dev )
 }
 static int ldv_usb_submit_urb_63___0(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_64(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_65___0(int ldv_func_arg1 , gfp_t flags ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
@@ -16815,13 +16815,11 @@ __inline static void ldv_spin_unlock_62(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_63(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_64(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -16849,13 +16847,11 @@ static struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_66(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_67(spinlock_t *ldv_func_arg1 )
@@ -18280,24 +18276,20 @@ int tm6000_ir_fini(struct tm6000_core *dev )
 }
 static int ldv_usb_submit_urb_63___0(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_64(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_65___0(int ldv_func_arg1 , gfp_t flags )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
@@ -9322,26 +9322,22 @@ __inline static void ldv_spin_unlock_irqrestore_66(spinlock_t *lock , unsigned l
 }
 static int ldv_usb_submit_urb_67(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_68(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_del_timer_69(struct timer_list *ldv_func_arg1 ) 
@@ -9419,14 +9415,12 @@ static void *ldv_usb_alloc_coherent_73(struct usb_device *ldv_func_arg1 , size_t
 }
 static int ldv_usb_submit_urb_74(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv__builtin_expect(long exp , long c ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
@@ -8962,24 +8962,20 @@ __inline static void ldv_spin_unlock_irqrestore_66(spinlock_t *lock , unsigned l
 }
 static int ldv_usb_submit_urb_67(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_68(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_del_timer_69(struct timer_list *ldv_func_arg1 )
@@ -9052,13 +9048,11 @@ static void *ldv_usb_alloc_coherent_73(struct usb_device *ldv_func_arg1 , size_t
 }
 static int ldv_usb_submit_urb_74(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv__builtin_expect(long exp , long c ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
@@ -18238,14 +18238,12 @@ static void ldv___ldv_spin_lock_62___0(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_64(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_65(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -18287,14 +18285,12 @@ static struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_68(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 extern size_t memweight(void const   * , size_t  ) ;
@@ -21672,14 +21668,12 @@ void uvc_status_stop(struct uvc_device *dev )
 }
 static int ldv_usb_submit_urb_60(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags ) 
@@ -21696,14 +21690,12 @@ static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_62(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int isight_decode(struct uvc_video_queue *queue , struct uvc_buffer *buf ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
@@ -17007,13 +17007,11 @@ static void ldv___ldv_spin_lock_62___0(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_64(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_65(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -17052,13 +17050,11 @@ static struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_68(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 extern size_t memweight(void const * , size_t ) ;
@@ -20112,13 +20108,11 @@ void uvc_status_stop(struct uvc_device *dev )
 }
 static int ldv_usb_submit_urb_60(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags )
@@ -20134,13 +20128,11 @@ static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_62(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int isight_decode(struct uvc_video_queue *queue , struct uvc_buffer *buf ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -9660,26 +9660,22 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
 }
 static int ldv_usb_submit_urb_83(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_84(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_85(spinlock_t *lock ) 
@@ -9708,14 +9704,12 @@ __inline static void ldv_spin_unlock_86(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_88(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_irq_89(spinlock_t *lock ) 
@@ -9758,14 +9752,12 @@ __inline static void ldv_spin_unlock_irq_91(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_94(spinlock_t *ldv_func_arg1 ) 
@@ -9961,14 +9953,12 @@ static void ldv_free_netdev_109(struct net_device *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_110(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_111(int ldv_func_arg1 , gfp_t flags ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -9294,24 +9294,20 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
 }
 static int ldv_usb_submit_urb_83(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_84(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_85(spinlock_t *lock )
@@ -9336,13 +9332,11 @@ __inline static void ldv_spin_unlock_86(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_88(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_irq_89(spinlock_t *lock )
@@ -9380,13 +9374,11 @@ __inline static void ldv_spin_unlock_irq_91(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_94(spinlock_t *ldv_func_arg1 )
@@ -9560,13 +9552,11 @@ static void ldv_free_netdev_109(struct net_device *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_110(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_111(int ldv_func_arg1 , gfp_t flags )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
@@ -10637,62 +10637,52 @@ static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_84(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_86(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_87(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_88(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_89(int ldv_func_arg1 , gfp_t flags ) 
@@ -10733,26 +10723,22 @@ static struct urb *ldv_usb_alloc_urb_91(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_93(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_94(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
@@ -10158,57 +10158,47 @@ static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_84(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_86(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_87(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_88(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_89(int ldv_func_arg1 , gfp_t flags )
@@ -10246,24 +10236,20 @@ static struct urb *ldv_usb_alloc_urb_91(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_93(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_94(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
@@ -11803,14 +11803,12 @@ static void ldv___ldv_spin_lock_91(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_95(spinlock_t *ldv_func_arg1 ) 
@@ -11899,14 +11897,12 @@ static int ldv_del_timer_112(struct timer_list *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_113(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_bh_114(spinlock_t *lock ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
@@ -11263,13 +11263,11 @@ static void ldv___ldv_spin_lock_91(spinlock_t *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_92(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_95(spinlock_t *ldv_func_arg1 )
@@ -11349,13 +11347,11 @@ static int ldv_del_timer_112(struct timer_list *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_113(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_bh_114(spinlock_t *lock )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.c
@@ -21053,26 +21053,22 @@ __inline static void *kcalloc(size_t n , size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_86(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_87(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.i
@@ -19866,24 +19866,20 @@ __inline static void *kcalloc(size_t n , size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_85(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_86(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_register_driver_87(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,

--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7151,14 +7151,12 @@ static int ldv_mutex_lock_interruptible_107(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_109(struct mutex *ldv_func_arg1 ) 
@@ -7219,14 +7217,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_113(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_117(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_118(spinlock_t *ldv_func_arg1 ) 
@@ -7255,14 +7251,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_121(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_123(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_125(struct mutex *ldv_func_arg1 ) 
@@ -7323,14 +7317,12 @@ static int ldv_mutex_lock_interruptible_130(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_133(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -9937,14 +9937,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_95(spinlock_t *ldv
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_unlock_irqrestore_97(spinlock_t *lock , unsigned long flags ) 
@@ -9989,38 +9987,32 @@ static int ldv_mod_timer_99(struct timer_list *ldv_func_arg1 , unsigned long ldv
 }
 static int ldv_usb_submit_urb_101(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_104(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -9510,13 +9510,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_95(spinlock_t *ldv
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_unlock_irqrestore_97(spinlock_t *lock , unsigned long flags )
@@ -9556,35 +9554,29 @@ static int ldv_mod_timer_99(struct timer_list *ldv_func_arg1 , unsigned long ldv
 }
 static int ldv_usb_submit_urb_101(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_104(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -9235,14 +9235,12 @@ static void ldv_mutex_unlock_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -9402,26 +9400,22 @@ static void ldv_usb_free_coherent_129(struct usb_device *dev , size_t size , voi
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_131(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_sysfs_create_group_132(struct kobject *ldv_func_arg1 , struct attribute_group  const  *ldv_func_arg2 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -8820,13 +8820,11 @@ static void ldv_mutex_unlock_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -8968,24 +8966,20 @@ static void ldv_usb_free_coherent_129(struct usb_device *dev , size_t size , voi
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_131(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_sysfs_create_group_132(struct kobject *ldv_func_arg1 , struct attribute_group const *ldv_func_arg2 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -11218,38 +11218,32 @@ static void ldv_usb_free_urb_95(struct urb *urb )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) 
@@ -11265,14 +11259,12 @@ static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 ) 
@@ -11299,14 +11291,12 @@ static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_104(struct mutex *ldv_func_arg1 ) 
@@ -11371,14 +11361,12 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_109(struct urb *urb ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -10578,35 +10578,29 @@ static void ldv_usb_free_urb_95(struct urb *urb )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 )
@@ -10620,13 +10614,11 @@ static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 )
@@ -10649,13 +10641,11 @@ static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_104(struct mutex *ldv_func_arg1 )
@@ -10714,13 +10704,11 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_109(struct urb *urb )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -11596,14 +11596,12 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags ) 
@@ -11645,14 +11643,12 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_101(struct usb_device *dev , size_t size , void *addr ,
@@ -11703,26 +11699,22 @@ static void ldv_usb_free_urb_104(struct urb *urb )
 }
 static int ldv_usb_submit_urb_105(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vmalloc_32_107(unsigned long ldv_func_arg1 ) 
@@ -11799,14 +11791,12 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_112(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_113(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -11047,13 +11047,11 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags )
@@ -11093,13 +11091,11 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_101(struct usb_device *dev , size_t size , void *addr ,
@@ -11142,24 +11138,20 @@ static void ldv_usb_free_urb_104(struct urb *urb )
 }
 static int ldv_usb_submit_urb_105(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vmalloc_32_107(unsigned long ldv_func_arg1 )
@@ -11229,13 +11221,11 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_112(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_113(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -11278,14 +11278,12 @@ static void ldv_mutex_unlock_128(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_129(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_130(struct urb *urb ) 
@@ -11319,14 +11317,12 @@ static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_dvb_register_frontend_133(struct dvb_adapter *ldv_func_arg1 , struct dvb_frontend *ldv_func_arg2 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -10960,13 +10960,11 @@ static void ldv_mutex_unlock_128(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_129(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_130(struct urb *urb )
@@ -10997,13 +10995,11 @@ static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_dvb_register_frontend_133(struct dvb_adapter *ldv_func_arg1 , struct dvb_frontend *ldv_func_arg2 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -20306,14 +20306,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100___0(spinlock_t
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_103(struct usb_device *dev , size_t size , void *addr ,
@@ -20396,14 +20394,12 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_104___1(struct mutex *ldv_func_arg1 ) ;
@@ -24050,14 +24046,12 @@ void uvc_status_stop(struct uvc_device *dev )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_97(int ldv_func_arg1 , gfp_t flags ) 
@@ -24091,14 +24085,12 @@ static void ldv_usb_free_urb_98(struct urb *urb )
 }
 static int ldv_usb_submit_urb_99(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int isight_decode(struct uvc_video_queue *queue , struct uvc_buffer *buf ,

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -18986,13 +18986,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100___0(spinlock_t
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_103(struct usb_device *dev , size_t size , void *addr ,
@@ -19068,13 +19066,11 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_104___1(struct mutex *ldv_func_arg1 ) ;
@@ -22364,13 +22360,11 @@ void uvc_status_stop(struct uvc_device *dev )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_97(int ldv_func_arg1 , gfp_t flags )
@@ -22401,13 +22395,11 @@ static void ldv_usb_free_urb_98(struct urb *urb )
 }
 static int ldv_usb_submit_urb_99(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int isight_decode(struct uvc_video_queue *queue , struct uvc_buffer *buf ,

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -10021,26 +10021,22 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_123(spinlock_t *lock ) 
@@ -10069,14 +10065,12 @@ __inline static void ldv_spin_unlock_124(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_126(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_irq_127(spinlock_t *lock ) 
@@ -10119,14 +10113,12 @@ __inline static void ldv_spin_unlock_irq_129(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_132(spinlock_t *ldv_func_arg1 ) 
@@ -10466,14 +10458,12 @@ static void ldv_free_netdev_157(struct net_device *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_158(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_159(struct urb *urb ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -9725,24 +9725,20 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_123(spinlock_t *lock )
@@ -9767,13 +9763,11 @@ __inline static void ldv_spin_unlock_124(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_126(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_irq_127(spinlock_t *lock )
@@ -9811,13 +9805,11 @@ __inline static void ldv_spin_unlock_irq_129(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_132(spinlock_t *ldv_func_arg1 )
@@ -10115,13 +10107,11 @@ static void ldv_free_netdev_157(struct net_device *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_158(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_159(struct urb *urb )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -13522,26 +13522,22 @@ static void ldv_usb_free_urb_126(struct urb *urb )
 }
 static int ldv_usb_submit_urb_127(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_128(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static unsigned long ldv_wait_for_completion_timeout_129(struct completion *ldv_func_arg1 ,
@@ -13607,14 +13603,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_134(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_136(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_137(spinlock_t *ldv_func_arg1 ) 
@@ -13781,14 +13775,12 @@ static int ldv_mod_timer_152(struct timer_list *ldv_func_arg1 , unsigned long ld
 }
 static int ldv_usb_submit_urb_153(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_154(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -13046,24 +13046,20 @@ static void ldv_usb_free_urb_126(struct urb *urb )
 }
 static int ldv_usb_submit_urb_127(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_128(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static unsigned long ldv_wait_for_completion_timeout_129(struct completion *ldv_func_arg1 ,
@@ -13120,13 +13116,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_134(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_136(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_137(spinlock_t *ldv_func_arg1 )
@@ -13273,13 +13267,11 @@ static int ldv_mod_timer_152(struct timer_list *ldv_func_arg1 , unsigned long ld
 }
 static int ldv_usb_submit_urb_153(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_154(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -7660,50 +7660,42 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_109(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_110(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_111(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_init_completion_112(struct completion *x ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -7401,46 +7401,38 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_109(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_110(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_111(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_init_completion_112(struct completion *x )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -7697,26 +7697,22 @@ __inline static void ldv_spin_unlock_100(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_107(struct urb *urb ) 
@@ -7789,14 +7785,12 @@ static int ldv_mutex_lock_interruptible_112(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_113(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 ) 
@@ -7812,14 +7806,12 @@ static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_116(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_118(struct mutex *ldv_func_arg1 ) 
@@ -7892,14 +7884,12 @@ static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_133(struct mutex *ldv_func_arg1 ) 
@@ -7982,14 +7972,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_141(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_144(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ldv_func_arg1 ) 
@@ -8182,14 +8170,12 @@ static void ldv_mutex_unlock_170(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_171(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_174(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -7396,24 +7396,20 @@ __inline static void ldv_spin_unlock_100(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_107(struct urb *urb )
@@ -7475,13 +7471,11 @@ static int ldv_mutex_lock_interruptible_112(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_113(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 )
@@ -7495,13 +7489,11 @@ static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_116(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_118(struct mutex *ldv_func_arg1 )
@@ -7563,13 +7555,11 @@ static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_133(struct mutex *ldv_func_arg1 )
@@ -7638,13 +7628,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_141(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_144(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ldv_func_arg1 )
@@ -7810,13 +7798,11 @@ static void ldv_mutex_unlock_170(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_171(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_174(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -6779,14 +6779,12 @@ __inline static void ldv_spin_unlock_96(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_99(struct usb_device *dev , size_t size , void *addr ,
@@ -6862,14 +6860,12 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_105(struct urb *urb ) 
@@ -7040,14 +7036,12 @@ static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_120(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_121(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -6552,13 +6552,11 @@ __inline static void ldv_spin_unlock_96(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_99(struct usb_device *dev , size_t size , void *addr ,
@@ -6626,13 +6624,11 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_105(struct urb *urb )
@@ -6773,13 +6769,11 @@ static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_120(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_121(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -6609,14 +6609,12 @@ static void ldv_mutex_unlock_103(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_105(struct mutex *ldv_func_arg1 ) 
@@ -6744,14 +6742,12 @@ static int ldv_mutex_lock_interruptible_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 ) 
@@ -6791,14 +6787,12 @@ __inline static void ldv_spin_unlock_121(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -6380,13 +6380,11 @@ static void ldv_mutex_unlock_103(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_105(struct mutex *ldv_func_arg1 )
@@ -6495,13 +6493,11 @@ static int ldv_mutex_lock_interruptible_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 )
@@ -6535,13 +6531,11 @@ __inline static void ldv_spin_unlock_121(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -7453,14 +7453,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_103(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -7152,13 +7152,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_103(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -6311,14 +6311,12 @@ __inline static void ldv_spin_unlock_irqrestore_101(spinlock_t *lock , unsigned 
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 ) 
@@ -6408,14 +6406,12 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) 
@@ -6542,14 +6538,12 @@ static void ldv_mutex_unlock_120(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -6116,13 +6116,11 @@ __inline static void ldv_spin_unlock_irqrestore_101(spinlock_t *lock , unsigned 
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 )
@@ -6207,13 +6205,11 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 )
@@ -6318,13 +6314,11 @@ static void ldv_mutex_unlock_120(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10261,14 +10261,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_115(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_117(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_ldv_post_init_118(int ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -9808,13 +9808,11 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_115(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_117(struct urb *ldv_func_arg1 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_ldv_post_init_118(int ldv_func_arg1 )

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7151,14 +7151,12 @@ static int ldv_mutex_lock_interruptible_107(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_109(struct mutex *ldv_func_arg1 ) 
@@ -7219,14 +7217,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_113(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_117(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_118(spinlock_t *ldv_func_arg1 ) 
@@ -7255,14 +7251,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_121(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_123(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_125(struct mutex *ldv_func_arg1 ) 
@@ -7323,14 +7317,12 @@ static int ldv_mutex_lock_interruptible_130(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_133(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -9937,14 +9937,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_95(spinlock_t *ldv
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_unlock_irqrestore_97(spinlock_t *lock , unsigned long flags ) 
@@ -9989,38 +9987,32 @@ static int ldv_mod_timer_99(struct timer_list *ldv_func_arg1 , unsigned long ldv
 }
 static int ldv_usb_submit_urb_101(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_104(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -9235,14 +9235,12 @@ static void ldv_mutex_unlock_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -9402,26 +9400,22 @@ static void ldv_usb_free_coherent_129(struct usb_device *dev , size_t size , voi
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_131(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_sysfs_create_group_132(struct kobject *ldv_func_arg1 , struct attribute_group  const  *ldv_func_arg2 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -11218,38 +11218,32 @@ static void ldv_usb_free_urb_95(struct urb *urb )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) 
@@ -11265,14 +11259,12 @@ static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 ) 
@@ -11299,14 +11291,12 @@ static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_103(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_104(struct mutex *ldv_func_arg1 ) 
@@ -11371,14 +11361,12 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_109(struct urb *urb ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -11596,14 +11596,12 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags ) 
@@ -11645,14 +11643,12 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
 }
 static int ldv_usb_submit_urb_100(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_101(struct usb_device *dev , size_t size , void *addr ,
@@ -11703,26 +11699,22 @@ static void ldv_usb_free_urb_104(struct urb *urb )
 }
 static int ldv_usb_submit_urb_105(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vmalloc_32_107(unsigned long ldv_func_arg1 ) 
@@ -11799,14 +11791,12 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_112(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_113(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -11278,14 +11278,12 @@ static void ldv_mutex_unlock_128(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_129(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_130(struct urb *urb ) 
@@ -11319,14 +11317,12 @@ static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_dvb_register_frontend_133(struct dvb_adapter *ldv_func_arg1 , struct dvb_frontend *ldv_func_arg2 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -20306,14 +20306,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100___0(spinlock_t
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_103(struct usb_device *dev , size_t size , void *addr ,
@@ -20396,14 +20394,12 @@ static struct urb *ldv_usb_alloc_urb_107(int ldv_func_arg1 , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_104___1(struct mutex *ldv_func_arg1 ) ;
@@ -24050,14 +24046,12 @@ void uvc_status_stop(struct uvc_device *dev )
 }
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_97(int ldv_func_arg1 , gfp_t flags ) 
@@ -24091,14 +24085,12 @@ static void ldv_usb_free_urb_98(struct urb *urb )
 }
 static int ldv_usb_submit_urb_99(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int isight_decode(struct uvc_video_queue *queue , struct uvc_buffer *buf ,

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -10021,26 +10021,22 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_123(spinlock_t *lock ) 
@@ -10069,14 +10065,12 @@ __inline static void ldv_spin_unlock_124(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_126(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_irq_127(spinlock_t *lock ) 
@@ -10119,14 +10113,12 @@ __inline static void ldv_spin_unlock_irq_129(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_130(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_132(spinlock_t *ldv_func_arg1 ) 
@@ -10466,14 +10458,12 @@ static void ldv_free_netdev_157(struct net_device *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_158(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_159(struct urb *urb ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -13522,26 +13522,22 @@ static void ldv_usb_free_urb_126(struct urb *urb )
 }
 static int ldv_usb_submit_urb_127(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_128(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static unsigned long ldv_wait_for_completion_timeout_129(struct completion *ldv_func_arg1 ,
@@ -13607,14 +13603,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_134(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_136(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_137(spinlock_t *ldv_func_arg1 ) 
@@ -13781,14 +13775,12 @@ static int ldv_mod_timer_152(struct timer_list *ldv_func_arg1 , unsigned long ld
 }
 static int ldv_usb_submit_urb_153(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_154(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -7660,50 +7660,42 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_109(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_110(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_111(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_init_completion_112(struct completion *x ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -7697,26 +7697,22 @@ __inline static void ldv_spin_unlock_100(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_usb_submit_urb_106(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_107(struct urb *urb ) 
@@ -7789,14 +7785,12 @@ static int ldv_mutex_lock_interruptible_112(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_113(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 ) 
@@ -7812,14 +7806,12 @@ static void ldv_mutex_unlock_114(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_116(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mutex_lock_interruptible_118(struct mutex *ldv_func_arg1 ) 
@@ -7892,14 +7884,12 @@ static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_132(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_133(struct mutex *ldv_func_arg1 ) 
@@ -7982,14 +7972,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_141(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_144(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ldv_func_arg1 ) 
@@ -8182,14 +8170,12 @@ static void ldv_mutex_unlock_170(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_171(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_174(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -6779,14 +6779,12 @@ __inline static void ldv_spin_unlock_96(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_98(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_coherent_99(struct usb_device *dev , size_t size , void *addr ,
@@ -6862,14 +6860,12 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_usb_free_urb_105(struct urb *urb ) 
@@ -7040,14 +7036,12 @@ static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_120(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_121(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -6609,14 +6609,12 @@ static void ldv_mutex_unlock_103(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_104(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_105(struct mutex *ldv_func_arg1 ) 
@@ -6744,14 +6742,12 @@ static int ldv_mutex_lock_interruptible_117(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_118(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_119(struct mutex *ldv_func_arg1 ) 
@@ -6791,14 +6787,12 @@ __inline static void ldv_spin_unlock_121(spinlock_t *lock )
 }
 static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -7453,14 +7453,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_100(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_103(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -6311,14 +6311,12 @@ __inline static void ldv_spin_unlock_irqrestore_101(spinlock_t *lock , unsigned 
 }
 static int ldv_usb_submit_urb_102(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 ) 
@@ -6408,14 +6406,12 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
 }
 static int ldv_usb_submit_urb_108(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) 
@@ -6542,14 +6538,12 @@ static void ldv_mutex_unlock_120(struct mutex *ldv_func_arg1 )
 }
 static int ldv_usb_submit_urb_121(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10261,14 +10261,12 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_115(spinlock_t *ld
 }
 static int ldv_usb_submit_urb_117(struct urb *ldv_func_arg1 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_ldv_post_init_118(int ldv_func_arg1 ) 


### PR DESCRIPTION
usb_submit_urb returns 0 on success and a non-zero integer on failure.
There is nothing requiring memory allocation, let alone one of
unspecified size. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^static int ldv_usb_submit_urb_\d+(___\d+)?\(struct urb \*ldv_func_arg1 , gfp_t flags \) ?$/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^  return \(\(int \)\(\(long \)tmp\)\);/) {
         print "  return __VERIFIER_nondet_int();\n";
         $p = 1;
         next;
       }
       elsif(/tmp/) { next; }
     }
     print;
   }' \
    c/ldv-*/*.[ci]
```
