### PR TITLE
Specialise kmem_cache_alloc to the desired allocation size

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -10916,6 +10916,7 @@ static int ldv_mod_timer_96(struct timer_list *ldv_func_arg1 , unsigned long ldv
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10923,7 +10924,7 @@ static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(64UL);
   }
   return (tmp);
 }
@@ -11767,7 +11768,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(24UL);
   }
   return (tmp);
 }
@@ -14305,7 +14306,7 @@ static void *ldv_kmem_cache_alloc_124(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
@@ -14317,12 +14318,11 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_128(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -10376,13 +10376,14 @@ static int ldv_mod_timer_96(struct timer_list *ldv_func_arg1 , unsigned long ldv
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(64UL);
   }
   return (tmp);
 }
@@ -11134,7 +11135,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(24UL);
   }
   return (tmp);
 }
@@ -13436,7 +13437,7 @@ static void *ldv_kmem_cache_alloc_124(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
@@ -13447,12 +13448,11 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_128(unsigned long ldv_func_arg1 )
 {
   void *tmp ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -27026,7 +27026,7 @@ static void *ldv_kmem_cache_alloc_166(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -27038,7 +27038,7 @@ static void *ldv_kmem_cache_alloc_167(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -27050,7 +27050,7 @@ static void *ldv_kmem_cache_alloc_168(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -30082,7 +30082,7 @@ static void *ldv_kmem_cache_alloc_95(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -30094,7 +30094,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -30139,7 +30139,7 @@ static void *ldv_kmem_cache_alloc_100(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34558,7 +34558,7 @@ static void *ldv_kmem_cache_alloc_95___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34570,7 +34570,7 @@ static void *ldv_kmem_cache_alloc_96___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34582,7 +34582,7 @@ static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34594,7 +34594,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34617,7 +34617,7 @@ static void *ldv_kmem_cache_alloc_100___0(struct kmem_cache *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -34684,7 +34684,7 @@ static void *ldv_kmem_cache_alloc_110(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -25245,7 +25245,7 @@ static void *ldv_kmem_cache_alloc_166(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -25256,7 +25256,7 @@ static void *ldv_kmem_cache_alloc_167(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -25267,7 +25267,7 @@ static void *ldv_kmem_cache_alloc_168(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -28069,7 +28069,7 @@ static void *ldv_kmem_cache_alloc_95(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -28080,7 +28080,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -28118,7 +28118,7 @@ static void *ldv_kmem_cache_alloc_100(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -32242,7 +32242,7 @@ static void *ldv_kmem_cache_alloc_95___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -32253,7 +32253,7 @@ static void *ldv_kmem_cache_alloc_96___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -32264,7 +32264,7 @@ static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -32275,7 +32275,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -32295,7 +32295,7 @@ static void *ldv_kmem_cache_alloc_100___0(struct kmem_cache *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -32351,7 +32351,7 @@ static void *ldv_kmem_cache_alloc_110(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -5719,7 +5719,7 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 }
 extern void dev_printk(char const * , struct device const * , char const *
                        , ...) ;
-extern void *realloc(void * , size_t  ) ;
+extern void *realloc(void * , size_t ) ;
 static void *ldv_krealloc_98(void const *ldv_func_arg1 , size_t ldv_func_arg2 ,
                              gfp_t flags ) ;
 extern void kfree(void const * ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -19473,7 +19473,7 @@ static void *ldv_kmem_cache_alloc_222(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(328UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -18520,7 +18520,7 @@ static void *ldv_kmem_cache_alloc_222(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(328UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -10430,7 +10430,7 @@ static void *ldv_kmem_cache_alloc_132(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -17526,7 +17526,7 @@ static void *ldv_kmem_cache_alloc_121(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(40UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -10053,7 +10053,7 @@ static void *ldv_kmem_cache_alloc_132(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -16504,7 +16504,7 @@ static void *ldv_kmem_cache_alloc_121(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(40UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -14624,7 +14624,7 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1176UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -13950,7 +13950,7 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1176UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -11973,7 +11973,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1032UL);
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -11399,7 +11399,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1032UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -10916,6 +10916,7 @@ static int ldv_mod_timer_96(struct timer_list *ldv_func_arg1 , unsigned long ldv
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
@@ -10923,7 +10924,7 @@ static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(64UL);
   }
   return (tmp);
 }
@@ -11767,7 +11768,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(24UL);
   }
   return (tmp);
 }
@@ -14305,7 +14306,7 @@ static void *ldv_kmem_cache_alloc_124(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
@@ -14317,12 +14318,11 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(72UL);
   }
   return (tmp);
 }
 }
-void *ldv_malloc(size_t size ) ;
 static void *ldv_vmalloc_128(unsigned long ldv_func_arg1 ) 
 { 
   void *tmp ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -27026,7 +27026,7 @@ static void *ldv_kmem_cache_alloc_166(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -27038,7 +27038,7 @@ static void *ldv_kmem_cache_alloc_167(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -27050,7 +27050,7 @@ static void *ldv_kmem_cache_alloc_168(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -30082,7 +30082,7 @@ static void *ldv_kmem_cache_alloc_95(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -30094,7 +30094,7 @@ static void *ldv_kmem_cache_alloc_96(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -30139,7 +30139,7 @@ static void *ldv_kmem_cache_alloc_100(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34558,7 +34558,7 @@ static void *ldv_kmem_cache_alloc_95___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34570,7 +34570,7 @@ static void *ldv_kmem_cache_alloc_96___0(struct kmem_cache *ldv_func_arg1 , gfp_
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34582,7 +34582,7 @@ static void *ldv_kmem_cache_alloc_97(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34594,7 +34594,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -34617,7 +34617,7 @@ static void *ldv_kmem_cache_alloc_100___0(struct kmem_cache *ldv_func_arg1 , gfp
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }
@@ -34684,7 +34684,7 @@ static void *ldv_kmem_cache_alloc_110(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(32UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -19473,7 +19473,7 @@ static void *ldv_kmem_cache_alloc_222(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(328UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -10430,7 +10430,7 @@ static void *ldv_kmem_cache_alloc_132(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(56UL);
   }
   return (tmp);
 }
@@ -17526,7 +17526,7 @@ static void *ldv_kmem_cache_alloc_121(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(40UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -14624,7 +14624,7 @@ static void *ldv_kmem_cache_alloc_125(struct kmem_cache *ldv_func_arg1 , gfp_t f
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1176UL);
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11973,7 +11973,7 @@ static void *ldv_kmem_cache_alloc_98(struct kmem_cache *ldv_func_arg1 , gfp_t fl
   {
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
+  tmp = ldv_malloc(1032UL);
   }
   return (tmp);
 }


### PR DESCRIPTION
kmem_cache_alloc should allocate (from a cache) memory of the size
specified when the cache was created (via kmem_cache_create). Since none
of the benchmarks provide a definition of kmem_cache_create (or struct
kmem_cache), this information cannot be communicated. Instead, hard-code
the allocation size as used in the specific device driver (and the
particular cache, when multiple caches are used) in kmem_cache_alloc and
use ldv_malloc instead of ldv_malloc_unknown_size.  This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).
