### PR TITLE
Fix unintended runtime exceptions in algorithms Java benchmarks

### DIFF
--- a/java/algorithms/BellmanFord-FunSat01/Main.java
+++ b/java/algorithms/BellmanFord-FunSat01/Main.java
@@ -97,7 +97,7 @@ public class Main {
 
   public static void main(String[] args) {
     final int V = Verifier.nondetInt();
-    Verifier.assume(V > 0 && V < 1000000);
+    Verifier.assume(V > 0 && V < 46341); // V*V < Integer.MAX_VALUE
 
     final int D[] = new int[V*V];
 
@@ -105,7 +105,7 @@ public class Main {
       for (int j = 0; j < V; j++) {
         if (i == j) continue;
         int tmp = Verifier.nondetInt();
-        Verifier.assume(tmp >= 0 && tmp < 1000000);
+        Verifier.assume(tmp >= 0 && tmp < 46341);
         D[i*V+j] = tmp;
       }
     }

--- a/java/algorithms/BellmanFord-MemSat01/Main.java
+++ b/java/algorithms/BellmanFord-MemSat01/Main.java
@@ -97,7 +97,7 @@ public class Main {
 
   public static void main(String[] args) {
     final int V = Verifier.nondetInt();
-    Verifier.assume(V > 0 && V < 1000000);
+    Verifier.assume(V > 0 && V < 46341); // V*V < Integer.MAX_VALUE
 
     final int D[] = new int[V*V];
 
@@ -105,7 +105,7 @@ public class Main {
       for (int j = 0; j < V; j++) {
         if (i == j) continue;
         int tmp = Verifier.nondetInt();
-        Verifier.assume(tmp >= 0 && tmp < 1000000);
+        Verifier.assume(tmp >= 0 && tmp < 46341);
         D[i*V+j] = tmp;
       }
     }

--- a/java/algorithms/MergeSortIterative-FunSat01/Main.java
+++ b/java/algorithms/MergeSortIterative-FunSat01/Main.java
@@ -35,7 +35,7 @@ public class Main {
     }
     iterativeMergesort(data);
 
-    assert(data[0] < data[1] || data.length < 2);
+    assert(data.length < 2 || data[0] < data[1]);
   }
 
   /////////////////////////////////////////


### PR DESCRIPTION
Would otherwise affect the expected verdict.

- [n/a] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [n/a] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [n/a] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [n/a] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [n/a] intended property matches the corresponding `.prp` file
- [n/a] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)
