### PR TITLE
Implement ldv_usb_alloc_urb_* using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
@@ -10255,6 +10255,7 @@ static int ldv_usb_submit_urb_82(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10262,7 +10263,7 @@ static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10274,7 +10275,7 @@ static struct urb *ldv_usb_alloc_urb_84(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10298,7 +10299,7 @@ static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10610,7 +10611,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
@@ -9750,13 +9750,14 @@ static int ldv_usb_submit_urb_82(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9767,7 +9768,7 @@ static struct urb *ldv_usb_alloc_urb_84(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9789,7 +9790,7 @@ static struct urb *ldv_usb_alloc_urb_86(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10063,7 +10064,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
@@ -19476,6 +19476,7 @@ static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -19483,7 +19484,7 @@ static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -29628,7 +29629,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
@@ -18527,13 +18527,14 @@ static int ldv_usb_submit_urb_89(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -27821,7 +27822,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
@@ -17885,6 +17885,7 @@ static void *ldv_usb_alloc_coherent_64(struct usb_device *ldv_func_arg1 , size_t
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -17892,7 +17893,7 @@ static struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -19462,7 +19463,7 @@ static struct urb *ldv_usb_alloc_urb_65___0(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -19693,7 +19694,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
@@ -16836,13 +16836,14 @@ static void *ldv_usb_alloc_coherent_64(struct usb_device *ldv_func_arg1 , size_t
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -18306,7 +18307,7 @@ static struct urb *ldv_usb_alloc_urb_65___0(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -18506,7 +18507,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
@@ -9392,6 +9392,7 @@ static int ldv_del_timer_71(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_72(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -9399,7 +9400,7 @@ static struct urb *ldv_usb_alloc_urb_72(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -17704,7 +17705,7 @@ static struct urb *ldv_usb_alloc_urb_70(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -19414,7 +19415,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
@@ -9027,13 +9027,14 @@ static int ldv_del_timer_71(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_72(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -16564,7 +16565,7 @@ static struct urb *ldv_usb_alloc_urb_70(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -18133,7 +18134,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
@@ -18261,6 +18261,7 @@ static void *ldv_usb_alloc_coherent_65(struct usb_device *ldv_func_arg1 , size_t
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_66(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -18268,7 +18269,7 @@ static struct urb *ldv_usb_alloc_urb_66(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -18280,7 +18281,7 @@ static struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -21689,7 +21690,7 @@ static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -22696,7 +22697,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
@@ -17028,13 +17028,14 @@ static void *ldv_usb_alloc_coherent_65(struct usb_device *ldv_func_arg1 , size_t
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_66(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -17045,7 +17046,7 @@ static struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -20127,7 +20128,7 @@ static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -21024,7 +21025,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -9845,6 +9845,7 @@ static void ldv_free_netdev_100(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_101(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -9852,7 +9853,7 @@ static struct urb *ldv_usb_alloc_urb_101(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9864,7 +9865,7 @@ static struct urb *ldv_usb_alloc_urb_102(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9876,7 +9877,7 @@ static struct urb *ldv_usb_alloc_urb_103(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9978,7 +9979,7 @@ static struct urb *ldv_usb_alloc_urb_111(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10239,7 +10240,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -9456,13 +9456,14 @@ static void ldv_free_netdev_100(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_101(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9473,7 +9474,7 @@ static struct urb *ldv_usb_alloc_urb_102(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9484,7 +9485,7 @@ static struct urb *ldv_usb_alloc_urb_103(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9575,7 +9576,7 @@ static struct urb *ldv_usb_alloc_urb_111(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -9802,7 +9803,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
@@ -10623,6 +10623,7 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10630,7 +10631,7 @@ static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10702,7 +10703,7 @@ static struct urb *ldv_usb_alloc_urb_89(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10714,7 +10715,7 @@ static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10726,7 +10727,7 @@ static struct urb *ldv_usb_alloc_urb_91(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -11080,7 +11081,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
@@ -10145,13 +10145,14 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_83(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10217,7 +10218,7 @@ static struct urb *ldv_usb_alloc_urb_89(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10228,7 +10229,7 @@ static struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10239,7 +10240,7 @@ static struct urb *ldv_usb_alloc_urb_91(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -10549,7 +10550,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
@@ -11741,6 +11741,7 @@ static int ldv_mod_timer_84(struct timer_list *ldv_func_arg1 , unsigned long ldv
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_85(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -11748,7 +11749,7 @@ static struct urb *ldv_usb_alloc_urb_85(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -12004,7 +12005,7 @@ static struct urb *ldv_usb_alloc_urb_125(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -12265,7 +12266,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
@@ -11210,13 +11210,14 @@ static int ldv_mod_timer_84(struct timer_list *ldv_func_arg1 , unsigned long ldv
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_85(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -11439,7 +11440,7 @@ static struct urb *ldv_usb_alloc_urb_125(int ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct urb));
   }
   return ((struct urb *)tmp);
 }
@@ -11666,7 +11667,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7355,6 +7355,7 @@ static void ldv_mutex_unlock_134(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_135(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9589,7 +9590,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -10232,6 +10232,7 @@ static void ldv_usb_free_coherent_128(struct usb_device *dev , size_t size , voi
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_129(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -17901,7 +17902,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -9767,6 +9767,7 @@ static void ldv_usb_free_coherent_128(struct usb_device *dev , size_t size , voi
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_129(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -16620,7 +16621,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -9264,6 +9264,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_120(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -11657,7 +11658,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -8847,6 +8847,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_120(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -10915,7 +10916,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -11187,6 +11187,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_94(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -13558,7 +13559,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -10550,6 +10550,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_94(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -12602,7 +12603,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -11606,6 +11606,7 @@ static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -14637,7 +14638,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -11056,6 +11056,7 @@ static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -13690,7 +13691,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -11299,6 +11299,7 @@ static void ldv_usb_free_urb_130(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -13550,7 +13551,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -10978,6 +10978,7 @@ static void ldv_usb_free_urb_130(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -12925,7 +12926,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -20358,6 +20358,7 @@ static void ldv_usb_free_urb_105(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_106(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -26807,7 +26808,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -19032,6 +19032,7 @@ static void ldv_usb_free_urb_105(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_106(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -24769,7 +24770,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -10206,6 +10206,7 @@ static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_139(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -9887,6 +9887,7 @@ static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_139(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -12017,7 +12018,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -13449,6 +13449,7 @@ static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ld
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_122(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -16363,7 +16364,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -12981,6 +12981,7 @@ static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ld
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_122(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -15494,7 +15495,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -7740,6 +7740,7 @@ static struct usb_device *ldv_usb_get_dev_114(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_115(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -10026,7 +10027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -7472,6 +7472,7 @@ static struct usb_device *ldv_usb_get_dev_114(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_115(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -9447,7 +9448,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -8004,6 +8004,7 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_147(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -10390,7 +10391,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -7657,6 +7657,7 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_147(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -9715,7 +9716,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -6823,6 +6823,7 @@ static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_102(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9332,7 +9333,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -6589,6 +6589,7 @@ static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_102(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -8749,7 +8750,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -6801,6 +6801,7 @@ static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9046,7 +9047,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -6544,6 +6544,7 @@ static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -8483,7 +8484,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -7421,6 +7421,7 @@ __inline static void ldv_init_completion_98(struct completion *x )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_99(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9676,7 +9677,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -7123,6 +7123,7 @@ __inline static void ldv_init_completion_98(struct completion *x )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_99(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -9072,7 +9073,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -6332,6 +6332,7 @@ static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_104(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -8717,7 +8718,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -6135,6 +6135,7 @@ static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_104(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -8196,7 +8197,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10199,6 +10199,7 @@ static void ldv_usb_free_urb_111(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_112(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -12395,7 +12396,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -9752,6 +9752,7 @@ static void ldv_usb_free_urb_111(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_112(int ldv_func_arg1 , gfp_t flags )
 {
   struct urb *res ;
@@ -11650,7 +11651,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7355,6 +7355,7 @@ static void ldv_mutex_unlock_134(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_135(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9589,7 +9590,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -10232,6 +10232,7 @@ static void ldv_usb_free_coherent_128(struct usb_device *dev , size_t size , voi
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_129(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -17901,7 +17902,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -9264,6 +9264,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_120(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -11657,7 +11658,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -11187,6 +11187,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_94(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -13558,7 +13559,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -11606,6 +11606,7 @@ static int ldv_usb_submit_urb_97(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -14637,7 +14638,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -11299,6 +11299,7 @@ static void ldv_usb_free_urb_130(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_131(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -13550,7 +13551,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -20358,6 +20358,7 @@ static void ldv_usb_free_urb_105(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_106(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -26807,7 +26808,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -10206,6 +10206,7 @@ static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_139(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -13449,6 +13449,7 @@ static int ldv_mod_timer_121(struct timer_list *ldv_func_arg1 , unsigned long ld
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_122(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -16363,7 +16364,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -7740,6 +7740,7 @@ static struct usb_device *ldv_usb_get_dev_114(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_115(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -10026,7 +10027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -8004,6 +8004,7 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_145(spinlock_t *ld
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_147(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -10390,7 +10391,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -6823,6 +6823,7 @@ static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_102(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9332,7 +9333,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -6801,6 +6801,7 @@ static int ldv_usb_submit_urb_122(struct urb *ldv_func_arg1 , gfp_t flags )
   return ((int )((long )tmp));
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_123(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9046,7 +9047,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -7421,6 +7421,7 @@ __inline static void ldv_init_completion_98(struct completion *x )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_99(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -9676,7 +9677,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -6332,6 +6332,7 @@ static struct usb_device *ldv_usb_get_dev_103(struct usb_device *ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_104(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -8717,7 +8718,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10199,6 +10199,7 @@ static void ldv_usb_free_urb_111(struct urb *urb )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 static struct urb *ldv_usb_alloc_urb_112(int ldv_func_arg1 , gfp_t flags ) 
 { 
   struct urb *res ;
@@ -12395,7 +12396,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct urb)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^static struct urb \*ldv_usb_alloc_urb_\d+(___\d+)?\(int ldv_func_arg1 , gfp_t flags \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct urb));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
