### PR TITLE
Change K&R-style declared functions to use the ANSI C syntax instead

### DIFF
--- a/c/termination-libowfat/strlcat.c
+++ b/c/termination-libowfat/strlcat.c
@@ -22,11 +22,7 @@ size_t strlen(const char *s) {
  * Returns strlen(initial dst) + strlen(src); if retval >= siz,
  * truncation occurred.
  */
-size_t strlcat(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
-{
+size_t strlcat(char *dst, const char *src, size_t siz) {
 	register char *d = dst;
 	register const char *s = src;
 	register size_t n = siz;

--- a/c/termination-libowfat/strlcpy.c
+++ b/c/termination-libowfat/strlcpy.c
@@ -13,11 +13,7 @@ extern int __VERIFIER_nondet_int(void);
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-size_t strlcpy(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
-{
+size_t strlcpy(char *dst, const char *src, size_t siz) {
 	register char *d = dst;
 	register const char *s = src;
 	register size_t n = siz;


### PR DESCRIPTION
The K&R-style function syntax is both outdated and deprecated. As this is additionally not common in today's C code, I propose to change this therefore such that the functions consistently make use of the ANSI C syntax instead.