### PR TITLE
ldv_pskb_expand_head*: Use __VERIFIER_nondet_int

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -46285,14 +46285,12 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff  const  *ldv_func_
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_135(struct device  const  *dev ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -42715,13 +42715,11 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff const *ldv_func_ar
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_135(struct device const *dev )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -22152,14 +22152,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_60(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_69(spinlock_t *lock ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -20869,13 +20869,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_60(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_69(spinlock_t *lock )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -19945,14 +19945,12 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
 static int ldv_pskb_expand_head_117(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_118(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -18785,13 +18785,11 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
 static int ldv_pskb_expand_head_117(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_118(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
@@ -61556,14 +61556,12 @@ static int ldv_mod_timer_129(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_130(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_133(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -56562,13 +56562,11 @@ static int ldv_mod_timer_129(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_130(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_133(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -42139,27 +42139,23 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_104(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_105(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv_is_err(void const   *ptr ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -39203,25 +39203,21 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_104(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_105(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv_is_err(void const *ptr ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
@@ -28275,14 +28275,12 @@ static int ldv_mod_timer_138(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_139(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_142(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -26344,13 +26344,11 @@ static int ldv_mod_timer_138(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_139(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_142(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -13239,14 +13239,12 @@ static int ldv_mod_timer_119(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_120(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -12642,13 +12642,11 @@ static int ldv_mod_timer_119(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_120(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -41724,27 +41724,23 @@ static int ldv_mod_timer_131(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_132(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_133(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_134(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -39039,25 +39039,21 @@ static int ldv_mod_timer_131(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_132(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_133(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_134(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -17959,14 +17959,12 @@ __inline static void ldv_spin_unlock_110(spinlock_t *lock )
 static int ldv_pskb_expand_head_111(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_112(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -16961,13 +16961,11 @@ __inline static void ldv_spin_unlock_110(spinlock_t *lock )
 static int ldv_pskb_expand_head_111(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_112(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.c
@@ -29216,14 +29216,12 @@ static int process_rxed_802_11_packet(struct lbs_private *priv , struct sk_buff 
 static int ldv_pskb_expand_head_82(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_82___1(spinlock_t *ldv_func_arg1 ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.i
@@ -27350,13 +27350,11 @@ static int process_rxed_802_11_packet(struct lbs_private *priv , struct sk_buff 
 static int ldv_pskb_expand_head_82(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_82___1(spinlock_t *ldv_func_arg1 ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -45525,14 +45525,12 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff  const  *ldv_func_
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_135(struct device  const  *dev ) 

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -42161,13 +42161,11 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff const *ldv_func_ar
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_dev_get_drvdata_135(struct device const *dev )

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -22011,14 +22011,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_60(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_69(spinlock_t *lock ) 

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -20848,13 +20848,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_59(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_60(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_69(spinlock_t *lock )

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -19798,14 +19798,12 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
 static int ldv_pskb_expand_head_117(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_118(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -18739,13 +18739,11 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
 static int ldv_pskb_expand_head_117(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_spin_lock_118(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -12963,14 +12963,12 @@ static int ldv_mod_timer_119(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_120(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 ) 

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -12453,13 +12453,11 @@ static int ldv_mod_timer_119(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_120(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ldv_func_arg2 )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
@@ -16078,14 +16078,12 @@ static void ldv___ldv_spin_lock_112(spinlock_t *ldv_func_arg1 )
 static int ldv_pskb_expand_head_116(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv___ldv_spin_trylock_117(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
@@ -15183,13 +15183,11 @@ static void ldv___ldv_spin_lock_112(spinlock_t *ldv_func_arg1 )
 static int ldv_pskb_expand_head_116(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv___ldv_spin_trylock_117(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
@@ -14055,14 +14055,12 @@ static void ldv___ldv_spin_lock_108(spinlock_t *ldv_func_arg1 )
 static int ldv_pskb_expand_head_112(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv___ldv_spin_trylock_113(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
@@ -13345,13 +13345,11 @@ static void ldv___ldv_spin_lock_108(spinlock_t *ldv_func_arg1 )
 static int ldv_pskb_expand_head_112(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv___ldv_spin_trylock_113(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
@@ -16828,14 +16828,12 @@ static int ldv_mod_timer_112(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_113(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_114(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -15906,13 +15906,11 @@ static int ldv_mod_timer_112(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_113(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_114(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
@@ -16750,14 +16750,12 @@ static void ldv_free_irq_108(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
 static int ldv_pskb_expand_head_109(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_bh_112(spinlock_t *lock ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
@@ -15749,13 +15749,11 @@ static void ldv_free_irq_108(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
 static int ldv_pskb_expand_head_109(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_bh_112(spinlock_t *lock )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
@@ -19522,14 +19522,12 @@ __inline static void ldv_spin_unlock_104(spinlock_t *lock )
 static int ldv_pskb_expand_head_108(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_free_irq_111(unsigned int ldv_func_arg1 , void *ldv_func_arg2 ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -18271,13 +18271,11 @@ __inline static void ldv_spin_unlock_104(spinlock_t *lock )
 static int ldv_pskb_expand_head_108(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_free_irq_111(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -42040,27 +42040,23 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_104(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_105(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv_is_err(void const   *ptr ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -39252,25 +39252,21 @@ static struct sk_buff *ldv___netdev_alloc_skb_61(struct net_device *ldv_func_arg
 static int ldv_pskb_expand_head_104(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_105(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 long ldv_is_err(void const *ptr ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -42516,27 +42516,23 @@ static int ldv_mod_timer_131(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_132(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_133(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_134(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -40161,25 +40161,21 @@ static int ldv_mod_timer_131(struct timer_list *ldv_func_arg1 , unsigned long ld
 static int ldv_pskb_expand_head_132(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static int ldv_pskb_expand_head_133(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct net_device *ldv_alloc_etherdev_mqs_134(int ldv_func_arg1 , unsigned int ldv_func_arg2 ,

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -14347,14 +14347,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -13749,13 +13749,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -46602,14 +46602,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_109(spinlock_t *lock ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -43230,13 +43230,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_109(spinlock_t *lock )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -21249,14 +21249,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 void i40evf_fill_default_direct_cmd_desc(struct i40e_aq_desc *desc , u16 opcode ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -20074,13 +20074,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 void i40evf_fill_default_direct_cmd_desc(struct i40e_aq_desc *desc , u16 opcode ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -17319,14 +17319,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -16507,13 +16507,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -20101,14 +20101,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -18949,13 +18949,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -13981,14 +13981,12 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 static int ldv_pskb_expand_head_98(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
@@ -14007,14 +14005,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -13353,13 +13353,11 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 static int ldv_pskb_expand_head_98(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
@@ -13377,13 +13375,11 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags )
 {
-  void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 )

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14347,14 +14347,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -46602,14 +46602,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 __inline static void ldv_spin_lock_109(spinlock_t *lock ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -21249,14 +21249,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 void i40evf_fill_default_direct_cmd_desc(struct i40e_aq_desc *desc , u16 opcode ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17319,14 +17319,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_105(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -20101,14 +20101,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_126(spinlock_t *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -13981,14 +13981,12 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 static int ldv_pskb_expand_head_98(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                    int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_arg1 ,
@@ -14007,14 +14005,12 @@ static struct sk_buff *ldv___netdev_alloc_skb_103(struct net_device *ldv_func_ar
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) 
 { 
-  void *tmp ;
 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
   }
-  return ((int )((long )tmp));
+  return __VERIFIER_nondet_int();
 }
 }
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) 


### PR DESCRIPTION
There is no need to use __VERIFIER_nondet_pointer here at all. This is
in preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^static int ldv_pskb_expand_head_\d+\(struct sk_buff \*ldv_func_arg1 , int ldv_func_arg2 , ?$/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^  return \(\(int \)\(\(long \)tmp\)\);/) {
         print "  return __VERIFIER_nondet_int();\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
       elsif(/tmp/) { next; }
     }
     print;
   }' \
  c/ldv-*/*.[ci]
```
