### PR TITLE
Add the forgotten memsafety tasks

### DIFF
--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -6,3 +6,13 @@ locks/*.yml
 memsafety-ext3/*.yml
 pthread-memsafety/*.yml
 memsafety-bftpd/*.yml
+verifythis/duplets.yml
+verifythis/elimination_max.yml
+verifythis/lcp.yml
+verifythis/prefixsum_iter.yml
+verifythis/tree_del_iter.yml
+verifythis/prefixsum_rec.yml
+verifythis/tree_del_rec.yml
+verifythis/tree_max.yml
+verifythis/elimination_max_rec.yml
+verifythis/elimination_max_rec_onepoint.yml


### PR DESCRIPTION
The new VerifyThis tasks came with properties `unreach-call` and `memsafety`, but only the `unreach-call` ones were added to SV-COMP categories.