### PR TITLE
Remove unnecessary use of external_allocated_data

### DIFF
--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
@@ -6063,13 +6063,10 @@ int ldv_emg___pci_register_driver(struct pci_driver *arg0 , struct module *arg1 
                                   char *arg2 )
 {
   struct pci_driver *ldv_9_pci_driver_pci_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_pci_driver_pci_driver = (struct pci_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -6101,11 +6098,8 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_pci_unregister_driver(struct pci_driver *arg0 )
 {
   struct pci_driver *ldv_8_pci_driver_pci_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_pci_driver_pci_driver = (struct pci_driver *)tmp;
   ldv_8_pci_driver_pci_driver = arg0;
   ldv_dispatch_deregister_8_1(ldv_8_pci_driver_pci_driver);
   }
@@ -6120,17 +6114,10 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
   void *ldv_7_data_data ;
   int ldv_7_line_line ;
   irqreturn_t (*ldv_7_thread_thread)(int , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_7_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_7_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -6157,15 +6144,11 @@ void *ldv_insmod_5(void *arg0 )
   int (*ldv_5_cafe_init_default)(void) ;
   int ldv_5_reg_guard_7_default ;
   int ldv_5_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_cafe_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_cafe_init_default = (int (*)(void))tmp___0;
+  ldv_5_cafe_exit_default = 0;
+  ldv_5_cafe_init_default = 0;
   ldv_free(arg0);
   ldv_5_ret_default = ldv_insmod_cafe_init_5_9(ldv_5_cafe_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
@@ -6228,17 +6211,13 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
+  ldv_2_thread_thread = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -6304,9 +6283,6 @@ void *ldv_pci_scenario_3(void *arg0 )
   ldv_3_resource_pm_message.event = 0;
   int ldv_3_ret_default ;
   struct ldv_struct_pci_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   void *tmp___2 ;
   void *tmp___3 ;
   int tmp___4 ;
@@ -6315,12 +6291,9 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_pci_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_pci_driver = (struct pci_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_dev = (struct pci_dev *)tmp___1;
+  ldv_3_container_pci_driver = 0;
+  ldv_3_ldv_param_17_1_default = 0;
+  ldv_3_resource_dev = 0;
   ldv_3_ret_default = ldv_undef_int();
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_pci_scenario_3 *)0)) {
@@ -6333,11 +6306,11 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   tmp___2 = ldv_xmalloc(2936UL);
   ldv_3_resource_dev = (struct pci_dev *)tmp___2;
-  ldv_3_resource_dev->bus = external_allocated_data();
-  ldv_3_resource_dev->subordinate = external_allocated_data();
-  ldv_3_resource_dev->sysdata = external_allocated_data();
-  ldv_3_resource_dev->procent = external_allocated_data();
-  ldv_3_resource_dev->slot = external_allocated_data();
+  ldv_3_resource_dev->bus = 0;
+  ldv_3_resource_dev->subordinate = 0;
+  ldv_3_resource_dev->sysdata = 0;
+  ldv_3_resource_dev->procent = 0;
+  ldv_3_resource_dev->slot = 0;
   }
   goto ldv_main_3;
   return ((void *)0);
@@ -9867,16 +9840,6 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   struct vm_area_struct *ldv_4_ldv_param_4_1_default ;
   struct file *ldv_4_resource_file ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
-  void *tmp___8 ;
   void *tmp___9 ;
   void *tmp___10 ;
   int tmp___11 ;
@@ -9889,26 +9852,10 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   int tmp___18 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_callback_mmap = (int (*)(struct file * , struct vm_area_struct * ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_callback_poll = (__u32 (*)(struct file * , poll_table * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_4_callback_read = (ssize_t (*)(struct file * , char * , size_t , loff_t * ))tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_4_callback_unlocked_ioctl = (ssize_t (*)(struct file * , __u32 , size_t ))tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_4_ldv_param_22_1_default = (char *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_4_ldv_param_22_3_default = (long long *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___7;
-  tmp___8 = external_allocated_data();
-  ldv_4_resource_file = (struct file *)tmp___8;
+  ldv_4_callback_mmap = 0;
+  ldv_4_callback_poll = 0;
+  ldv_4_callback_read = 0;
+  ldv_4_callback_unlocked_ioctl = 0;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___9 = ldv_xmalloc(0UL);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.c
@@ -6103,14 +6103,12 @@ int ldv_emg___pci_register_driver(struct pci_driver *arg0 , struct module *arg1 
                                   char *arg2 ) 
 { 
   struct pci_driver *ldv_9_pci_driver_pci_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_pci_driver_pci_driver = (struct pci_driver *)tmp;
+  ldv_9_pci_driver_pci_driver = 0;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -6143,12 +6141,9 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_pci_unregister_driver(struct pci_driver *arg0 ) 
 { 
   struct pci_driver *ldv_8_pci_driver_pci_driver ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_pci_driver_pci_driver = (struct pci_driver *)tmp;
   ldv_8_pci_driver_pci_driver = arg0;
   ldv_dispatch_deregister_8_1(ldv_8_pci_driver_pci_driver);
   }
@@ -6163,18 +6158,11 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , void * ) 
   void *ldv_7_data_data ;
   int ldv_7_line_line ;
   irqreturn_t (*ldv_7_thread_thread)(int  , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_7_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_7_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -6202,16 +6190,12 @@ void *ldv_insmod_5(void *arg0 )
   int (*ldv_5_cafe_init_default)(void) ;
   int ldv_5_reg_guard_7_default ;
   int ldv_5_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_cafe_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_cafe_init_default = (int (*)(void))tmp___0;
+  ldv_5_cafe_exit_default = 0;
+  ldv_5_cafe_init_default = 0;
   ldv_free(arg0);
   ldv_5_ret_default = ldv_insmod_cafe_init_5_9(ldv_5_cafe_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
@@ -6280,18 +6264,13 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int  , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -6362,8 +6341,6 @@ void *ldv_pci_scenario_3(void *arg0 )
   int ldv_3_ret_default ;
   struct ldv_struct_pci_scenario_3 *data ;
   void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   void *tmp___2 ;
   void *tmp___3 ;
   int tmp___4 ;
@@ -6373,12 +6350,7 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_pci_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_pci_driver = (struct pci_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_dev = (struct pci_dev *)tmp___1;
+  ldv_3_container_pci_driver = 0;
   ldv_3_ret_default = ldv_undef_int();
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_pci_scenario_3 *)0)) {
@@ -6392,11 +6364,11 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   tmp___2 = ldv_xmalloc(2936UL);
   ldv_3_resource_dev = (struct pci_dev *)tmp___2;
-  ldv_3_resource_dev->bus = external_allocated_data();
-  ldv_3_resource_dev->subordinate = external_allocated_data();
-  ldv_3_resource_dev->sysdata = external_allocated_data();
-  ldv_3_resource_dev->procent = external_allocated_data();
-  ldv_3_resource_dev->slot = external_allocated_data();
+  ldv_3_resource_dev->bus = 0;
+  ldv_3_resource_dev->subordinate = 0;
+  ldv_3_resource_dev->sysdata = 0;
+  ldv_3_resource_dev->procent = 0;
+  ldv_3_resource_dev->slot = 0;
 
   }
   goto ldv_main_3;
@@ -10277,16 +10249,6 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   struct vm_area_struct *ldv_4_ldv_param_4_1_default ;
   struct file *ldv_4_resource_file ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
-  void *tmp___8 ;
   void *tmp___9 ;
   void *tmp___10 ;
   int tmp___11 ;
@@ -10300,26 +10262,11 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_callback_mmap = (int (*)(struct file * , struct vm_area_struct * ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_callback_poll = (__u32 (*)(struct file * , poll_table * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_4_callback_read = (ssize_t (*)(struct file * , char * , size_t  , loff_t * ))tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_4_callback_unlocked_ioctl = (ssize_t (*)(struct file * , __u32  , size_t  ))tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_4_ldv_param_22_1_default = (char *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_4_ldv_param_22_3_default = (long long *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___7;
-  tmp___8 = external_allocated_data();
-  ldv_4_resource_file = (struct file *)tmp___8;
+  ldv_4_callback_mmap = 0;
+  ldv_4_callback_poll = 0;
+  ldv_4_callback_read = 0;
+  ldv_4_callback_unlocked_ioctl = 0;
+  ldv_4_ldv_param_4_1_default = 0;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___9 = ldv_xmalloc(0UL);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
@@ -6063,13 +6063,11 @@ int ldv_emg___pci_register_driver(struct pci_driver *arg0 , struct module *arg1 
                                   char *arg2 )
 {
   struct pci_driver *ldv_9_pci_driver_pci_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_pci_driver_pci_driver = (struct pci_driver *)tmp;
+  ldv_9_pci_driver_pci_driver = 0;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -6101,11 +6099,8 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_pci_unregister_driver(struct pci_driver *arg0 )
 {
   struct pci_driver *ldv_8_pci_driver_pci_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_pci_driver_pci_driver = (struct pci_driver *)tmp;
   ldv_8_pci_driver_pci_driver = arg0;
   ldv_dispatch_deregister_8_1(ldv_8_pci_driver_pci_driver);
   }
@@ -6120,17 +6115,10 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
   void *ldv_7_data_data ;
   int ldv_7_line_line ;
   irqreturn_t (*ldv_7_thread_thread)(int , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_7_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_7_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -6158,15 +6146,11 @@ void *ldv_insmod_5(void *arg0 )
   int (*ldv_5_cafe_init_default)(void) ;
   int ldv_5_reg_guard_7_default ;
   int ldv_5_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_cafe_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_cafe_init_default = (int (*)(void))tmp___0;
+  ldv_5_cafe_exit_default = 0;
+  ldv_5_cafe_init_default = 0;
   ldv_free(arg0);
   ldv_5_ret_default = ldv_insmod_cafe_init_5_9(ldv_5_cafe_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
@@ -6230,17 +6214,12 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -6307,8 +6286,6 @@ void *ldv_pci_scenario_3(void *arg0 )
   int ldv_3_ret_default ;
   struct ldv_struct_pci_scenario_3 *data ;
   void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   void *tmp___2 ;
   void *tmp___3 ;
   int tmp___4 ;
@@ -6317,12 +6294,7 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_pci_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_pci_driver = (struct pci_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_17_1_default = (struct pci_device_id *)tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_dev = (struct pci_dev *)tmp___1;
+  ldv_3_container_pci_driver = 0;
   ldv_3_ret_default = ldv_undef_int();
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_pci_scenario_3 *)0)) {
@@ -6335,11 +6307,11 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   tmp___2 = ldv_xmalloc(2936UL);
   ldv_3_resource_dev = (struct pci_dev *)tmp___2;
-  ldv_3_resource_dev->bus = external_allocated_data();
-  ldv_3_resource_dev->subordinate = external_allocated_data();
-  ldv_3_resource_dev->sysdata = external_allocated_data();
-  ldv_3_resource_dev->procent = external_allocated_data();
-  ldv_3_resource_dev->slot = external_allocated_data();
+  ldv_3_resource_dev->bus = 0;
+  ldv_3_resource_dev->subordinate = 0;
+  ldv_3_resource_dev->sysdata = 0;
+  ldv_3_resource_dev->procent = 0;
+  ldv_3_resource_dev->slot = 0;
   }
   goto ldv_main_3;
   return ((void *)0);
@@ -9868,16 +9840,6 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   struct vm_area_struct *ldv_4_ldv_param_4_1_default ;
   struct file *ldv_4_resource_file ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
-  void *tmp___8 ;
   void *tmp___9 ;
   void *tmp___10 ;
   int tmp___11 ;
@@ -9890,26 +9852,11 @@ void *ldv_partially_ordered_scenario_4(void *arg0 )
   int tmp___18 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_callback_mmap = (int (*)(struct file * , struct vm_area_struct * ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_callback_poll = (__u32 (*)(struct file * , poll_table * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_4_callback_read = (ssize_t (*)(struct file * , char * , size_t , loff_t * ))tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_4_callback_unlocked_ioctl = (ssize_t (*)(struct file * , __u32 , size_t ))tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_4_container_v4l2_file_operations = (struct v4l2_file_operations *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_4_ldv_param_19_1_default = (struct poll_table_struct *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_4_ldv_param_22_1_default = (char *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_4_ldv_param_22_3_default = (long long *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_4_ldv_param_4_1_default = (struct vm_area_struct *)tmp___7;
-  tmp___8 = external_allocated_data();
-  ldv_4_resource_file = (struct file *)tmp___8;
+  ldv_4_callback_mmap = 0;
+  ldv_4_callback_poll = 0;
+  ldv_4_callback_read = 0;
+  ldv_4_callback_unlocked_ioctl = 0;
+  ldv_4_ldv_param_4_1_default = 0;
   ldv_4_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___9 = ldv_xmalloc(0UL);

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.c
@@ -10246,14 +10246,11 @@ void ldv_dispatch_register_7_3(struct platform_driver *arg0 )
 int ldv_emg___platform_driver_register(struct platform_driver *arg0 , struct module *arg1 ) 
 { 
   struct platform_driver *ldv_7_platform_driver_platform_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_platform_driver_platform_driver = (struct platform_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -10286,12 +10283,9 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_free_netdev(struct net_device *arg0 ) 
 { 
   struct net_device *ldv_9_netdev_net_device ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_netdev_net_device = (struct net_device *)tmp;
   ldv_9_netdev_net_device = arg0;
   ldv_free((void *)ldv_9_netdev_net_device);
   }
@@ -10302,12 +10296,9 @@ void ldv_emg_free_netdev(struct net_device *arg0 )
 void ldv_emg_platform_driver_unregister(struct platform_driver *arg0 ) 
 { 
   struct platform_driver *ldv_10_platform_driver_platform_driver ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_10_platform_driver_platform_driver = (struct platform_driver *)tmp;
   ldv_10_platform_driver_platform_driver = arg0;
   ldv_dispatch_deregister_10_1(ldv_10_platform_driver_platform_driver);
   }
@@ -10319,7 +10310,6 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 { 
   struct net_device *ldv_11_netdev_net_device ;
   int ldv_11_ret_default ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
@@ -10327,8 +10317,6 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_11_netdev_net_device = (struct net_device *)tmp;
   ldv_11_ret_default = ldv_undef_int();
   tmp___3 = ldv_undef_int();
   }
@@ -10369,18 +10357,11 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , void * ) 
   void *ldv_12_data_data ;
   int ldv_12_line_line ;
   irqreturn_t (*ldv_12_thread_thread)(int  , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_12_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_12_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_12_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -10404,12 +10385,9 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , void * ) 
 void ldv_emg_unregister_netdev(struct net_device *arg0 ) 
 { 
   struct net_device *ldv_13_netdev_net_device ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_13_netdev_net_device = (struct net_device *)tmp;
   ldv_13_netdev_net_device = arg0;
   ldv_unregister_netdev_stop_13_2((ldv_13_netdev_net_device->netdev_ops)->ndo_stop,
                                   ldv_13_netdev_net_device);
@@ -10424,16 +10402,12 @@ void *ldv_insmod_6(void *arg0 )
   void (*ldv_6_nsc_ircc_cleanup_default)(void) ;
   int (*ldv_6_nsc_ircc_init_default)(void) ;
   int ldv_6_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_nsc_ircc_cleanup_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_6_nsc_ircc_init_default = (int (*)(void))tmp___0;
+  ldv_6_nsc_ircc_cleanup_default = 0;
+  ldv_6_nsc_ircc_init_default = 0;
   ldv_free(arg0);
   ldv_6_ret_default = ldv_insmod_nsc_ircc_init_6_6(ldv_6_nsc_ircc_init_default);
   ldv_6_ret_default = ldv_post_init(ldv_6_ret_default);
@@ -10484,18 +10458,13 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int  , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -10565,11 +10534,6 @@ void *ldv_platform_instance_4(void *arg0 )
   int ldv_4_probed_default ;
   struct platform_device *ldv_4_resource_platform_device ;
   struct ldv_struct_platform_instance_4 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
   int tmp___6 ;
@@ -10579,17 +10543,10 @@ void *ldv_platform_instance_4(void *arg0 )
   {
   {
   data = (struct ldv_struct_platform_instance_4 *)arg0;
-  tmp = external_allocated_data();
-  ldv_4_callback_resume = (int (*)(struct platform_device * ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_callback_suspend = (int (*)(struct platform_device * , pm_message_t  ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_4_container_platform_driver = (struct platform_driver *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_4_ldv_param_18_1_default = (struct pm_message *)tmp___2;
+  ldv_4_callback_resume = 0;
+  ldv_4_callback_suspend = 0;
+  ldv_4_container_platform_driver = 0;
   ldv_4_probed_default = ldv_undef_int();
-  tmp___3 = external_allocated_data();
-  ldv_4_resource_platform_device = (struct platform_device *)tmp___3;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_platform_instance_4 *)0)) {
     {
@@ -10716,8 +10673,6 @@ void *ldv_pm_ops_scenario_5(void *arg0 )
 { 
   struct device *ldv_5_device_device ;
   struct dev_pm_ops *ldv_5_pm_ops_dev_pm_ops ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -10726,10 +10681,8 @@ void *ldv_pm_ops_scenario_5(void *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_device_device = (struct device *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_pm_ops_dev_pm_ops = (struct dev_pm_ops *)tmp___0;
+  ldv_5_device_device = 0;
+  ldv_5_pm_ops_dev_pm_ops = 0;
   ldv_free(arg0);
   }
   goto ldv_do_5;
@@ -10828,11 +10781,6 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   int ldv_3_ldv_param_3_2_default = 0;
   struct sk_buff *ldv_3_ldv_param_8_0_default ;
   struct ldv_struct_random_allocationless_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   void *tmp___5 ;
   int tmp___6 ;
@@ -10841,16 +10789,9 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_random_allocationless_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_callback_ndo_do_ioctl = (int (*)(struct net_device * , struct ifreq * , int  ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_callback_ndo_start_xmit = (netdev_tx_t (*)(struct sk_buff * , struct net_device * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_container_net_device = (struct net_device *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___3;
+  ldv_3_callback_ndo_do_ioctl = 0;
+  ldv_3_callback_ndo_start_xmit = 0;
+  ldv_3_container_net_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_random_allocationless_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil.i
@@ -9919,13 +9919,10 @@ void ldv_dispatch_register_7_3(struct platform_driver *arg0 )
 int ldv_emg___platform_driver_register(struct platform_driver *arg0 , struct module *arg1 )
 {
   struct platform_driver *ldv_7_platform_driver_platform_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_platform_driver_platform_driver = (struct platform_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -9957,11 +9954,8 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_free_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_9_netdev_net_device ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_netdev_net_device = (struct net_device *)tmp;
   ldv_9_netdev_net_device = arg0;
   ldv_free((void *)ldv_9_netdev_net_device);
   }
@@ -9972,11 +9966,8 @@ void ldv_emg_free_netdev(struct net_device *arg0 )
 void ldv_emg_platform_driver_unregister(struct platform_driver *arg0 )
 {
   struct platform_driver *ldv_10_platform_driver_platform_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_10_platform_driver_platform_driver = (struct platform_driver *)tmp;
   ldv_10_platform_driver_platform_driver = arg0;
   ldv_dispatch_deregister_10_1(ldv_10_platform_driver_platform_driver);
   }
@@ -9988,15 +9979,12 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_11_netdev_net_device ;
   int ldv_11_ret_default ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_11_netdev_net_device = (struct net_device *)tmp;
   ldv_11_ret_default = ldv_undef_int();
   tmp___3 = ldv_undef_int();
   }
@@ -10037,17 +10025,10 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
   void *ldv_12_data_data ;
   int ldv_12_line_line ;
   irqreturn_t (*ldv_12_thread_thread)(int , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_12_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_12_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_12_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -10071,11 +10052,8 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
 void ldv_emg_unregister_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_13_netdev_net_device ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_13_netdev_net_device = (struct net_device *)tmp;
   ldv_13_netdev_net_device = arg0;
   ldv_unregister_netdev_stop_13_2((ldv_13_netdev_net_device->netdev_ops)->ndo_stop,
                                   ldv_13_netdev_net_device);
@@ -10090,15 +10068,11 @@ void *ldv_insmod_6(void *arg0 )
   void (*ldv_6_nsc_ircc_cleanup_default)(void) ;
   int (*ldv_6_nsc_ircc_init_default)(void) ;
   int ldv_6_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_nsc_ircc_cleanup_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_6_nsc_ircc_init_default = (int (*)(void))tmp___0;
+  ldv_6_nsc_ircc_cleanup_default = 0;
+  ldv_6_nsc_ircc_init_default = 0;
   ldv_free(arg0);
   ldv_6_ret_default = ldv_insmod_nsc_ircc_init_6_6(ldv_6_nsc_ircc_init_default);
   ldv_6_ret_default = ldv_post_init(ldv_6_ret_default);
@@ -10146,17 +10120,12 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -10222,11 +10191,6 @@ void *ldv_platform_instance_4(void *arg0 )
   int ldv_4_probed_default ;
   struct platform_device *ldv_4_resource_platform_device ;
   struct ldv_struct_platform_instance_4 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
   int tmp___6 ;
@@ -10235,17 +10199,10 @@ void *ldv_platform_instance_4(void *arg0 )
   {
   {
   data = (struct ldv_struct_platform_instance_4 *)arg0;
-  tmp = external_allocated_data();
-  ldv_4_callback_resume = (int (*)(struct platform_device * ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_callback_suspend = (int (*)(struct platform_device * , pm_message_t ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_4_container_platform_driver = (struct platform_driver *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_4_ldv_param_18_1_default = (struct pm_message *)tmp___2;
+  ldv_4_callback_resume = 0;
+  ldv_4_callback_suspend = 0;
+  ldv_4_container_platform_driver = 0;
   ldv_4_probed_default = ldv_undef_int();
-  tmp___3 = external_allocated_data();
-  ldv_4_resource_platform_device = (struct platform_device *)tmp___3;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_platform_instance_4 *)0)) {
     {
@@ -10363,8 +10320,6 @@ void *ldv_pm_ops_scenario_5(void *arg0 )
 {
   struct device *ldv_5_device_device ;
   struct dev_pm_ops *ldv_5_pm_ops_dev_pm_ops ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -10372,10 +10327,8 @@ void *ldv_pm_ops_scenario_5(void *arg0 )
   int tmp___5 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_device_device = (struct device *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_pm_ops_dev_pm_ops = (struct dev_pm_ops *)tmp___0;
+  ldv_5_device_device = 0;
+  ldv_5_pm_ops_dev_pm_ops = 0;
   ldv_free(arg0);
   }
   goto ldv_do_5;
@@ -10467,11 +10420,6 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   int ldv_3_ldv_param_3_2_default = 0;
   struct sk_buff *ldv_3_ldv_param_8_0_default ;
   struct ldv_struct_random_allocationless_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   void *tmp___5 ;
   int tmp___6 ;
@@ -10479,16 +10427,9 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_random_allocationless_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_callback_ndo_do_ioctl = (int (*)(struct net_device * , struct ifreq * , int ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_callback_ndo_start_xmit = (netdev_tx_t (*)(struct sk_buff * , struct net_device * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_container_net_device = (struct net_device *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___3;
+  ldv_3_callback_ndo_do_ioctl = 0;
+  ldv_3_callback_ndo_start_xmit = 0;
+  ldv_3_container_net_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_random_allocationless_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.c
@@ -7841,12 +7841,9 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_free_netdev(struct net_device *arg0 ) 
 { 
   struct net_device *ldv_6_netdev_net_device ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_netdev_net_device = (struct net_device *)tmp;
   ldv_6_netdev_net_device = arg0;
   ldv_free((void *)ldv_6_netdev_net_device);
   }
@@ -7858,7 +7855,6 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 { 
   struct net_device *ldv_7_netdev_net_device ;
   int ldv_7_ret_default ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
@@ -7866,8 +7862,6 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_netdev_net_device = (struct net_device *)tmp;
   ldv_7_ret_default = ldv_undef_int();
   tmp___3 = ldv_undef_int();
   }
@@ -7908,18 +7902,11 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , void * ) 
   void *ldv_8_data_data ;
   int ldv_8_line_line ;
   irqreturn_t (*ldv_8_thread_thread)(int  , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_8_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_8_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -7943,12 +7930,9 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , void * ) 
 void ldv_emg_unregister_netdev(struct net_device *arg0 ) 
 { 
   struct net_device *ldv_9_netdev_net_device ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_netdev_net_device = (struct net_device *)tmp;
   ldv_9_netdev_net_device = arg0;
   ldv_unregister_netdev_stop_9_2((ldv_9_netdev_net_device->netdev_ops)->ndo_stop,
                                  ldv_9_netdev_net_device);
@@ -7963,16 +7947,12 @@ void *ldv_insmod_4(void *arg0 )
   int ldv_4_ret_default ;
   void (*ldv_4_w83977af_cleanup_default)(void) ;
   int (*ldv_4_w83977af_init_default)(void) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_w83977af_cleanup_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_w83977af_init_default = (int (*)(void))tmp___0;
+  ldv_4_w83977af_cleanup_default = 0;
+  ldv_4_w83977af_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_w83977af_init_4_6(ldv_4_w83977af_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -8023,18 +8003,13 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int  , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -8104,11 +8079,6 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   int ldv_3_ldv_param_3_2_default = ldv_undef_int() ;
   struct sk_buff *ldv_3_ldv_param_8_0_default ;
   struct ldv_struct_random_allocationless_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   void *tmp___5 ;
   int tmp___6 ;
@@ -8117,16 +8087,9 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_random_allocationless_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_callback_ndo_do_ioctl = (int (*)(struct net_device * , struct ifreq * , int  ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_callback_ndo_start_xmit = (netdev_tx_t (*)(struct sk_buff * , struct net_device * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_container_net_device = (struct net_device *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___3;
+  ldv_3_callback_ndo_do_ioctl = 0;
+  ldv_3_callback_ndo_start_xmit = 0;
+  ldv_3_container_net_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_random_allocationless_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko.cil.i
@@ -7694,11 +7694,8 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_free_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_6_netdev_net_device ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_netdev_net_device = (struct net_device *)tmp;
   ldv_6_netdev_net_device = arg0;
   ldv_free((void *)ldv_6_netdev_net_device);
   }
@@ -7710,15 +7707,12 @@ int ldv_emg_register_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_7_netdev_net_device ;
   int ldv_7_ret_default ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_7_netdev_net_device = (struct net_device *)tmp;
   ldv_7_ret_default = ldv_undef_int();
   tmp___3 = ldv_undef_int();
   }
@@ -7759,17 +7753,10 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
   void *ldv_8_data_data ;
   int ldv_8_line_line ;
   irqreturn_t (*ldv_8_thread_thread)(int , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_8_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_8_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -7793,11 +7780,8 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
 void ldv_emg_unregister_netdev(struct net_device *arg0 )
 {
   struct net_device *ldv_9_netdev_net_device ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_netdev_net_device = (struct net_device *)tmp;
   ldv_9_netdev_net_device = arg0;
   ldv_unregister_netdev_stop_9_2((ldv_9_netdev_net_device->netdev_ops)->ndo_stop,
                                  ldv_9_netdev_net_device);
@@ -7812,15 +7796,11 @@ void *ldv_insmod_4(void *arg0 )
   int ldv_4_ret_default ;
   void (*ldv_4_w83977af_cleanup_default)(void) ;
   int (*ldv_4_w83977af_init_default)(void) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_w83977af_cleanup_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_w83977af_init_default = (int (*)(void))tmp___0;
+  ldv_4_w83977af_cleanup_default = 0;
+  ldv_4_w83977af_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_w83977af_init_4_6(ldv_4_w83977af_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -7868,17 +7848,12 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -7944,11 +7919,6 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   int ldv_3_ldv_param_3_2_default = ldv_undef_int() ;
   struct sk_buff *ldv_3_ldv_param_8_0_default ;
   struct ldv_struct_random_allocationless_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
   void *tmp___4 ;
   void *tmp___5 ;
   int tmp___6 ;
@@ -7956,16 +7926,9 @@ void *ldv_random_allocationless_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_random_allocationless_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_callback_ndo_do_ioctl = (int (*)(struct net_device * , struct ifreq * , int ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_callback_ndo_start_xmit = (netdev_tx_t (*)(struct sk_buff * , struct net_device * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_3_container_net_device = (struct net_device *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_ldv_param_3_1_default = (struct ifreq *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_3_ldv_param_8_0_default = (struct sk_buff *)tmp___3;
+  ldv_3_callback_ndo_do_ioctl = 0;
+  ldv_3_callback_ndo_start_xmit = 0;
+  ldv_3_container_net_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_random_allocationless_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.c
@@ -5290,14 +5290,11 @@ void ldv_dispatch_register_6_3(struct platform_driver *arg0 )
 int ldv_emg___platform_driver_register(struct platform_driver *arg0 , struct module *arg1 ) 
 { 
   struct platform_driver *ldv_6_platform_driver_platform_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_platform_driver_platform_driver = (struct platform_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -5330,12 +5327,9 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_platform_driver_unregister(struct platform_driver *arg0 ) 
 { 
   struct platform_driver *ldv_8_platform_driver_platform_driver ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_platform_driver_platform_driver = (struct platform_driver *)tmp;
   ldv_8_platform_driver_platform_driver = arg0;
   ldv_dispatch_deregister_8_1(ldv_8_platform_driver_platform_driver);
   }
@@ -5351,18 +5345,11 @@ int ldv_emg_request_threaded_irq(unsigned int arg0 , irqreturn_t (*arg1)(int  , 
   void *ldv_9_data_data ;
   int ldv_9_line_line ;
   irqreturn_t (*ldv_9_thread_thread)(int  , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_9_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_9_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -5388,16 +5375,12 @@ void *ldv_insmod_5(void *arg0 )
   int ldv_5_ret_default ;
   void (*ldv_5_tegra_slink_driver_exit_default)(void) ;
   int (*ldv_5_tegra_slink_driver_init_default)(void) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_tegra_slink_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_tegra_slink_driver_init_default = (int (*)(void))tmp___0;
+  ldv_5_tegra_slink_driver_exit_default = 0;
+  ldv_5_tegra_slink_driver_init_default = 0;
   ldv_free(arg0);
   ldv_5_ret_default = ldv_insmod_tegra_slink_driver_init_5_6(ldv_5_tegra_slink_driver_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
@@ -5448,18 +5431,14 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int  , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int  , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int  , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
+  ldv_2_thread_thread = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -5539,8 +5518,6 @@ void *ldv_platform_instance_3(void *arg0 )
   int ldv_3_probed_default ;
   struct platform_device *ldv_3_resource_platform_device ;
   struct ldv_struct_platform_instance_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   void *tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -5549,11 +5526,8 @@ void *ldv_platform_instance_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_platform_instance_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_platform_driver = (struct platform_driver *)tmp;
+  ldv_3_container_platform_driver = 0;
   ldv_3_probed_default = ldv_undef_int();
-  tmp___0 = external_allocated_data();
-  ldv_3_resource_platform_device = (struct platform_device *)tmp___0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_platform_instance_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.i
@@ -5124,13 +5124,10 @@ void ldv_dispatch_register_6_3(struct platform_driver *arg0 )
 int ldv_emg___platform_driver_register(struct platform_driver *arg0 , struct module *arg1 )
 {
   struct platform_driver *ldv_6_platform_driver_platform_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_6_platform_driver_platform_driver = (struct platform_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -5162,11 +5159,8 @@ void ldv_emg_free_irq(int arg0 , void *arg1 )
 void ldv_emg_platform_driver_unregister(struct platform_driver *arg0 )
 {
   struct platform_driver *ldv_8_platform_driver_platform_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_8_platform_driver_platform_driver = (struct platform_driver *)tmp;
   ldv_8_platform_driver_platform_driver = arg0;
   ldv_dispatch_deregister_8_1(ldv_8_platform_driver_platform_driver);
   }
@@ -5182,17 +5176,10 @@ int ldv_emg_request_threaded_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , v
   void *ldv_9_data_data ;
   int ldv_9_line_line ;
   irqreturn_t (*ldv_9_thread_thread)(int , void * ) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_9_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_9_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_9_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
   tmp___2 = ldv_undef_int();
   }
   if (tmp___2 != 0) {
@@ -5218,15 +5205,11 @@ void *ldv_insmod_5(void *arg0 )
   int ldv_5_ret_default ;
   void (*ldv_5_tegra_slink_driver_exit_default)(void) ;
   int (*ldv_5_tegra_slink_driver_init_default)(void) ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_tegra_slink_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_5_tegra_slink_driver_init_default = (int (*)(void))tmp___0;
+  ldv_5_tegra_slink_driver_exit_default = 0;
+  ldv_5_tegra_slink_driver_init_default = 0;
   ldv_free(arg0);
   ldv_5_ret_default = ldv_insmod_tegra_slink_driver_init_5_6(ldv_5_tegra_slink_driver_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
@@ -5274,17 +5257,13 @@ void *ldv_interrupt_scenario_2(void *arg0 )
   enum irqreturn ldv_2_ret_val_default ;
   irqreturn_t (*ldv_2_thread_thread)(int , void * ) ;
   struct ldv_struct_interrupt_scenario_2 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
   data = (struct ldv_struct_interrupt_scenario_2 *)arg0;
-  tmp = external_allocated_data();
-  ldv_2_callback_handler = (irqreturn_t (*)(int , void * ))tmp;
-  ldv_2_data_data = external_allocated_data();
-  tmp___0 = external_allocated_data();
-  ldv_2_thread_thread = (irqreturn_t (*)(int , void * ))tmp___0;
+  ldv_2_callback_handler = 0;
+  ldv_2_data_data = 0;
+  ldv_2_thread_thread = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_interrupt_scenario_2 *)0)) {
     {
@@ -5358,8 +5337,6 @@ void *ldv_platform_instance_3(void *arg0 )
   int ldv_3_probed_default ;
   struct platform_device *ldv_3_resource_platform_device ;
   struct ldv_struct_platform_instance_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
   void *tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -5367,11 +5344,8 @@ void *ldv_platform_instance_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_platform_instance_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_platform_driver = (struct platform_driver *)tmp;
+  ldv_3_container_platform_driver = 0;
   ldv_3_probed_default = ldv_undef_int();
-  tmp___0 = external_allocated_data();
-  ldv_3_resource_platform_device = (struct platform_device *)tmp___0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_platform_instance_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.c
@@ -5851,15 +5851,6 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   struct inode *ldv_2_resource_inode ;
   int ldv_2_ret_default ;
   size_t ldv_2_size_cnt_write_size ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
   void *tmp___8 ;
   void *tmp___9 ;
   void *tmp___10 ;
@@ -5875,24 +5866,8 @@ void *ldv_character_driver_scenario_2(void *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_2_callback_llseek = (loff_t (*)(struct file * , loff_t  , int  ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_2_callback_read = (ssize_t (*)(struct file * , char * , size_t  , loff_t * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_2_container_file_operations = (struct file_operations *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_2_ldv_param_22_1_default = (char *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_2_ldv_param_22_3_default = (long long *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_2_ldv_param_4_1_default = (char *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_2_ldv_param_4_3_default = (long long *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_2_resource_file = (struct file *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_2_resource_inode = (struct inode *)tmp___7;
+  ldv_2_callback_llseek = 0;
+  ldv_2_callback_read = 0;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___8 = ldv_xmalloc(0UL);
@@ -6170,12 +6145,9 @@ void ldv_dispatch_register_6_3(struct usb_driver *arg0 )
 void ldv_emg_usb_deregister(struct usb_driver *arg0 ) 
 { 
   struct usb_driver *ldv_5_usb_driver_usb_driver ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_usb_driver_usb_driver = (struct usb_driver *)tmp;
   ldv_5_usb_driver_usb_driver = arg0;
   ldv_dispatch_deregister_5_1(ldv_5_usb_driver_usb_driver);
   }
@@ -6187,15 +6159,12 @@ int ldv_emg_usb_register_driver(struct usb_driver *arg0 , struct module *arg1 , 
 { 
   int ldv_6_res_default ;
   struct usb_driver *ldv_6_usb_driver_usb_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
 
   {
   {
   ldv_6_res_default = ldv_undef_int();
-  tmp = external_allocated_data();
-  ldv_6_usb_driver_usb_driver = (struct usb_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -6219,16 +6188,12 @@ void *ldv_insmod_4(void *arg0 )
   int (*ldv_4_adu_driver_init_default)(void) ;
   int ldv_4_reg_guard_3_default ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_adu_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_adu_driver_init_default = (int (*)(void))tmp___0;
+  ldv_4_adu_driver_exit_default = 0;
+  ldv_4_adu_driver_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_adu_driver_init_4_9(ldv_4_adu_driver_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -6313,10 +6278,6 @@ void *ldv_usb_scenario_3(void *arg0 )
   struct usb_interface *ldv_3_resource_usb_interface ;
   struct usb_device *ldv_3_usb_device_usb_device ;
   struct ldv_struct_usb_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
   void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
@@ -6328,16 +6289,11 @@ void *ldv_usb_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_usb_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_usb_driver = (struct usb_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___0;
+  ldv_3_container_usb_driver = 0;
   ldv_3_probe_retval_default = ldv_undef_int();
   ldv_3_reset_flag_default = 0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_usb_interface = (struct usb_interface *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_usb_device_usb_device = (struct usb_device *)tmp___2;
+  ldv_3_resource_usb_interface = 0;
+  ldv_3_usb_device_usb_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_usb_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko.cil.i
@@ -5741,15 +5741,6 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   struct inode *ldv_2_resource_inode ;
   int ldv_2_ret_default ;
   size_t ldv_2_size_cnt_write_size ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
   void *tmp___8 ;
   void *tmp___9 ;
   void *tmp___10 ;
@@ -5764,24 +5755,8 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   int tmp___19 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_2_callback_llseek = (loff_t (*)(struct file * , loff_t , int ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_2_callback_read = (ssize_t (*)(struct file * , char * , size_t , loff_t * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_2_container_file_operations = (struct file_operations *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_2_ldv_param_22_1_default = (char *)tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_2_ldv_param_22_3_default = (long long *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_2_ldv_param_4_1_default = (char *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_2_ldv_param_4_3_default = (long long *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_2_resource_file = (struct file *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_2_resource_inode = (struct inode *)tmp___7;
+  ldv_2_callback_llseek = 0;
+  ldv_2_callback_read = 0;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___8 = ldv_xmalloc(0UL);
@@ -6041,11 +6016,8 @@ void ldv_dispatch_register_6_3(struct usb_driver *arg0 )
 void ldv_emg_usb_deregister(struct usb_driver *arg0 )
 {
   struct usb_driver *ldv_5_usb_driver_usb_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_usb_driver_usb_driver = (struct usb_driver *)tmp;
   ldv_5_usb_driver_usb_driver = arg0;
   ldv_dispatch_deregister_5_1(ldv_5_usb_driver_usb_driver);
   }
@@ -6057,14 +6029,11 @@ int ldv_emg_usb_register_driver(struct usb_driver *arg0 , struct module *arg1 , 
 {
   int ldv_6_res_default ;
   struct usb_driver *ldv_6_usb_driver_usb_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
   ldv_6_res_default = ldv_undef_int();
-  tmp = external_allocated_data();
-  ldv_6_usb_driver_usb_driver = (struct usb_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -6088,15 +6057,11 @@ void *ldv_insmod_4(void *arg0 )
   int (*ldv_4_adu_driver_init_default)(void) ;
   int ldv_4_reg_guard_3_default ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_adu_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_adu_driver_init_default = (int (*)(void))tmp___0;
+  ldv_4_adu_driver_exit_default = 0;
+  ldv_4_adu_driver_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_adu_driver_init_4_9(ldv_4_adu_driver_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -6174,10 +6139,6 @@ void *ldv_usb_scenario_3(void *arg0 )
   struct usb_interface *ldv_3_resource_usb_interface ;
   struct usb_device *ldv_3_usb_device_usb_device ;
   struct ldv_struct_usb_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
   void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
@@ -6188,16 +6149,11 @@ void *ldv_usb_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_usb_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_usb_driver = (struct usb_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___0;
+  ldv_3_container_usb_driver = 0;
   ldv_3_probe_retval_default = ldv_undef_int();
   ldv_3_reset_flag_default = 0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_usb_interface = (struct usb_interface *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_usb_device_usb_device = (struct usb_device *)tmp___2;
+  ldv_3_resource_usb_interface = 0;
+  ldv_3_usb_device_usb_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_usb_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.c
@@ -5267,18 +5267,6 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   struct inode *ldv_2_resource_inode ;
   int ldv_2_ret_default ;
   size_t ldv_2_size_cnt_write_size ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
-  void *tmp___8 ;
-  void *tmp___9 ;
-  void *tmp___10 ;
   void *tmp___11 ;
   void *tmp___12 ;
   void *tmp___13 ;
@@ -5295,30 +5283,10 @@ void *ldv_character_driver_scenario_2(void *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_2_callback_llseek = (loff_t (*)(struct file * , loff_t  , int  ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_2_callback_poll = (gfp_t (*)(struct file * , poll_table * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_2_callback_read = (ssize_t (*)(struct file * , char * , size_t  , loff_t * ))tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_2_callback_unlocked_ioctl = (ssize_t (*)(struct file * , gfp_t  , size_t  ))tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_2_container_file_operations = (struct file_operations *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_2_ldv_param_22_1_default = (struct poll_table_struct *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_2_ldv_param_25_1_default = (char *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_2_ldv_param_25_3_default = (long long *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_2_ldv_param_4_1_default = (char *)tmp___7;
-  tmp___8 = external_allocated_data();
-  ldv_2_ldv_param_4_3_default = (long long *)tmp___8;
-  tmp___9 = external_allocated_data();
-  ldv_2_resource_file = (struct file *)tmp___9;
-  tmp___10 = external_allocated_data();
-  ldv_2_resource_inode = (struct inode *)tmp___10;
+  ldv_2_callback_llseek = 0;
+  ldv_2_callback_poll = 0;
+  ldv_2_callback_read = 0;
+  ldv_2_callback_unlocked_ioctl = 0;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___11 = ldv_xmalloc(0UL);
@@ -5666,12 +5634,9 @@ void ldv_dispatch_register_6_3(struct usb_driver *arg0 )
 void ldv_emg_usb_deregister(struct usb_driver *arg0 ) 
 { 
   struct usb_driver *ldv_5_usb_driver_usb_driver ;
-  void *tmp ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_usb_driver_usb_driver = (struct usb_driver *)tmp;
   ldv_5_usb_driver_usb_driver = arg0;
   ldv_dispatch_deregister_5_1(ldv_5_usb_driver_usb_driver);
   }
@@ -5683,15 +5648,12 @@ int ldv_emg_usb_register_driver(struct usb_driver *arg0 , struct module *arg1 , 
 { 
   int ldv_6_res_default ;
   struct usb_driver *ldv_6_usb_driver_usb_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
 
   {
   {
   ldv_6_res_default = ldv_undef_int();
-  tmp = external_allocated_data();
-  ldv_6_usb_driver_usb_driver = (struct usb_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -5715,16 +5677,12 @@ void *ldv_insmod_4(void *arg0 )
   int (*ldv_4_iowarrior_driver_init_default)(void) ;
   int ldv_4_reg_guard_3_default ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_iowarrior_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_iowarrior_driver_init_default = (int (*)(void))tmp___0;
+  ldv_4_iowarrior_driver_exit_default = 0;
+  ldv_4_iowarrior_driver_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_iowarrior_driver_init_4_9(ldv_4_iowarrior_driver_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -5809,10 +5767,6 @@ void *ldv_usb_scenario_3(void *arg0 )
   struct usb_interface *ldv_3_resource_usb_interface ;
   struct usb_device *ldv_3_usb_device_usb_device ;
   struct ldv_struct_usb_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
   void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
@@ -5824,16 +5778,11 @@ void *ldv_usb_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_usb_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_usb_driver = (struct usb_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___0;
+  ldv_3_container_usb_driver = 0;
   ldv_3_probe_retval_default = ldv_undef_int();
   ldv_3_reset_flag_default = 0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_usb_interface = (struct usb_interface *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_usb_device_usb_device = (struct usb_device *)tmp___2;
+  ldv_3_resource_usb_interface = 0;
+  ldv_3_usb_device_usb_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_usb_scenario_3 *)0)) {
     {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko.cil.i
@@ -5165,18 +5165,6 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   struct inode *ldv_2_resource_inode ;
   int ldv_2_ret_default ;
   size_t ldv_2_size_cnt_write_size ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
-  void *tmp___3 ;
-  void *tmp___4 ;
-  void *tmp___5 ;
-  void *tmp___6 ;
-  void *tmp___7 ;
-  void *tmp___8 ;
-  void *tmp___9 ;
-  void *tmp___10 ;
   void *tmp___11 ;
   void *tmp___12 ;
   void *tmp___13 ;
@@ -5192,30 +5180,10 @@ void *ldv_character_driver_scenario_2(void *arg0 )
   void *tmp___23 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_2_callback_llseek = (loff_t (*)(struct file * , loff_t , int ))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_2_callback_poll = (gfp_t (*)(struct file * , poll_table * ))tmp___0;
-  tmp___1 = external_allocated_data();
-  ldv_2_callback_read = (ssize_t (*)(struct file * , char * , size_t , loff_t * ))tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_2_callback_unlocked_ioctl = (ssize_t (*)(struct file * , gfp_t , size_t ))tmp___2;
-  tmp___3 = external_allocated_data();
-  ldv_2_container_file_operations = (struct file_operations *)tmp___3;
-  tmp___4 = external_allocated_data();
-  ldv_2_ldv_param_22_1_default = (struct poll_table_struct *)tmp___4;
-  tmp___5 = external_allocated_data();
-  ldv_2_ldv_param_25_1_default = (char *)tmp___5;
-  tmp___6 = external_allocated_data();
-  ldv_2_ldv_param_25_3_default = (long long *)tmp___6;
-  tmp___7 = external_allocated_data();
-  ldv_2_ldv_param_4_1_default = (char *)tmp___7;
-  tmp___8 = external_allocated_data();
-  ldv_2_ldv_param_4_3_default = (long long *)tmp___8;
-  tmp___9 = external_allocated_data();
-  ldv_2_resource_file = (struct file *)tmp___9;
-  tmp___10 = external_allocated_data();
-  ldv_2_resource_inode = (struct inode *)tmp___10;
+  ldv_2_callback_llseek = 0;
+  ldv_2_callback_poll = 0;
+  ldv_2_callback_read = 0;
+  ldv_2_callback_unlocked_ioctl = 0;
   ldv_2_ret_default = ldv_undef_int();
   ldv_free(arg0);
   tmp___11 = ldv_xmalloc(0UL);
@@ -5537,11 +5505,8 @@ void ldv_dispatch_register_6_3(struct usb_driver *arg0 )
 void ldv_emg_usb_deregister(struct usb_driver *arg0 )
 {
   struct usb_driver *ldv_5_usb_driver_usb_driver ;
-  void *tmp ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_5_usb_driver_usb_driver = (struct usb_driver *)tmp;
   ldv_5_usb_driver_usb_driver = arg0;
   ldv_dispatch_deregister_5_1(ldv_5_usb_driver_usb_driver);
   }
@@ -5553,14 +5518,11 @@ int ldv_emg_usb_register_driver(struct usb_driver *arg0 , struct module *arg1 , 
 {
   int ldv_6_res_default ;
   struct usb_driver *ldv_6_usb_driver_usb_driver ;
-  void *tmp ;
   int tmp___0 ;
   int tmp___1 ;
   {
   {
   ldv_6_res_default = ldv_undef_int();
-  tmp = external_allocated_data();
-  ldv_6_usb_driver_usb_driver = (struct usb_driver *)tmp;
   tmp___1 = ldv_undef_int();
   }
   if (tmp___1 != 0) {
@@ -5584,15 +5546,11 @@ void *ldv_insmod_4(void *arg0 )
   int (*ldv_4_iowarrior_driver_init_default)(void) ;
   int ldv_4_reg_guard_3_default ;
   int ldv_4_ret_default ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_iowarrior_driver_exit_default = (void (*)(void))tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_iowarrior_driver_init_default = (int (*)(void))tmp___0;
+  ldv_4_iowarrior_driver_exit_default = 0;
+  ldv_4_iowarrior_driver_init_default = 0;
   ldv_free(arg0);
   ldv_4_ret_default = ldv_insmod_iowarrior_driver_init_4_9(ldv_4_iowarrior_driver_init_default);
   ldv_4_ret_default = ldv_post_init(ldv_4_ret_default);
@@ -5670,10 +5628,6 @@ void *ldv_usb_scenario_3(void *arg0 )
   struct usb_interface *ldv_3_resource_usb_interface ;
   struct usb_device *ldv_3_usb_device_usb_device ;
   struct ldv_struct_usb_scenario_3 *data ;
-  void *tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
   void *tmp___3 ;
   void *tmp___4 ;
   int tmp___5 ;
@@ -5684,16 +5638,11 @@ void *ldv_usb_scenario_3(void *arg0 )
   {
   {
   data = (struct ldv_struct_usb_scenario_3 *)arg0;
-  tmp = external_allocated_data();
-  ldv_3_container_usb_driver = (struct usb_driver *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_3_ldv_param_14_1_default = (struct usb_device_id *)tmp___0;
+  ldv_3_container_usb_driver = 0;
   ldv_3_probe_retval_default = ldv_undef_int();
   ldv_3_reset_flag_default = 0;
-  tmp___1 = external_allocated_data();
-  ldv_3_resource_usb_interface = (struct usb_interface *)tmp___1;
-  tmp___2 = external_allocated_data();
-  ldv_3_usb_device_usb_device = (struct usb_device *)tmp___2;
+  ldv_3_resource_usb_interface = 0;
+  ldv_3_usb_device_usb_device = 0;
   }
   if ((unsigned long )data != (unsigned long )((struct ldv_struct_usb_scenario_3 *)0)) {
     {


### PR DESCRIPTION
Removes calls to external_allocated_data where the value was overwritten
immediately afterwards or where the value is never read anyway. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).
