### PR TITLE
Extra java algorithm benchmarks which check stronger sortedness properties

### DIFF
--- a/java/algorithms/InsertionSort-FunSat02.yml
+++ b/java/algorithms/InsertionSort-FunSat02.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - InsertionSort-FunSat02/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+

--- a/java/algorithms/InsertionSort-FunSat02/Main.java
+++ b/java/algorithms/InsertionSort-FunSat02/Main.java
@@ -1,0 +1,88 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+/**
+ * Type             : Functional Safety
+ * Expected Verdict : True
+ * Last modified by : Zafer Esen <zafer.esen@it.uu.se>
+ * Date             : 11 November 2019
+ *
+ * This benchmark is just like InsertionSort-FunSat01, but
+ * with a stronger sortedness assertion.
+ *
+ * Original license follows.
+ */
+
+/**
+ * Copyright (c) 2011, Regents of the University of California
+ * All rights reserved.
+ * <p/>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * <p/>
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * <p/>
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * <p/>
+ * 3. Neither the name of the University of California, Berkeley nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ * <p/>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Jacob Burnim <jburnim@cs.berkeley.edu>
+ */
+
+public class Main {
+
+  public static void sort(int[] a) {
+    final int N = a.length;
+    for (int i = 1; i < N; i++) {  // N branches
+      int j = i - 1;
+      int x = a[i];
+      // First branch (j >= 0):  2 + 3 + ... + N = N(N+1)/2 - 1 branches
+      // Second branch (a[j] > x):  1 + 2 + ... + N-1 = (N-1)N/2 branches
+      while ((j >= 0) && (a[j] > x)) {
+        a[j + 1] = a[j];
+        j--;
+      }
+      a[j + 1] = x;
+    }
+  }
+
+  public static void main(String[] args) {
+    int N = Verifier.nondetInt();
+    Verifier.assume(N > 0);
+
+    int a[] = new int[N];
+    for (int i = 0; i < N; i++) {
+      a[i] = N-i;
+    }
+
+    sort(a);
+
+    int i1 = Verifier.nondetInt();
+    int i2 = Verifier.nondetInt();
+    Verifier.assume(0 <= i1 && i1 < i2 && i2 < N);
+    assert (a[i1] <= a[i2]);
+  }
+}
+

--- a/java/algorithms/MergeSortIterative-FunSat01/Main.java
+++ b/java/algorithms/MergeSortIterative-FunSat01/Main.java
@@ -27,8 +27,7 @@ public class Main {
 
   public static void main(String[] args) {
     final int N = Verifier.nondetInt();
-
-    if (N < 1) return;
+    Verifier.assume(N > 0);
 
     int data[] = new int[N];
     for (int i = 0; i < N; i++) {

--- a/java/algorithms/MergeSortIterative-FunSat02.yml
+++ b/java/algorithms/MergeSortIterative-FunSat02.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - MergeSortIterative-FunSat02/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+

--- a/java/algorithms/MergeSortIterative-FunSat02/Main.java
+++ b/java/algorithms/MergeSortIterative-FunSat02/Main.java
@@ -1,0 +1,134 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+/**
+ * Type             : Functional Safety
+ * Expected Verdict : True
+ * Last modified by : Zafer Esen <zafer.esen@it.uu.se>
+ * Date             : 11 November 2019
+ *
+ * This benchmark is just like IterativeMergeSort-FunSat01, but
+ * with a stronger sortedness assertion.
+ *
+ * Permission to freely use and modify the file granted via e-mail on 26.10.2019
+ * by the original author David Kosbie <koz@cmu.edu>.
+ */
+
+// IterativeMergeSort.java
+// By David Kosbie
+
+// To see iterative mergesort in action, check out the (really great!) xSortLab:
+//   http://math.hws.edu/TMCM/java/xSortLab/
+// Select "mergesort" and step through the algorithm visually.  Neat!
+
+// How it works:  on the first pass, we merge a[0] and a[1], then we merge
+// a[2] and a[3], and so on.  So the array of n elements contains n/2 sorted
+// subarrays of size 2.  On the second pass, we merge a[0]-a[3], a[4]-a[7],
+// and so on, so the array of n elements contains n/4 sorted subarrays of size
+// 4.  We keep doubling our "blockSize" until it reaches n, and we're done.
+
+public class Main {
+
+  public static void main(String[] args) {
+    final int N = Verifier.nondetInt();
+
+    if (N < 1) return;
+
+    int data[] = new int[N];
+    for (int i = 0; i < N; i++) {
+      data[i] = i;
+    }
+    iterativeMergesort(data);
+
+    int i1 = Verifier.nondetInt();
+    int i2 = Verifier.nondetInt();
+    Verifier.assume(0 <= i1 && i1 < i2 && i2 < N);
+    assert (data[i1] <= data[i2]);
+  }
+
+  /////////////////////////////////////////
+  // Iterative mergeSort
+  /////////////////////////////////////////
+
+	public static void iterativeMergesort(int[] a) {
+    int[] aux = new int[a.length];
+		for (int blockSize=1; blockSize<a.length; blockSize*=2)
+			for (int start=0; start<a.length; start+=2*blockSize)
+				merge(a, aux, start, start+blockSize, start+2*blockSize);
+	}
+
+	/////////////////////////////////////////
+	// Iterative mergeSort without copy
+	/////////////////////////////////////////
+
+  public static void iterativeMergesortWithoutCopy(int[] a) {
+    int[] from = a, to = new int[a.length];
+    for (int blockSize=1; blockSize<a.length; blockSize*=2) {
+      for (int start=0; start<a.length; start+=2*blockSize)
+        mergeWithoutCopy(from, to, start, start+blockSize, start+2*blockSize);
+      int[] temp = from;
+      from = to;
+      to = temp;
+    }
+    if (a != from)
+      // copy back
+      for (int k = 0; k < a.length; k++)
+        a[k] = from[k];
+  }
+
+  private static void mergeWithoutCopy(int[] from, int[] to, int lo, int mid, int hi) {
+    // DK: cannot just return if mid >= a.length, but must still copy remaining elements!
+    // DK: add two tests to first verify "mid" and "hi" are in range
+    if (mid > from.length) mid = from.length;
+    if (hi > from.length) hi = from.length;
+    int i = lo, j = mid;
+    for (int k = lo; k < hi; k++) {
+      if      (i == mid)          to[k] = from[j++];
+      else if (j == hi)           to[k] = from[i++];
+      else if (from[j] < from[i]) to[k] = from[j++];
+      else                        to[k] = from[i++];
+    }
+    // DO NOT copy back
+    // for (int k = lo; k < hi; k++)
+    //   a[k] = aux[k];
+  }
+
+  /////////////////////////////////////////
+  // Recursive mergeSort, adapted from:
+  // Sedgewick and Wayne, Introduction to Programming in Java
+  // http://www.cs.princeton.edu/introcs/42sort/MergeSort.java.html
+  /////////////////////////////////////////
+
+  private static void merge(int[] a, int[] aux, int lo, int mid, int hi) {
+    // DK: add two tests to first verify "mid" and "hi" are in range
+    if (mid >= a.length) return;
+    if (hi > a.length) hi = a.length;
+    int i = lo, j = mid;
+    for (int k = lo; k < hi; k++) {
+      if      (i == mid)     aux[k] = a[j++];
+      else if (j == hi)      aux[k] = a[i++];
+      else if (a[j] < a[i])  aux[k] = a[j++];
+      else                   aux[k] = a[i++];
+    }
+    // copy back
+    for (int k = lo; k < hi; k++)
+      a[k] = aux[k];
+  }
+
+  public static void recursiveMergesort(int[] a, int[] aux, int lo, int hi) {
+    // base case
+    if (hi - lo <= 1) return;
+    // sort each half, recursively
+    int mid = lo + (hi - lo) / 2;
+    recursiveMergesort(a, aux, lo, mid);
+    recursiveMergesort(a, aux, mid, hi);
+    // merge back together
+    merge(a, aux, lo, mid, hi);
+  }
+
+  public static void recursiveMergesort(int[] a) {
+    int n = a.length;
+    int[] aux = new int[n];
+    recursiveMergesort(a, aux, 0, n);
+  }
+}
+

--- a/java/algorithms/MergeSortIterative-FunSat02/Main.java
+++ b/java/algorithms/MergeSortIterative-FunSat02/Main.java
@@ -31,7 +31,7 @@ public class Main {
   public static void main(String[] args) {
     final int N = Verifier.nondetInt();
 
-    if (N < 1) return;
+    Verifier.assume(N > 0);
 
     int data[] = new int[N];
     for (int i = 0; i < N; i++) {

--- a/java/algorithms/MergeSortIterative-FunUnsat01/Main.java
+++ b/java/algorithms/MergeSortIterative-FunUnsat01/Main.java
@@ -28,7 +28,7 @@ public class Main {
   public static void main(String[] args) {
     final int N = Verifier.nondetInt();
 
-    if (N < 1) return;
+    Verifier.assume(N > 0);
 
     int data[] = new int[N];
     for (int i = 0; i < N; i++) {

--- a/java/algorithms/MergeSortIterative-MemSat01/Main.java
+++ b/java/algorithms/MergeSortIterative-MemSat01/Main.java
@@ -28,7 +28,7 @@ public class Main {
   public static void main(String[] args) {
     final int N = Verifier.nondetInt();
 
-    if (N < 1) return;
+    Verifier.assume(N > 0);
 
     int data[] = new int[N];
     for (int i = 0; i < N; i++) {

--- a/java/algorithms/MergeSortIterative-MemUnsat01/Main.java
+++ b/java/algorithms/MergeSortIterative-MemUnsat01/Main.java
@@ -28,7 +28,7 @@ public class Main {
   public static void main(String[] args) {
     final int N = Verifier.nondetInt();
 
-    if (N < 1) return;
+    Verifier.assume(N > 0);
 
     int data[] = new int[N];
     for (int i = 0; i < N; i++) {

--- a/java/algorithms/SortedListInsert-FunSat02.yml
+++ b/java/algorithms/SortedListInsert-FunSat02.yml
@@ -1,0 +1,8 @@
+format_version: "1.0"
+input_files:
+  - ../common/
+  - SortedListInsert-FunSat02/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+

--- a/java/algorithms/SortedListInsert-FunSat02/Main.java
+++ b/java/algorithms/SortedListInsert-FunSat02/Main.java
@@ -1,0 +1,93 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+/**
+ * Type             : Functional Safety
+ * Expected Verdict : True
+ * Last modified by : Zafer Esen <zafer.esen@it.uu.se>
+ * Date             : 11 November 2019
+ *
+ * This benchmark is just like SortedListInsert-FunSat01, but
+ * with a stronger sortedness assertion.
+ *
+ * Original license follows.
+ */
+
+/**
+ * Copyright (c) 2011, Regents of the University of California
+ * All rights reserved.
+ * <p/>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * <p/>
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * <p/>
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * <p/>
+ * 3. Neither the name of the University of California, Berkeley nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ * <p/>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Jacob Burnim <jburnim@cs.berkeley.edu>
+ */
+public class Main {
+
+  private static class List {
+    public int x;
+    public List next;
+
+    private static final int SENTINEL = Integer.MAX_VALUE;
+
+    private List(int x, List next) {
+      this.x = x;
+      this.next = next;
+    }
+
+    public List() {
+      this(SENTINEL, null);
+    }
+
+    public void insert(int data) {
+      if (data > this.x) {
+        next.insert(data);
+      } else {
+        next = new List(x, next);
+        x = data;
+      }
+    }
+  }
+
+  public static void main(String[] args) {
+    final int N = Verifier.nondetInt();
+    Verifier.assume(N > 1);
+
+    List list = new List();
+    for (int i = 0; i < N; i++){
+      list.insert(Verifier.nondetInt());
+    }
+
+    for (List l = list; l.next != null; l = l.next){
+      assert (l.x <= l.next.x);
+    }
+  }
+}


### PR DESCRIPTION
Three extra java algorithm benchmarks, which are actually copies of some of the benchmarks from [this PR](https://github.com/sosy-lab/sv-benchmarks/pull/823), but with stronger sortedness assertions as discussed [here](https://github.com/sosy-lab/sv-benchmarks/pull/823#discussion_r338081500).

- [X] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [X] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [X] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [] intended property matches the corresponding `.prp` file
- [X] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)
