### PR TITLE
Implement ldv_vzalloc_{,node_}* using ldv_zalloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -45579,6 +45579,7 @@ __inline static void ldv_spin_unlock_bh_119(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -45586,7 +45587,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -46498,7 +46499,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -42252,13 +42252,14 @@ __inline static void ldv_spin_unlock_bh_119(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -43054,7 +43055,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -19918,6 +19918,7 @@ static void ldv_free_netdev_114(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -19925,7 +19926,7 @@ static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -19937,7 +19938,7 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -35625,7 +35626,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -18760,13 +18760,14 @@ static void ldv_free_netdev_114(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18777,7 +18778,7 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -33160,7 +33161,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
@@ -61394,6 +61394,7 @@ static void ldv_free_irq_116(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -61401,7 +61402,7 @@ static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -61413,7 +61414,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -62447,7 +62448,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -56414,13 +56414,14 @@ static void ldv_free_irq_116(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -56431,7 +56432,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -57367,7 +57368,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
@@ -28184,6 +28184,7 @@ static void ldv_free_netdev_130(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_131(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -28191,7 +28192,7 @@ static void *ldv_vzalloc_131(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -28203,7 +28204,7 @@ static void *ldv_vzalloc_132(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -50843,7 +50844,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -26259,13 +26259,14 @@ static void ldv_free_netdev_130(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_131(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26276,7 +26277,7 @@ static void *ldv_vzalloc_132(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -46971,7 +46972,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -13196,6 +13196,7 @@ static void ldv_free_netdev_116(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -13203,7 +13204,7 @@ static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -13215,7 +13216,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17954,7 +17955,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -12602,13 +12602,14 @@ static void ldv_free_netdev_116(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -12619,7 +12620,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17045,7 +17046,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -41645,6 +41645,7 @@ static int ldv_del_timer_sync_125(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg2 ) 
 { 
   void *tmp ;
@@ -41652,7 +41653,7 @@ static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41664,7 +41665,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41676,7 +41677,7 @@ static void *ldv_vzalloc_node_128(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41688,7 +41689,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -81317,7 +81318,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -38967,13 +38967,14 @@ static int ldv_del_timer_sync_125(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -38984,7 +38985,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -38995,7 +38996,7 @@ static void *ldv_vzalloc_node_128(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -39006,7 +39007,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -74817,7 +74818,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -14991,6 +14991,7 @@ __inline static void ldv_spin_unlock_85(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -14998,7 +14999,7 @@ static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15034,7 +15035,7 @@ static void *ldv_vzalloc_90(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15046,7 +15047,7 @@ static void *ldv_vzalloc_91(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15058,7 +15059,7 @@ static void *ldv_vzalloc_92(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15070,7 +15071,7 @@ static void *ldv_vzalloc_93(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15082,7 +15083,7 @@ static void *ldv_vzalloc_94(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15094,7 +15095,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15106,7 +15107,7 @@ static void *ldv_vzalloc_98(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -31910,7 +31911,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -14357,13 +14357,14 @@ __inline static void ldv_spin_unlock_85(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14396,7 +14397,7 @@ static void *ldv_vzalloc_90(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14407,7 +14408,7 @@ static void *ldv_vzalloc_91(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14418,7 +14419,7 @@ static void *ldv_vzalloc_92(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14429,7 +14430,7 @@ static void *ldv_vzalloc_93(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14440,7 +14441,7 @@ static void *ldv_vzalloc_94(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14451,7 +14452,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14462,7 +14463,7 @@ static void *ldv_vzalloc_98(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -29905,7 +29906,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -35514,6 +35514,7 @@ __inline static void ldv_spin_unlock_bh_101(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -35521,7 +35522,7 @@ static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -76048,7 +76049,7 @@ static void *ldv_vzalloc_125(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -102529,7 +102530,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -32931,13 +32931,14 @@ __inline static void ldv_spin_unlock_bh_101(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -69488,7 +69489,7 @@ static void *ldv_vzalloc_125(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -93413,7 +93414,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -34450,6 +34450,7 @@ void ldv_switch_automaton_state_3_8(void)
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -34457,7 +34458,7 @@ static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -37103,7 +37104,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -32315,13 +32315,14 @@ void ldv_switch_automaton_state_3_8(void)
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -34805,7 +34806,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -19771,6 +19771,7 @@ static void ldv_free_netdev_114(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -19778,7 +19779,7 @@ static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -19790,7 +19791,7 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -35408,7 +35409,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -18714,13 +18714,14 @@ static void ldv_free_netdev_114(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18731,7 +18732,7 @@ static void *ldv_vzalloc_116(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -33052,7 +33053,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -12920,6 +12920,7 @@ static void ldv_free_netdev_116(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -12927,7 +12928,7 @@ static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -12939,7 +12940,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17658,7 +17659,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -12413,13 +12413,14 @@ static void ldv_free_netdev_116(struct net_device *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -12430,7 +12431,7 @@ static void *ldv_vzalloc_118(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16836,7 +16837,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -15018,6 +15018,7 @@ __inline static void ldv_spin_unlock_85(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -15025,7 +15026,7 @@ static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15061,7 +15062,7 @@ static void *ldv_vzalloc_90(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15073,7 +15074,7 @@ static void *ldv_vzalloc_91(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15085,7 +15086,7 @@ static void *ldv_vzalloc_92(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15097,7 +15098,7 @@ static void *ldv_vzalloc_93(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15109,7 +15110,7 @@ static void *ldv_vzalloc_94(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15121,7 +15122,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15133,7 +15134,7 @@ static void *ldv_vzalloc_98(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -31229,7 +31230,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -14385,13 +14385,14 @@ __inline static void ldv_spin_unlock_85(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_87(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14424,7 +14425,7 @@ static void *ldv_vzalloc_90(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14435,7 +14436,7 @@ static void *ldv_vzalloc_91(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14446,7 +14447,7 @@ static void *ldv_vzalloc_92(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14457,7 +14458,7 @@ static void *ldv_vzalloc_93(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14468,7 +14469,7 @@ static void *ldv_vzalloc_94(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14479,7 +14480,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14490,7 +14491,7 @@ static void *ldv_vzalloc_98(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -29348,7 +29349,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -33903,6 +33903,7 @@ void ldv_pm_pm_ops_instance_2(void *arg0 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -33910,7 +33911,7 @@ static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -36556,7 +36557,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -31917,13 +31917,14 @@ void ldv_pm_pm_ops_instance_2(void *arg0 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_89(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -34407,7 +34408,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -26866,6 +26866,7 @@ __inline static void ldv_spin_unlock_bh_111(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -26873,7 +26874,7 @@ static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26885,7 +26886,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -27270,7 +27271,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -25073,13 +25073,14 @@ __inline static void ldv_spin_unlock_bh_111(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -25090,7 +25091,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -25437,7 +25438,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
@@ -16652,6 +16652,7 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_101(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -16659,7 +16660,7 @@ static void *ldv_vzalloc_101(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16671,7 +16672,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17011,7 +17012,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -15742,13 +15742,14 @@ static int ldv_dev_set_drvdata_82(struct device *dev , void *data )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_101(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15759,7 +15760,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16069,7 +16070,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
@@ -13988,6 +13988,7 @@ void ldv_switch_automaton_state_4_6(void)
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_47(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -13995,7 +13996,7 @@ static void *ldv_vzalloc_47(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15385,7 +15386,7 @@ static void *ldv_vzalloc_47___0(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18427,7 +18428,7 @@ static void *ldv_vzalloc_47___1(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18967,7 +18968,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
@@ -13117,13 +13117,14 @@ void ldv_switch_automaton_state_4_6(void)
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_47(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -14404,7 +14405,7 @@ static void *ldv_vzalloc_47___0(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17204,7 +17205,7 @@ static void *ldv_vzalloc_47___1(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17703,7 +17704,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -18790,6 +18790,7 @@ __inline static void ldv_spin_unlock_113(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -18797,7 +18798,7 @@ static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18809,7 +18810,7 @@ static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -19050,7 +19051,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -17725,13 +17725,14 @@ __inline static void ldv_spin_unlock_113(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_114(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17742,7 +17743,7 @@ static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17959,7 +17960,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
@@ -11372,6 +11372,7 @@ __inline static void ldv_spin_unlock_102(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -11379,7 +11380,7 @@ static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26665,7 +26666,7 @@ static void *ldv_vzalloc_101(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26677,7 +26678,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -29824,7 +29825,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
@@ -10950,13 +10950,14 @@ __inline static void ldv_spin_unlock_102(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_115(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -24887,7 +24888,7 @@ static void *ldv_vzalloc_101(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -24898,7 +24899,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -27771,7 +27772,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -26163,6 +26163,7 @@ __inline static void ldv_spin_unlock_bh_111(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -26170,7 +26171,7 @@ static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26182,7 +26183,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26567,7 +26568,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -24522,13 +24522,14 @@ __inline static void ldv_spin_unlock_bh_111(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_112(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -24539,7 +24540,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -24886,7 +24887,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -42353,6 +42353,7 @@ __inline static void ldv_spin_unlock_bh_119(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -42360,7 +42361,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -43242,7 +43243,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -39457,13 +39457,14 @@ __inline static void ldv_spin_unlock_bh_119(spinlock_t *lock )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -40229,7 +40230,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
@@ -23269,6 +23269,7 @@ static void ldv_free_irq_116(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -23276,7 +23277,7 @@ static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -37491,7 +37492,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -22121,13 +22121,14 @@ static void ldv_free_irq_116(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_117(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -35238,7 +35239,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -42437,6 +42437,7 @@ static int ldv_del_timer_sync_125(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg2 ) 
 { 
   void *tmp ;
@@ -42444,7 +42445,7 @@ static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -42456,7 +42457,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -42468,7 +42469,7 @@ static void *ldv_vzalloc_node_128(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -42480,7 +42481,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -81277,7 +81278,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -40089,13 +40089,14 @@ static int ldv_del_timer_sync_125(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_node_126(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -40106,7 +40107,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -40117,7 +40118,7 @@ static void *ldv_vzalloc_node_128(unsigned long ldv_func_arg1 , int ldv_func_arg
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -40128,7 +40129,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -75138,7 +75139,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -13370,6 +13370,7 @@ static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -13377,7 +13378,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16516,7 +16517,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -12618,13 +12618,14 @@ static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -15430,7 +15431,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -6496,6 +6496,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -6503,7 +6504,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -6515,7 +6516,7 @@ static void *ldv_vzalloc_96(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -12483,7 +12484,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -36811,7 +36812,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -6353,13 +6353,14 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -6370,7 +6371,7 @@ static void *ldv_vzalloc_96(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -11849,7 +11850,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -34232,7 +34233,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -17329,6 +17329,7 @@ static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func
   return ((int )((long )tmp));
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -17336,7 +17337,7 @@ static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17348,7 +17349,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18412,7 +18413,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -16516,13 +16516,14 @@ static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func
   return ((int )((long )tmp));
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16533,7 +16534,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17471,7 +17472,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -12320,6 +12320,7 @@ static void ldv_iounmap_130(void volatile   *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_143(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -12327,7 +12328,7 @@ static void *ldv_vzalloc_143(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26714,7 +26715,7 @@ static void *ldv_vzalloc_128(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26726,7 +26727,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -30446,7 +30447,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -11894,13 +11894,14 @@ static void ldv_iounmap_130(void volatile *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_143(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -25078,7 +25079,7 @@ static void *ldv_vzalloc_128(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -25089,7 +25090,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -28454,7 +28455,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -34893,6 +34893,7 @@ void ldv_pm_pm_ops_instance_2(void *arg0 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_123(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -34900,7 +34901,7 @@ static void *ldv_vzalloc_123(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -38302,7 +38303,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -32924,13 +32924,14 @@ void ldv_pm_pm_ops_instance_2(void *arg0 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_123(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -36070,7 +36071,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -44824,6 +44824,7 @@ static void ldv_mutex_unlock_175(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_176(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -44831,7 +44832,7 @@ static void *ldv_vzalloc_176(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44843,7 +44844,7 @@ static void *ldv_vzalloc_177(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44855,7 +44856,7 @@ static void *ldv_vzalloc_178(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44867,7 +44868,7 @@ static void *ldv_vzalloc_179(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44917,7 +44918,7 @@ static void *ldv_vzalloc_183(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -45026,7 +45027,7 @@ static void *ldv_vzalloc_193(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -45038,7 +45039,7 @@ static void *ldv_vzalloc_194(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -71327,7 +71328,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -41797,13 +41797,14 @@ static void ldv_mutex_unlock_175(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_176(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41814,7 +41815,7 @@ static void *ldv_vzalloc_177(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41825,7 +41826,7 @@ static void *ldv_vzalloc_178(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41836,7 +41837,7 @@ static void *ldv_vzalloc_179(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41882,7 +41883,7 @@ static void *ldv_vzalloc_183(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41980,7 +41981,7 @@ static void *ldv_vzalloc_193(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -41991,7 +41992,7 @@ static void *ldv_vzalloc_194(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -66060,7 +66061,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10061,6 +10061,7 @@ static void *ldv_vmalloc_99(unsigned long ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_100(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -10068,7 +10069,7 @@ static void *ldv_vzalloc_100(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -11009,7 +11010,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -9633,13 +9633,14 @@ static void *ldv_vmalloc_99(unsigned long ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_100(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -10459,7 +10460,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size )
 {
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -13370,6 +13370,7 @@ static void ldv_mutex_unlock_101(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -13377,7 +13378,7 @@ static void *ldv_vzalloc_102(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -16516,7 +16517,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -6496,6 +6496,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -6503,7 +6504,7 @@ static void *ldv_vzalloc_95(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -6515,7 +6516,7 @@ static void *ldv_vzalloc_96(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -12483,7 +12484,7 @@ static void *ldv_vzalloc_113(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -36811,7 +36812,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17329,6 +17329,7 @@ static int ldv_pskb_expand_head_106(struct sk_buff *ldv_func_arg1 , int ldv_func
   return ((int )((long )tmp));
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -17336,7 +17337,7 @@ static void *ldv_vzalloc_126(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -17348,7 +17349,7 @@ static void *ldv_vzalloc_127(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -18412,7 +18413,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -12320,6 +12320,7 @@ static void ldv_iounmap_130(void volatile   *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_143(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -12327,7 +12328,7 @@ static void *ldv_vzalloc_143(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26714,7 +26715,7 @@ static void *ldv_vzalloc_128(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -26726,7 +26727,7 @@ static void *ldv_vzalloc_129(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -30446,7 +30447,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -34893,6 +34893,7 @@ void ldv_pm_pm_ops_instance_2(void *arg0 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_123(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -34900,7 +34901,7 @@ static void *ldv_vzalloc_123(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -38302,7 +38303,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -44824,6 +44824,7 @@ static void ldv_mutex_unlock_175(struct mutex *ldv_func_arg1 )
   return;
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_176(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -44831,7 +44832,7 @@ static void *ldv_vzalloc_176(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44843,7 +44844,7 @@ static void *ldv_vzalloc_177(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44855,7 +44856,7 @@ static void *ldv_vzalloc_178(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44867,7 +44868,7 @@ static void *ldv_vzalloc_179(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -44917,7 +44918,7 @@ static void *ldv_vzalloc_183(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -45026,7 +45027,7 @@ static void *ldv_vzalloc_193(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -45038,7 +45039,7 @@ static void *ldv_vzalloc_194(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -71327,7 +71328,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10061,6 +10061,7 @@ static void *ldv_vmalloc_99(unsigned long ldv_func_arg1 )
   return (tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 static void *ldv_vzalloc_100(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -10068,7 +10069,7 @@ static void *ldv_vzalloc_100(unsigned long ldv_func_arg1 )
   {
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_zalloc(ldv_func_arg1);
   }
   return (tmp);
 }
@@ -11009,7 +11010,6 @@ int ldv_dev_set_drvdata(struct device *dev , void *data )
   return (0);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 struct spi_master *ldv_spi_alloc_master(struct device *host , unsigned int size ) 
 { 
   struct spi_master *master ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known, thus using
ldv_zalloc is perfectly safe, and also more consistent as it will ensure
zero-initialisation. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_zalloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^static void \*ldv_vzalloc_(node_)?\d+(___\d+)?\(unsigned long ldv_func_arg1( , int ldv_func_arg2)? \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_zalloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_zalloc(ldv_func_arg1);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
