### PR TITLE
Implement ldv_skb_clone* using ldv_malloc(sizeof(struct sk_buff))

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -16490,7 +16490,7 @@ static struct sk_buff *ldv_skb_clone_125___0(struct sk_buff *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -15639,7 +15639,7 @@ static struct sk_buff *ldv_skb_clone_125___0(struct sk_buff *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16490,7 +16490,7 @@ static struct sk_buff *ldv_skb_clone_125___0(struct sk_buff *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   }
   return ((struct sk_buff *)tmp);
 }


### PR DESCRIPTION
This is a manual follow-up to b7723fa766ab, the script of which should
also have been applied to functions with a `___0` suffix.
