### PR TITLE
Corrected divbin verdict (from #808) and its correct version

### DIFF
--- a/c/nla-digbench/divbin2.c
+++ b/c/nla-digbench/divbin2.c
@@ -1,0 +1,48 @@
+/*
+  A division algorithm, by Kaldewaij
+  returns A//B
+*/
+
+#include <limits.h>
+
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+    A = __VERIFIER_nondet_unsigned_int();
+    B = 1;
+
+    q = 0;
+    r = A;
+    b = B;
+
+    while (1) {
+        if (!(r >= b)) break;
+        b = 2 * b;
+    }
+
+    while (1) {
+        __VERIFIER_assert(A == q * b + r);
+        if (!(b != B)) break;
+
+        q = 2 * q;
+        b = b / 2;
+        if (r >= b) {
+            q = q + 1;
+            r = r - b;
+        }
+    }
+
+    __VERIFIER_assert(A == q * b + r);
+    return 0;
+}

--- a/c/nla-digbench/divbin2.i
+++ b/c/nla-digbench/divbin2.i
@@ -1,0 +1,35 @@
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+    A = __VERIFIER_nondet_unsigned_int();
+    B = 1;
+    q = 0;
+    r = A;
+    b = B;
+    while (1) {
+        if (!(r >= b)) break;
+        b = 2 * b;
+    }
+    while (1) {
+        __VERIFIER_assert(A == q * b + r);
+        if (!(b != B)) break;
+        q = 2 * q;
+        b = b / 2;
+        if (r >= b) {
+            q = q + 1;
+            r = r - b;
+        }
+    }
+    __VERIFIER_assert(A == q * b + r);
+    return 0;
+}

--- a/c/nla-digbench/divbin2.yml
+++ b/c/nla-digbench/divbin2.yml
@@ -1,5 +1,5 @@
 format_version: '1.0'
-input_files: 'divbin.i'
+input_files: 'divbin2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true


### PR DESCRIPTION
The assertion in the divbin program is violable. Counter example was obtained using a bounded model checker and manually verified. Hence this pull request changes the verdict of this program. Also, corrected program version divbin2 with verifiable assertion is added.

Benchmarks from PR #808 
Similar issues discussed in PR #813 
Partial corrections issued in PR #837  

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
