### PR TITLE
Implement ldv_krealloc_* using realloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
@@ -6857,6 +6857,7 @@ __inline static bool queue_delayed_work(struct workqueue_struct *wq , struct del
 }
 extern void msleep(unsigned int  ) ;
 extern void get_random_bytes(void * , int  ) ;
+extern void *realloc(void * , size_t  ) ;
 static void *ldv_krealloc_84(void const   *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const   * ) ;
@@ -16933,7 +16934,7 @@ static void *ldv_krealloc_84(void const   *ldv_func_arg1 , size_t ldv_func_arg2 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   }
   return (tmp);
 }

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
@@ -6835,6 +6835,7 @@ __inline static bool queue_delayed_work(struct workqueue_struct *wq , struct del
 }
 extern void msleep(unsigned int ) ;
 extern void get_random_bytes(void * , int ) ;
+extern void *realloc(void * , size_t ) ;
 static void *ldv_krealloc_84(void const *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const * ) ;
@@ -16075,7 +16076,7 @@ static void *ldv_krealloc_84(void const *ldv_func_arg1 , size_t ldv_func_arg2 ,
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -5762,6 +5762,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 extern void dev_printk(char const   * , struct device  const  * , char const   * 
                        , ...) ;
+extern void *realloc(void * , size_t  ) ;
 static void *ldv_krealloc_98(void const   *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const   * ) ;
@@ -18219,7 +18220,7 @@ static void *ldv_krealloc_98(void const   *ldv_func_arg1 , size_t ldv_func_arg2 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -5719,6 +5719,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 extern void dev_printk(char const * , struct device const * , char const *
                        , ...) ;
+extern void *realloc(void * , size_t  ) ;
 static void *ldv_krealloc_98(void const *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const * ) ;
@@ -17252,7 +17253,7 @@ static void *ldv_krealloc_98(void const *ldv_func_arg1 , size_t ldv_func_arg2 ,
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -5762,6 +5762,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 extern void dev_printk(char const   * , struct device  const  * , char const   * 
                        , ...) ;
+extern void *realloc(void * , size_t  ) ;
 static void *ldv_krealloc_98(void const   *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const   * ) ;
@@ -18219,7 +18220,7 @@ static void *ldv_krealloc_98(void const   *ldv_func_arg1 , size_t ldv_func_arg2 
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   }
   return (tmp);
 }


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (passed in as
parameter), and `realloc` much more closely resembles the semantics.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^static void \*ldv_krealloc_\d+\(void const  *\*ldv_func_arg1 , size_t ldv_func_arg2 , ?$/) {
       $p = 2;
       if($d == 0) {
         print "extern void *realloc(void * , size_t  ) ;\n";
         $d = 1;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = realloc(ldv_func_arg1, ldv_func_arg2);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
