### PR TITLE
Implement ldv___get_free_pages_* using ldv_malloc

### DIFF
--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
@@ -10700,9 +10700,9 @@ static unsigned long ldv___get_free_pages_68(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 long ldv_is_err_or_null(void const   *ptr ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
@@ -10147,9 +10147,9 @@ static unsigned long ldv___get_free_pages_68(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 long ldv_is_err_or_null(void const *ptr ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -9824,9 +9824,9 @@ static unsigned long ldv___get_free_pages_99(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_free_netdev_100(struct net_device *ldv_func_arg1 ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -9437,9 +9437,9 @@ static unsigned long ldv___get_free_pages_99(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_free_netdev_100(struct net_device *ldv_func_arg1 )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -29715,9 +29715,9 @@ static unsigned long ldv___get_free_pages_87(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 __inline static void ldv_spin_lock_92(spinlock_t *lock ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27972,9 +27972,9 @@ static unsigned long ldv___get_free_pages_87(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 __inline static void ldv_spin_lock_92(spinlock_t *lock )

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -28616,9 +28616,9 @@ static unsigned long ldv___get_free_pages_87(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 __inline static void ldv_spin_lock_92(spinlock_t *lock ) 

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -27007,9 +27007,9 @@ static unsigned long ldv___get_free_pages_87(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 __inline static void ldv_spin_lock_92(spinlock_t *lock )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -10474,9 +10474,9 @@ static unsigned long ldv___get_free_pages_118(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -9958,9 +9958,9 @@ static unsigned long ldv___get_free_pages_118(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -31704,9 +31704,9 @@ static unsigned long ldv___get_free_pages_98(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -29396,9 +29396,9 @@ static unsigned long ldv___get_free_pages_98(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -20527,9 +20527,9 @@ static unsigned long ldv___get_free_pages_107(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_func_arg2 ) 
@@ -20539,9 +20539,9 @@ static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_unlock_109(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -19231,9 +19231,9 @@ static unsigned long ldv___get_free_pages_107(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_func_arg2 )
@@ -19242,9 +19242,9 @@ static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_unlock_109(struct mutex *ldv_func_arg1 )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -10185,9 +10185,9 @@ static unsigned long ldv___get_free_pages_137(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -9868,9 +9868,9 @@ static unsigned long ldv___get_free_pages_137(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 )

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -10474,9 +10474,9 @@ static unsigned long ldv___get_free_pages_118(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -31704,9 +31704,9 @@ static unsigned long ldv___get_free_pages_98(gfp_t flags , unsigned int ldv_func
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -20527,9 +20527,9 @@ static unsigned long ldv___get_free_pages_107(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_func_arg2 ) 
@@ -20539,9 +20539,9 @@ static unsigned long ldv___get_free_pages_108(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_mutex_unlock_109(struct mutex *ldv_func_arg1 ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -10185,9 +10185,9 @@ static unsigned long ldv___get_free_pages_137(gfp_t flags , unsigned int ldv_fun
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   }
-  return ((unsigned long )((unsigned int )((long )tmp)));
+  return tmp;
 }
 }
 static void ldv_free_netdev_138(struct net_device *ldv_func_arg1 ) 


### PR DESCRIPTION
Removes one of the uses of ldv_malloc_unknown_size, which is implemented
using __VERIFIER_nondet_pointer. The size is known (the second argument
is the order, which is the 2-logarithm of the number of pages, and a
page usually is 4K), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^static unsigned long ldv___get_free_pages_\d+\(gfp_t flags , unsigned int ldv_func_arg2 \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_malloc_unknown_size\(\);/) {
         print "  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));\n";
         next;
       }
       elsif(/^  return \(\(unsigned long \)\(\(unsigned int \)\(\(long \)tmp\)\)\);/) {
         print "  return tmp;\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
