### PR TITLE
Implement alloc_skb using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.c
+++ b/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.c
@@ -9668,6 +9668,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.i
+++ b/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.i
@@ -9235,6 +9235,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -22793,6 +22793,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -22800,7 +22801,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -46666,7 +46667,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -21448,13 +21448,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43198,7 +43199,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -34549,6 +34549,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -34556,7 +34557,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35793,7 +35794,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -32137,13 +32137,14 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33304,7 +33305,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
@@ -42737,6 +42737,7 @@ __inline static void *kcalloc(size_t n , size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -42744,7 +42745,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -62615,7 +62616,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -39364,13 +39364,14 @@ __inline static void *kcalloc(size_t n , size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -57511,7 +57512,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
@@ -34412,6 +34412,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -34419,7 +34420,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -51011,7 +51012,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -31939,13 +31939,14 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -47115,7 +47116,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -53511,6 +53511,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -53518,7 +53519,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -81485,7 +81486,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -49799,13 +49799,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -74961,7 +74962,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -82164,6 +82164,7 @@ void efx_selftest_async_work(struct work_struct *data )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -82171,7 +82172,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -102697,7 +102698,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -75047,13 +75047,14 @@ void efx_selftest_async_work(struct work_struct *data )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -93557,7 +93558,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -11717,6 +11717,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -11724,7 +11725,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -12228,7 +12229,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -11167,13 +11167,14 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11616,7 +11617,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -34332,6 +34332,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -34339,7 +34340,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35576,7 +35577,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -32029,13 +32029,14 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33196,7 +33197,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
@@ -16687,6 +16687,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -16694,7 +16695,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17143,7 +17144,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
@@ -15609,13 +15609,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16009,7 +16010,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
@@ -10998,6 +10998,7 @@ void ldv_unregister_netdev_stop_7_2(int (*arg0)(struct net_device * ) , struct n
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -11005,7 +11006,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25876,7 +25877,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -10603,13 +10603,14 @@ void ldv_unregister_netdev_stop_7_2(int (*arg0)(struct net_device * ) , struct n
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23999,7 +24000,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.c
@@ -17414,6 +17414,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -17421,7 +17422,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -17808,7 +17809,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.i
@@ -16209,13 +16209,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16555,7 +16556,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -32590,6 +32590,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -32597,7 +32598,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -34273,7 +34274,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -30602,13 +30602,14 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32127,7 +32128,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
@@ -33818,6 +33818,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -33825,7 +33826,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35012,7 +35013,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -31596,13 +31596,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -32640,7 +32641,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void *ldv_calloc_unknown_size(void) ;
 void *ldv_zalloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -20203,6 +20203,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -20210,7 +20211,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -43410,7 +43411,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -19208,13 +19208,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -40373,7 +40374,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
@@ -23063,6 +23063,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -23070,7 +23071,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -37659,7 +37660,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -21938,13 +21938,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -35382,7 +35383,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -54229,6 +54229,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -54236,7 +54237,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -81445,7 +81446,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -50854,13 +50854,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -75282,7 +75283,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -11134,6 +11134,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -11141,7 +11142,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11645,7 +11646,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -10664,13 +10664,14 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -11113,7 +11114,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
@@ -10548,6 +10548,7 @@ void ldv_unregister_netdev_stop_7_2(int (*arg0)(struct net_device * ) , struct n
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10555,7 +10556,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -25426,7 +25427,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -10207,13 +10207,14 @@ void ldv_unregister_netdev_stop_7_2(int (*arg0)(struct net_device * ) , struct n
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -23603,7 +23604,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -31491,6 +31491,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -31498,7 +31499,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -33174,7 +33175,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -29637,13 +29637,14 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -31162,7 +31163,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.c
@@ -12003,6 +12003,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.i
@@ -11394,6 +11394,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.c
@@ -11848,6 +11848,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.i
@@ -11363,6 +11363,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.c
@@ -7997,6 +7997,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
@@ -7783,6 +7783,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.c
@@ -9617,6 +9617,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.i
@@ -9260,6 +9260,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.c
@@ -7839,6 +7839,7 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
@@ -7585,6 +7585,7 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.c
@@ -11656,6 +11656,7 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
@@ -11044,6 +11044,7 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.c
@@ -4449,6 +4449,7 @@ int ldv_devm_request_threaded_irq_19(struct device *ldv_func_arg1 , unsigned int
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
@@ -4270,6 +4270,7 @@ int ldv_devm_request_threaded_irq_19(struct device *ldv_func_arg1 , unsigned int
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.c
@@ -24417,6 +24417,7 @@ void *ldv_kmem_cache_alloc_214(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   struct sk_buff *tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
@@ -22710,6 +22710,7 @@ void *ldv_kmem_cache_alloc_214(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   struct sk_buff *tmp ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -13427,6 +13427,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13434,7 +13435,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15829,7 +15830,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -12896,13 +12896,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -14967,7 +14968,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -13966,6 +13966,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13973,7 +13974,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16686,7 +16687,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -13339,13 +13339,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15678,7 +15679,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -17394,6 +17394,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -17401,7 +17402,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20005,7 +20006,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -16380,13 +16380,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -18627,7 +18628,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -13421,6 +13421,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13428,7 +13429,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16363,7 +16364,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -12955,13 +12955,14 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15494,7 +15495,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -7646,6 +7646,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -7653,7 +7654,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10026,7 +10027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -7388,13 +7388,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -9447,7 +9448,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -18768,6 +18768,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -18775,7 +18776,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21883,7 +21884,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -17920,13 +17920,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20604,7 +20605,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -10386,6 +10386,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10393,7 +10394,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24359,7 +24360,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -10015,13 +10015,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22601,7 +22602,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -24270,6 +24270,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -24277,7 +24278,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -30182,7 +30183,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void ldv_free(void *s ) ;
 extern void *external_allocated_data(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -22851,13 +22851,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -28028,7 +28029,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void ldv_free(void *s ) ;
 extern void *external_allocated_data(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -16025,6 +16025,7 @@ void rose_transmit_link(struct sk_buff *skb , struct rose_neigh *neigh )
 }
 }
 extern int ldv_del_timer(int  , struct timer_list * ) ;
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -16032,7 +16033,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24185,7 +24186,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -15213,13 +15213,14 @@ void rose_transmit_link(struct sk_buff *skb , struct rose_neigh *neigh )
 }
 }
 extern int ldv_del_timer(int , struct timer_list * ) ;
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -22546,7 +22547,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
@@ -11337,6 +11337,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
@@ -10849,6 +10849,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
@@ -13405,6 +13405,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
@@ -12872,6 +12872,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.c
@@ -9467,6 +9467,7 @@ void *ldv_kmem_cache_alloc_79(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.i
@@ -9149,6 +9149,7 @@ void *ldv_kmem_cache_alloc_79(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.c
@@ -9604,6 +9604,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.i
@@ -9250,6 +9250,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
@@ -17190,6 +17190,7 @@ void *ldv_kmem_cache_alloc_25(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
@@ -16196,6 +16196,7 @@ void *ldv_kmem_cache_alloc_25(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -28469,6 +28469,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -26451,6 +26451,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
@@ -33561,6 +33561,7 @@ void *ldv_kmem_cache_alloc_393(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
@@ -30992,6 +30992,7 @@ void *ldv_kmem_cache_alloc_393(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.c
@@ -30044,6 +30044,7 @@ void *ldv_kmem_cache_alloc_130(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -27845,6 +27845,7 @@ void *ldv_kmem_cache_alloc_130(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
@@ -36781,6 +36781,7 @@ void *ldv_kmem_cache_alloc_161(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -34031,6 +34031,7 @@ void *ldv_kmem_cache_alloc_161(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -48416,6 +48416,7 @@ void *ldv_kmem_cache_alloc_427(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -44501,6 +44501,7 @@ void *ldv_kmem_cache_alloc_427(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
@@ -9418,6 +9418,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
@@ -9119,6 +9119,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
@@ -11644,6 +11644,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
@@ -11114,6 +11114,7 @@ void *ldv_kmem_cache_alloc_20(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
@@ -9974,6 +9974,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
@@ -9878,6 +9878,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -30639,6 +30639,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -28654,6 +28654,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
@@ -34475,6 +34475,7 @@ void *ldv_kmem_cache_alloc_25(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -31800,6 +31800,7 @@ void *ldv_kmem_cache_alloc_25(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
@@ -15333,6 +15333,7 @@ void *ldv_kmem_cache_alloc_190(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -14674,6 +14674,7 @@ void *ldv_kmem_cache_alloc_190(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
@@ -8743,6 +8743,7 @@ void *ldv_kmem_cache_alloc_78(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
@@ -8542,6 +8542,7 @@ void *ldv_kmem_cache_alloc_78(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
@@ -11586,6 +11586,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
@@ -11025,6 +11025,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -13427,6 +13427,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13434,7 +13435,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -15829,7 +15830,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -13966,6 +13966,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13973,7 +13974,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16686,7 +16687,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -17394,6 +17394,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -17401,7 +17402,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -20005,7 +20006,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -13421,6 +13421,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   return (res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -13428,7 +13429,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -16363,7 +16364,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -7646,6 +7646,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -7653,7 +7654,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -10026,7 +10027,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -18768,6 +18768,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -18775,7 +18776,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -21883,7 +21884,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -10386,6 +10386,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10393,7 +10394,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24359,7 +24360,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -24270,6 +24270,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -24277,7 +24278,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -30182,7 +30183,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 void ldv_free(void *s ) ;
 extern void *external_allocated_data(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16025,6 +16025,7 @@ void rose_transmit_link(struct sk_buff *skb , struct rose_neigh *neigh )
 }
 }
 extern int ldv_del_timer(int  , struct timer_list * ) ;
+void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -16032,7 +16033,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }
@@ -24185,7 +24186,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct
sk_buff)), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^__inline static struct sk_buff \*alloc_skb\(unsigned int size , gfp_t flags \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct sk_buff));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
