### PR TITLE
Specialise mempool_alloc to the desired allocation size

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -44589,7 +44589,7 @@ static void *ldv_mempool_alloc_146(mempool_t *ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct srb));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -41598,7 +41598,7 @@ static void *ldv_mempool_alloc_146(mempool_t *ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct srb));
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -44589,7 +44589,7 @@ static void *ldv_mempool_alloc_146(mempool_t *ldv_func_arg1 , gfp_t flags )
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(sizeof(struct srb));
   }
   return (tmp);
 }


### PR DESCRIPTION
mempool_alloc should allocate (from a memory pool) memory of the size specified
when the pool was created (via mempool_create). Since none of the benchmarks
provide a definition of mempool_create, this information cannot be
communicated. Instead, hard-code the allocation size as used in the specific
device driver in mempool_alloc and use ldv_malloc instead of
ldv_malloc_unknown_size.  This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).
