### PR TITLE
Implement ldv_skb_(clone|copy){,_expand}* using ldv_malloc(sizeof(str…

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7936,6 +7936,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const   *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_126(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -46263,7 +46264,7 @@ static struct sk_buff *ldv_skb_copy_126(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46277,7 +46278,7 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46786,7 +46787,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7810,6 +7810,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_126(struct sk_buff const *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -42694,7 +42695,7 @@ static struct sk_buff *ldv_skb_copy_126(struct sk_buff const *ldv_func_arg1 , gf
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -42707,7 +42708,7 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff const *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43154,7 +43155,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
@@ -39873,6 +39873,7 @@ int mwifiex_process_sta_rx_packet(struct mwifiex_private *priv , struct sk_buff 
 }
 static void ldv___ldv_spin_lock_101___0(spinlock_t *ldv_func_arg1 ) ;
 __inline static void ldv_spin_unlock_irqrestore_106___1(spinlock_t *lock , unsigned long flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_103(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 __inline static bool is_multicast_ether_addr(u8 const   *addr ) 
 { 
@@ -40475,7 +40476,7 @@ static struct sk_buff *ldv_skb_copy_103(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49109,7 +49110,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -37298,6 +37298,7 @@ int mwifiex_process_sta_rx_packet(struct mwifiex_private *priv , struct sk_buff 
 }
 static void ldv___ldv_spin_lock_101___0(spinlock_t *ldv_func_arg1 ) ;
 __inline static void ldv_spin_unlock_irqrestore_106___1(spinlock_t *lock , unsigned long flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_103(struct sk_buff const *ldv_func_arg1 , gfp_t flags ) ;
 __inline static bool is_multicast_ether_addr(u8 const *addr )
 {
@@ -37855,7 +37856,7 @@ static struct sk_buff *ldv_skb_copy_103(struct sk_buff const *ldv_func_arg1 , gf
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -45792,7 +45793,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -7965,6 +7965,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const   *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_126(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -45503,7 +45504,7 @@ static struct sk_buff *ldv_skb_copy_126(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -45517,7 +45518,7 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46026,7 +46027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -7839,6 +7839,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_126(struct sk_buff const *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_128(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -42140,7 +42141,7 @@ static struct sk_buff *ldv_skb_copy_126(struct sk_buff const *ldv_func_arg1 , gf
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -42153,7 +42154,7 @@ static struct sk_buff *ldv_skb_copy_expand_127(struct sk_buff const *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -42600,7 +42601,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
@@ -10188,6 +10188,7 @@ extern void mutex_lock_nested(struct mutex * , unsigned int  ) ;
 extern void mutex_unlock(struct mutex * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_83(struct sk_buff  const  *ldv_func_arg1 ,
                                               int ldv_func_arg2 , int ldv_func_arg3 ,
                                               gfp_t flags ) ;
@@ -11476,7 +11477,7 @@ static struct sk_buff *ldv_skb_copy_expand_83(struct sk_buff  const  *ldv_func_a
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14108,7 +14109,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
@@ -9799,6 +9799,7 @@ extern void mutex_lock_nested(struct mutex * , unsigned int ) ;
 extern void mutex_unlock(struct mutex * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 extern void kfree_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_83(struct sk_buff const *ldv_func_arg1 ,
                                               int ldv_func_arg2 , int ldv_func_arg3 ,
                                               gfp_t flags ) ;
@@ -10974,7 +10975,7 @@ static struct sk_buff *ldv_skb_copy_expand_83(struct sk_buff const *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13346,7 +13347,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -5688,6 +5688,7 @@ extern void __const_udelay(unsigned long  ) ;
 extern long schedule_timeout(long  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_90(struct sk_buff  const  *ldv_func_arg1 ,
                                               int ldv_func_arg2 , int ldv_func_arg3 ,
                                               gfp_t flags ) ;
@@ -9739,7 +9740,7 @@ static struct sk_buff *ldv_skb_copy_expand_90(struct sk_buff  const  *ldv_func_a
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10239,7 +10240,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -5650,6 +5650,7 @@ extern void __const_udelay(unsigned long ) ;
 extern long schedule_timeout(long ) ;
 extern void kfree(void const * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_90(struct sk_buff const *ldv_func_arg1 ,
                                               int ldv_func_arg2 , int ldv_func_arg3 ,
                                               gfp_t flags ) ;
@@ -9363,7 +9364,7 @@ static struct sk_buff *ldv_skb_copy_expand_90(struct sk_buff const *ldv_func_arg
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -9802,7 +9803,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
@@ -7778,6 +7778,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
 }
 extern void consume_skb(struct sk_buff * ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_167(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 __inline static bool skb_is_nonlinear(struct sk_buff  const  *skb ) 
 { 
@@ -34580,7 +34581,7 @@ static struct sk_buff *ldv_skb_copy_167(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35012,7 +35013,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -7688,6 +7688,7 @@ __inline static int dma_set_coherent_mask(struct device *dev , u64 mask )
 }
 extern void consume_skb(struct sk_buff * ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_167(struct sk_buff const *ldv_func_arg1 , gfp_t flags ) ;
 __inline static bool skb_is_nonlinear(struct sk_buff const *skb )
 {
@@ -32265,7 +32266,7 @@ static struct sk_buff *ldv_skb_copy_167(struct sk_buff const *ldv_func_arg1 , gf
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32640,7 +32641,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -6848,6 +6848,7 @@ extern void _dev_info(struct device  const  * , char const   *  , ...) ;
 extern void msleep(unsigned int  ) ;
 extern void kfree_skb(struct sk_buff * ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static int skb_shared(struct sk_buff  const  *skb ) 
 { 
@@ -10951,7 +10952,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13383,7 +13384,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -6806,6 +6806,7 @@ extern void _dev_info(struct device const * , char const * , ...) ;
 extern void msleep(unsigned int ) ;
 extern void kfree_skb(struct sk_buff * ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static int skb_shared(struct sk_buff const *skb )
 {
@@ -10554,7 +10555,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12652,7 +12653,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -9049,6 +9049,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const   *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_151(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -46775,7 +46776,7 @@ static struct sk_buff *ldv_skb_copy_151(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46789,7 +46790,7 @@ static struct sk_buff *ldv_skb_copy_expand_152(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49432,7 +49433,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -8898,6 +8898,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_151(struct sk_buff const *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -43375,7 +43376,7 @@ static struct sk_buff *ldv_skb_copy_151(struct sk_buff const *ldv_func_arg1 , gf
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43388,7 +43389,7 @@ static struct sk_buff *ldv_skb_copy_expand_152(struct sk_buff const *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -45668,7 +45669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -6650,6 +6650,7 @@ extern void __const_udelay(unsigned long  ) ;
 extern long schedule_timeout(long  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff  const  *ldv_func_arg1 ,
                                                int ldv_func_arg2 , int ldv_func_arg3 ,
                                                gfp_t flags ) ;
@@ -10100,7 +10101,7 @@ static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -6604,6 +6604,7 @@ extern void __const_udelay(unsigned long ) ;
 extern long schedule_timeout(long ) ;
 extern void kfree(void const * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff const *ldv_func_arg1 ,
                                                int ldv_func_arg2 , int ldv_func_arg3 ,
                                                gfp_t flags ) ;
@@ -9794,7 +9795,7 @@ static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff const *ldv_func_ar
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12017,7 +12018,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -14614,6 +14614,7 @@ __inline static int constant_test_bit(long nr , unsigned long const volatile   *
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 __inline static void atomic_add(int i , atomic_t *v ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static void skb_orphan(struct sk_buff *skb ) 
 { 
@@ -15081,7 +15082,7 @@ static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16301,7 +16302,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24185,7 +24186,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -13923,6 +13923,7 @@ __inline static int constant_test_bit(long nr , unsigned long const volatile *ad
 extern int memcmp(void const * , void const * , size_t ) ;
 __inline static void atomic_add(int i , atomic_t *v ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static void skb_orphan(struct sk_buff *skb )
 {
@@ -14340,7 +14341,7 @@ static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15465,7 +15466,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22546,7 +22547,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -6848,6 +6848,7 @@ extern void _dev_info(struct device  const  * , char const   *  , ...) ;
 extern void msleep(unsigned int  ) ;
 extern void kfree_skb(struct sk_buff * ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static int skb_shared(struct sk_buff  const  *skb ) 
 { 
@@ -10951,7 +10952,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -13383,7 +13384,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -9049,6 +9049,7 @@ __inline static unsigned int skb_frag_size(skb_frag_t const   *frag )
 }
 extern void consume_skb(struct sk_buff * ) ;
 extern struct sk_buff *build_skb(void * , unsigned int  ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_151(struct sk_buff  const  *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func_arg2 ,
                                     int ldv_func_arg3 , gfp_t flags ) ;
@@ -46775,7 +46776,7 @@ static struct sk_buff *ldv_skb_copy_151(struct sk_buff  const  *ldv_func_arg1 , 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46789,7 +46790,7 @@ static struct sk_buff *ldv_skb_copy_expand_152(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -49432,7 +49433,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -6650,6 +6650,7 @@ extern void __const_udelay(unsigned long  ) ;
 extern long schedule_timeout(long  ) ;
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff  const  *ldv_func_arg1 ,
                                                int ldv_func_arg2 , int ldv_func_arg3 ,
                                                gfp_t flags ) ;
@@ -10100,7 +10101,7 @@ static struct sk_buff *ldv_skb_copy_expand_128(struct sk_buff  const  *ldv_func_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12668,7 +12669,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14614,6 +14614,7 @@ __inline static int constant_test_bit(long nr , unsigned long const volatile   *
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 __inline static void atomic_add(int i , atomic_t *v ) ;
 extern void consume_skb(struct sk_buff * ) ;
+void *ldv_malloc(size_t size ) ;
 static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t flags ) ;
 __inline static void skb_orphan(struct sk_buff *skb ) 
 { 
@@ -15081,7 +15082,7 @@ static struct sk_buff *ldv_skb_clone_126(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16301,7 +16302,7 @@ static struct sk_buff *ldv_skb_clone_125(struct sk_buff *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24185,7 +24186,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
…uct sk_buff))

Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct
sk_buff)), thus using ldv_malloc is perfectly safe. The additional
effects of skb_clone, skb_copy, and skb_copy_expand are not implemented
at this time. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^static struct sk_buff \*ldv_skb_(copy|clone)_(expand_)?\d+\(struct sk_buff  ?(const  ?)?\*ldv_func_arg1 ,/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct sk_buff));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
