### PR TITLE
Implement ldv_dma_pool_alloc_* using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -81256,7 +81256,7 @@ static void *ldv_dma_pool_alloc_113(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(2048UL);
   }
   return (tmp);
 }

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74763,7 +74763,7 @@ static void *ldv_dma_pool_alloc_113(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(2048UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
@@ -6514,6 +6514,7 @@ extern void free_pages(unsigned long  , unsigned int  ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_61(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                    dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -10510,7 +10511,6 @@ __inline static long IS_ERR(void const   *ptr )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -10616,7 +10616,7 @@ static void *ldv_dma_pool_alloc_61(struct dma_pool *ldv_func_arg1 , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(576);
   }
   return (tmp);
 }
@@ -15368,7 +15368,6 @@ void mlx5_pagealloc_stop(struct mlx5_core_dev *dev )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct page *alloc_pages(gfp_t flags , unsigned int order ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
@@ -6343,6 +6343,7 @@ extern void free_pages(unsigned long , unsigned int ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,
                                         size_t , size_t ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_61(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                    dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
@@ -9986,7 +9987,6 @@ __inline static long IS_ERR(void const *ptr )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;
@@ -10076,7 +10076,7 @@ static void *ldv_dma_pool_alloc_61(struct dma_pool *ldv_func_arg1 , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(576);
   }
   return (tmp);
 }
@@ -14389,7 +14389,6 @@ void mlx5_pagealloc_stop(struct mlx5_core_dev *dev )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
 {
   void *tmp ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
@@ -34439,7 +34439,7 @@ static void *ldv_dma_pool_alloc_146(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(8191UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -32147,7 +32147,7 @@ static void *ldv_dma_pool_alloc_146(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(8191UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -81216,7 +81216,7 @@ static void *ldv_dma_pool_alloc_113(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(2048UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75084,7 +75084,7 @@ static void *ldv_dma_pool_alloc_113(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(2048UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -6408,6 +6408,7 @@ static void ldv_pci_unregister_driver_162(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -15453,7 +15454,6 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -15596,7 +15596,7 @@ static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -15609,7 +15609,7 @@ static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -15622,7 +15622,7 @@ static void *ldv_dma_pool_alloc_104(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(256UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -6288,6 +6288,7 @@ static void ldv_pci_unregister_driver_162(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,
                                         size_t , size_t ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -14570,7 +14571,6 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;
@@ -14698,7 +14698,7 @@ static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -14710,7 +14710,7 @@ static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -14722,7 +14722,7 @@ static void *ldv_dma_pool_alloc_104(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(256UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -12406,6 +12406,7 @@ static int ldv___pci_register_driver_175(struct pci_driver *ldv_func_arg1 , stru
                                          char const   *ldv_func_arg3 ) ;
 extern void pci_unregister_driver(struct pci_driver * ) ;
 static void ldv_pci_unregister_driver_176(struct pci_driver *ldv_func_arg1 ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -25549,7 +25550,6 @@ __inline static void atomic_dec(atomic_t *v )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -25923,7 +25923,7 @@ static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(324UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -12055,6 +12055,7 @@ static int ldv___pci_register_driver_175(struct pci_driver *ldv_func_arg1 , stru
                                          char const *ldv_func_arg3 ) ;
 extern void pci_unregister_driver(struct pci_driver * ) ;
 static void ldv_pci_unregister_driver_176(struct pci_driver *ldv_func_arg1 ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
@@ -24187,7 +24188,6 @@ __inline static void atomic_dec(atomic_t *v )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;
@@ -24512,7 +24512,7 @@ static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(324UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -12511,6 +12511,7 @@ __inline static bool schedule_delayed_work(struct delayed_work *dwork , unsigned
 }
 extern void put_device(struct device * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                    dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -16317,7 +16318,6 @@ void ldv_dispatch_instance_deregister_10_1(struct timer_list *arg0 )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -16350,7 +16350,7 @@ static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(8192UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -12044,6 +12044,7 @@ __inline static bool schedule_delayed_work(struct delayed_work *dwork , unsigned
 }
 extern void put_device(struct device * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                    dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
@@ -15520,7 +15521,6 @@ void ldv_dispatch_instance_deregister_10_1(struct timer_list *arg0 )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;
@@ -15550,7 +15550,7 @@ static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(8192UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -8941,6 +8941,7 @@ static void ldv_pci_unregister_driver_242(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -18732,7 +18733,6 @@ __inline static int atomic_add_return(int i , atomic_t *v )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct page *alloc_pages(gfp_t flags , unsigned int order ) 
 { 
   void *tmp ;
@@ -18745,7 +18745,6 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -18770,7 +18769,6 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -19488,7 +19486,7 @@ static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1472UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -8880,6 +8880,7 @@ static void ldv_pci_unregister_driver_242(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,
                                         size_t , size_t ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t ) ;
@@ -17887,7 +17888,6 @@ __inline static int atomic_add_return(int i , atomic_t *v )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
 {
   void *tmp ;
@@ -17899,7 +17899,6 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;
@@ -17922,7 +17921,6 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 {
   void *tmp ;
@@ -18534,7 +18532,7 @@ static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1472UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -10982,6 +10982,7 @@ static void ldv_pci_unregister_driver_209(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -44414,7 +44415,6 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_129(spinlock_t *ld
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_131(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -44457,7 +44457,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44894,7 +44894,7 @@ static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44907,7 +44907,7 @@ static void *ldv_dma_pool_alloc_182(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44943,7 +44943,7 @@ static void *ldv_dma_pool_alloc_185(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44968,7 +44968,7 @@ static void *ldv_dma_pool_alloc_187(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -45016,7 +45016,7 @@ static void *ldv_dma_pool_alloc_192(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -47911,7 +47911,7 @@ static void *ldv_dma_pool_alloc_150(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -51459,7 +51459,7 @@ static void *ldv_dma_pool_alloc_145(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -51472,7 +51472,7 @@ static void *ldv_dma_pool_alloc_146(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -62326,7 +62326,6 @@ void ldv_dummy_resourceless_instance_callback_9_10(enum irqreturn (*arg0)(int  ,
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -10903,6 +10903,7 @@ static void ldv_pci_unregister_driver_209(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,
                                         size_t , size_t ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -41447,7 +41448,6 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_129(spinlock_t *ld
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_131(unsigned long ldv_func_arg1 )
 {
   void *tmp ;
@@ -41484,7 +41484,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -41861,7 +41861,7 @@ static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -41873,7 +41873,7 @@ static void *ldv_dma_pool_alloc_182(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -41905,7 +41905,7 @@ static void *ldv_dma_pool_alloc_185(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -41928,7 +41928,7 @@ static void *ldv_dma_pool_alloc_187(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -41971,7 +41971,7 @@ static void *ldv_dma_pool_alloc_192(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44578,7 +44578,7 @@ static void *ldv_dma_pool_alloc_150(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -47812,7 +47812,7 @@ static void *ldv_dma_pool_alloc_145(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -47824,7 +47824,7 @@ static void *ldv_dma_pool_alloc_146(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -57765,7 +57765,6 @@ void ldv_dummy_resourceless_instance_callback_9_10(enum irqreturn (*arg0)(int , 
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *res ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -4591,6 +4591,7 @@ static void ldv_pci_unregister_driver_141(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -11145,7 +11146,7 @@ static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11182,7 +11183,7 @@ static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11255,7 +11256,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11268,7 +11269,7 @@ static void *ldv_dma_pool_alloc_135(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -13534,7 +13535,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -4548,6 +4548,7 @@ static void ldv_pci_unregister_driver_141(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const * , struct device * , size_t ,
                                         size_t , size_t ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -10499,7 +10500,7 @@ static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -10531,7 +10532,7 @@ static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -10593,7 +10594,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -10605,7 +10606,7 @@ static void *ldv_dma_pool_alloc_135(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -12565,7 +12566,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -6408,6 +6408,7 @@ static void ldv_pci_unregister_driver_162(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -15453,7 +15454,6 @@ __inline static void *ioremap(resource_size_t offset , unsigned long size )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -15596,7 +15596,7 @@ static void *ldv_dma_pool_alloc_102(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -15609,7 +15609,7 @@ static void *ldv_dma_pool_alloc_103(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL);
   }
   return (tmp);
 }
@@ -15622,7 +15622,7 @@ static void *ldv_dma_pool_alloc_104(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(256UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -12406,6 +12406,7 @@ static int ldv___pci_register_driver_175(struct pci_driver *ldv_func_arg1 , stru
                                          char const   *ldv_func_arg3 ) ;
 extern void pci_unregister_driver(struct pci_driver * ) ;
 static void ldv_pci_unregister_driver_176(struct pci_driver *ldv_func_arg1 ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -25549,7 +25550,6 @@ __inline static void atomic_dec(atomic_t *v )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -25923,7 +25923,7 @@ static void *ldv_dma_pool_alloc_162(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(324UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -12511,6 +12511,7 @@ __inline static bool schedule_delayed_work(struct delayed_work *dwork , unsigned
 }
 extern void put_device(struct device * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                    dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -16317,7 +16318,6 @@ void ldv_dispatch_instance_deregister_10_1(struct timer_list *arg0 )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -16350,7 +16350,7 @@ static void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(8192UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -8941,6 +8941,7 @@ static void ldv_pci_unregister_driver_242(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 extern void dma_pool_free(struct dma_pool * , void * , dma_addr_t  ) ;
@@ -18732,7 +18733,6 @@ __inline static int atomic_add_return(int i , atomic_t *v )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct page *alloc_pages(gfp_t flags , unsigned int order ) 
 { 
   void *tmp ;
@@ -18745,7 +18745,6 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;
@@ -18770,7 +18769,6 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -19488,7 +19486,7 @@ static void *ldv_dma_pool_alloc_223(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1472UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -10982,6 +10982,7 @@ static void ldv_pci_unregister_driver_209(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -44414,7 +44415,6 @@ static void ldv___ldv_linux_kernel_locking_spinlock_spin_lock_129(spinlock_t *ld
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_131(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;
@@ -44457,7 +44457,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44894,7 +44894,7 @@ static void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44907,7 +44907,7 @@ static void *ldv_dma_pool_alloc_182(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44943,7 +44943,7 @@ static void *ldv_dma_pool_alloc_185(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -44968,7 +44968,7 @@ static void *ldv_dma_pool_alloc_187(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -45016,7 +45016,7 @@ static void *ldv_dma_pool_alloc_192(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -47911,7 +47911,7 @@ static void *ldv_dma_pool_alloc_150(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -51459,7 +51459,7 @@ static void *ldv_dma_pool_alloc_145(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -51472,7 +51472,7 @@ static void *ldv_dma_pool_alloc_146(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(512UL);
   }
   return (tmp);
 }
@@ -62326,7 +62326,6 @@ void ldv_dummy_resourceless_instance_callback_9_10(enum irqreturn (*arg0)(int  ,
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *res ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -4591,6 +4591,7 @@ static void ldv_pci_unregister_driver_141(struct pci_driver *ldv_func_arg1 ) ;
 extern struct dma_pool *dma_pool_create(char const   * , struct device * , size_t  ,
                                         size_t  , size_t  ) ;
 extern void dma_pool_destroy(struct dma_pool * ) ;
+void *ldv_malloc(size_t size ) ;
 static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
                                     dma_addr_t *ldv_func_arg3 ) ;
 static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags ,
@@ -11145,7 +11146,7 @@ static void *ldv_dma_pool_alloc_106(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11182,7 +11183,7 @@ static void *ldv_dma_pool_alloc_111(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11255,7 +11256,7 @@ static void *ldv_dma_pool_alloc_134(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -11268,7 +11269,7 @@ static void *ldv_dma_pool_alloc_135(struct dma_pool *ldv_func_arg1 , gfp_t flags
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(16UL);
   }
   return (tmp);
 }
@@ -13534,7 +13535,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 void *ldv_calloc_unknown_size(void) ;


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is inferred as described
below.  This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^static void \*ldv_dma_pool_alloc_\d+\(struct dma_pool \*ldv_func_arg1 , gfp_t flags , ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(FIXME);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
The actual allocation size (the "FIXME" in the above) was then inserted
manually by looking at the `dma_pool_create` calls. This is necessary as
the definition of `struct dma_pool` is not included in the benchmarks,
which would hold the allocation size as one of its members. In two
cases, the size also is an over-approximation as two different pools are
in use and either 4096 or 256 bytes could be required (thus always using
4096 bytes).
