### PR TITLE
Remove unused ldv_alloc_macro

### DIFF
--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.c
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.c
@@ -5252,18 +5252,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
@@ -5247,17 +5247,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.c
@@ -6136,18 +6136,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-dvb-core-dvb-core.cil.i
@@ -6131,17 +6131,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-bt8xx-bttv.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-bt8xx-bttv.cil.c
@@ -5574,18 +5574,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-bt8xx-bttv.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-bt8xx-bttv.cil.i
@@ -5568,17 +5568,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-zoran-zr36067.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-zoran-zr36067.cil.c
@@ -5034,18 +5034,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void might_fault(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-zoran-zr36067.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-zoran-zr36067.cil.i
@@ -5029,17 +5029,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern void might_fault(void) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.c
@@ -3833,18 +3833,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-rc-imon.cil.i
@@ -3829,17 +3829,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.c
@@ -6847,18 +6847,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.i
@@ -6842,17 +6842,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.c
@@ -7076,18 +7076,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dib0700.cil.i
@@ -7071,17 +7071,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dw2102.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dw2102.cil.c
@@ -6788,18 +6788,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dw2102.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-dvb-usb-dvb-usb-dw2102.cil.i
@@ -6783,17 +6783,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.c
@@ -4592,18 +4592,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.i
@@ -4587,17 +4587,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern void *memcpy(void * , void const * , size_t ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.c
@@ -6291,18 +6291,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-tm6000-tm6000.cil.i
@@ -6286,17 +6286,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
@@ -5370,18 +5370,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -5364,17 +5364,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.c
@@ -5280,18 +5280,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-pcnet32.cil.i
@@ -5275,17 +5275,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.c
@@ -6115,18 +6115,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-alx-alx.cil.i
@@ -6109,17 +6109,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -6759,18 +6759,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -6753,17 +6753,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -7040,18 +7040,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -7035,17 +7035,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -7617,18 +7617,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -7612,17 +7612,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -6622,18 +6622,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -6617,17 +6617,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.c
@@ -6839,18 +6839,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int __dynamic_netdev_dbg(struct _ddebug * , struct net_device  const  * , char const   * 
                                 , ...) ;
 extern void mutex_lock_nested(struct mutex * , unsigned int  ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -6833,17 +6833,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int __dynamic_netdev_dbg(struct _ddebug * , struct net_device const * , char const *
                                 , ...) ;
 extern void mutex_lock_nested(struct mutex * , unsigned int ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -8004,18 +8004,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -7999,17 +7999,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.c
@@ -7030,18 +7030,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -7024,17 +7024,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6238,18 +6238,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6233,17 +6233,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -7796,18 +7796,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -7791,17 +7791,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -6225,18 +6225,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -6220,17 +6220,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.c
@@ -5251,18 +5251,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-natsemi-natsemi.cil.i
@@ -5246,17 +5246,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -8058,18 +8058,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 
 { 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -8053,17 +8053,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )
 {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
@@ -5455,18 +5455,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
@@ -5449,17 +5449,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.c
@@ -5255,18 +5255,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-renesas-sh_eth.cil.i
@@ -5249,17 +5249,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.c
@@ -7621,18 +7621,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -7615,17 +7615,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -5293,18 +5293,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -5288,17 +5288,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
@@ -5325,18 +5325,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
@@ -5320,17 +5320,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
@@ -6116,18 +6116,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
@@ -6110,17 +6110,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.c
@@ -6458,18 +6458,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-vmxnet3-vmxnet3.cil.i
@@ -6452,17 +6452,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.c
@@ -6686,18 +6686,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -6681,17 +6681,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.c
@@ -6789,18 +6789,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 
 { 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-libertas-libertas.cil.i
@@ -6784,17 +6784,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )
 {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.c
@@ -8822,18 +8822,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -8817,17 +8817,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.c
@@ -6706,18 +6706,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rndis_wlan.cil.i
@@ -6701,17 +6701,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.c
@@ -6496,18 +6496,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
@@ -6491,17 +6491,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -7835,18 +7835,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -7829,17 +7829,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const * , void const * , size_t ) ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
@@ -6106,18 +6106,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
@@ -6101,17 +6101,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.c
@@ -5395,18 +5395,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -5389,17 +5389,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.c
@@ -6788,18 +6788,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-tg3.cil.i
@@ -6782,17 +6782,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.c
@@ -7642,18 +7642,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -7637,17 +7637,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.c
@@ -6647,18 +6647,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -6642,17 +6642,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.c
@@ -6256,18 +6256,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgb-ixgb.cil.i
@@ -6251,17 +6251,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.c
@@ -8085,18 +8085,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 
 { 

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -8080,17 +8080,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )
 {

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.c
@@ -5480,18 +5480,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-nvidia-forcedeth.cil.i
@@ -5474,17 +5474,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.c
@@ -6142,18 +6142,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-via-via-velocity.cil.i
@@ -6136,17 +6136,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.c
@@ -7842,18 +7842,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8192de-rtl8192de.cil.i
@@ -7836,17 +7836,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const * , void const * , size_t ) ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.c
@@ -6120,18 +6120,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-xen-netfront.cil.i
@@ -6115,17 +6115,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-common-saa7146-saa7146_vv.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-common-saa7146-saa7146_vv.cil.c
@@ -5026,18 +5026,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-common-saa7146-saa7146_vv.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-common-saa7146-saa7146_vv.cil.i
@@ -5021,17 +5021,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx25821-cx25821.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx25821-cx25821.cil.c
@@ -5047,18 +5047,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx25821-cx25821.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx25821-cx25821.cil.i
@@ -5042,17 +5042,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx88-cx8800.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx88-cx8800.cil.c
@@ -7802,18 +7802,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx88-cx8800.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-cx88-cx8800.cil.i
@@ -7796,17 +7796,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7134-saa7134.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7134-saa7134.cil.c
@@ -8340,18 +8340,6 @@ struct ldv_thread {
 void ldv_assume(int expression ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned char readb(void const volatile   *addr ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7134-saa7134.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7134-saa7134.cil.i
@@ -8334,17 +8334,6 @@ struct ldv_thread {
 void ldv_assume(int expression ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned char readb(void const volatile *addr )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.c
@@ -7956,18 +7956,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void msleep(unsigned int  ) ;
 extern void tveeprom_hauppauge_analog(struct i2c_client * , struct tveeprom * , unsigned char * ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.i
@@ -7950,17 +7950,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void msleep(unsigned int ) ;
 extern void tveeprom_hauppauge_analog(struct i2c_client * , struct tveeprom * , unsigned char * ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-stv06xx-gspca_stv06xx.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-stv06xx-gspca_stv06xx.cil.c
@@ -4850,18 +4850,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-stv06xx-gspca_stv06xx.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-gspca-stv06xx-gspca_stv06xx.cil.i
@@ -4845,17 +4845,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.c
@@ -4958,18 +4958,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 
 { 
 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-usbvision-usbvision.cil.i
@@ -4953,17 +4953,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static void INIT_LIST_HEAD(struct list_head *list )
 {
   {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.c
@@ -5674,18 +5674,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-media-usb-uvc-uvcvideo.cil.i
@@ -5667,17 +5667,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.c
@@ -5423,18 +5423,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
@@ -5418,17 +5418,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.c
@@ -6169,18 +6169,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-alteon-acenic.cil.i
@@ -6164,17 +6164,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.c
@@ -5296,18 +5296,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-amd-amd8111e.cil.i
@@ -5291,17 +5291,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.c
@@ -6238,18 +6238,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1c-atl1c.cil.i
@@ -6232,17 +6232,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.c
@@ -6192,18 +6192,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
@@ -6187,17 +6187,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -6602,18 +6602,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -6596,17 +6596,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.c
@@ -6487,18 +6487,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -6482,17 +6482,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.c
@@ -5383,18 +5383,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-de4x5.cil.i
@@ -5378,17 +5378,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.c
@@ -5301,18 +5301,6 @@ struct ldv_thread {
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u16 __fswab16(__u16 val ) 
 { 
 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
@@ -5296,17 +5296,6 @@ struct ldv_thread {
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u16 __fswab16(__u16 val )
 {
   {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.c
@@ -5257,18 +5257,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
@@ -5252,17 +5252,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.c
@@ -5251,18 +5251,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
@@ -5246,17 +5246,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.c
@@ -5214,18 +5214,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-hp-hp100.cil.i
@@ -5209,17 +5209,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.c
@@ -6257,18 +6257,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned int readl(void const volatile   *addr ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -6252,17 +6252,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned int readl(void const volatile *addr )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.c
@@ -6149,18 +6149,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-jme.cil.i
@@ -6143,17 +6143,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
@@ -5421,18 +5421,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
@@ -5415,17 +5415,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.c
@@ -6150,18 +6150,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-marvell-sky2.cil.i
@@ -6144,17 +6144,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.c
@@ -4523,18 +4523,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-mellanox-mlx5-core-mlx5_core.cil.i
@@ -4518,17 +4518,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.c
@@ -5518,18 +5518,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
@@ -5513,17 +5513,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.c
@@ -6316,18 +6316,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int __dynamic_netdev_dbg(struct _ddebug * , struct net_device  const  * , char const   * 
                                 , ...) ;
 extern void __const_udelay(unsigned long  ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -6310,17 +6310,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int __dynamic_netdev_dbg(struct _ddebug * , struct net_device const * , char const *
                                 , ...) ;
 extern void __const_udelay(unsigned long ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.c
@@ -6775,18 +6775,6 @@ long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 
 { 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-netxen-netxen_nic.cil.i
@@ -6770,17 +6770,6 @@ long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )
 {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.c
@@ -6538,18 +6538,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -6533,17 +6533,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.c
@@ -6644,18 +6644,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -6638,17 +6638,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.c
@@ -5899,18 +5899,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -5894,17 +5894,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.c
@@ -6120,18 +6120,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-tehuti-tehuti.cil.i
@@ -6115,17 +6115,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
@@ -6277,18 +6277,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -6272,17 +6272,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -5752,18 +5752,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5747,17 +5747,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.c
@@ -5442,18 +5442,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-team-team.cil.i
@@ -5437,17 +5437,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.c
@@ -5602,18 +5602,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static int constant_test_bit(long nr , unsigned long const volatile   *addr ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-asix.cil.i
@@ -5597,17 +5597,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static int constant_test_bit(long nr , unsigned long const volatile *addr )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.c
@@ -5426,18 +5426,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-kaweth.cil.i
@@ -5421,17 +5421,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.c
@@ -5390,18 +5390,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-usb-pegasus.cil.i
@@ -5385,17 +5385,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.c
@@ -5365,18 +5365,6 @@ struct ldv_thread {
 void ldv_assume(int expression ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void lmc_trace(struct net_device *dev , char *msg ) ;
 void lmc_trace(struct net_device *dev , char *msg ) 
 { 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wan-lmc-lmc.cil.i
@@ -5360,17 +5360,6 @@ struct ldv_thread {
 void ldv_assume(int expression ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void lmc_trace(struct net_device *dev , char *msg ) ;
 void lmc_trace(struct net_device *dev , char *msg )
 {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -7420,18 +7420,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -7413,17 +7413,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.c
@@ -7160,18 +7160,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -7155,17 +7155,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.c
@@ -6919,18 +6919,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -6914,17 +6914,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.c
@@ -6220,18 +6220,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-orinoco-orinoco_usb.cil.i
@@ -6215,17 +6215,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.c
@@ -6836,18 +6836,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void __set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rt2x00-rt2500usb.cil.i
@@ -6831,17 +6831,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void __set_bit(long nr , unsigned long volatile *addr )
 {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
@@ -7788,18 +7788,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern void lock_acquire(struct lockdep_map * , unsigned int  , int  , int  , int  ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -7782,17 +7782,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern void lock_acquire(struct lockdep_map * , unsigned int , int , int , int ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-autofs4-autofs4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-autofs4-autofs4.cil.c
@@ -3930,18 +3930,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct dentry *mount_nodev(struct file_system_type * , int  , void * , int (*)(struct super_block * ,
                                                                                       void * ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-autofs4-autofs4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-autofs4-autofs4.cil.i
@@ -3926,17 +3926,6 @@ extern void *external_allocated_data(void) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct dentry *mount_nodev(struct file_system_type * , int , void * , int (*)(struct super_block * ,
                                                                                       void * ,

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-nfs-nfs_layout_nfsv41_files.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-nfs-nfs_layout_nfsv41_files.cil.c
@@ -7164,18 +7164,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-nfs-nfs_layout_nfsv41_files.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_fs-nfs-nfs_layout_nfsv41_files.cil.i
@@ -7159,17 +7159,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-i2c-cx25840-cx25840.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-i2c-cx25840-cx25840.cil.c
@@ -4309,18 +4309,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-i2c-cx25840-cx25840.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-i2c-cx25840-cx25840.cil.i
@@ -4304,17 +4304,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.c
@@ -7974,18 +7974,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void msleep(unsigned int  ) ;
 extern void tveeprom_hauppauge_analog(struct i2c_client * , struct tveeprom * , unsigned char * ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-pci-saa7164-saa7164.cil.i
@@ -7968,17 +7968,6 @@ struct ldv_thread {
 };
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void msleep(unsigned int ) ;
 extern void tveeprom_hauppauge_analog(struct i2c_client * , struct tveeprom * , unsigned char * ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.c
@@ -4598,18 +4598,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-media-usb-gspca-gspca_topro.cil.i
@@ -4593,17 +4593,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern void *memcpy(void * , void const * , size_t ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.c
@@ -6627,18 +6627,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -6621,17 +6621,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.c
@@ -7069,18 +7069,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -7064,17 +7064,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.c
@@ -7677,18 +7677,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -7672,17 +7672,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.c
@@ -8029,18 +8029,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-i40e-i40e.cil.i
@@ -8024,17 +8024,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.c
@@ -7825,18 +7825,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -7820,17 +7820,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.c
@@ -5450,18 +5450,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-marvell-skge.cil.i
@@ -5444,17 +5444,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.c
@@ -6251,18 +6251,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -6246,17 +6246,6 @@ int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.c
@@ -5318,18 +5318,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -5313,17 +5313,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.c
@@ -5347,18 +5347,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-ti-tlan.cil.i
@@ -5342,17 +5342,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.c
@@ -6295,18 +6295,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -6290,17 +6290,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.c
@@ -5770,18 +5770,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-irda-via-ircc.cil.i
@@ -5765,17 +5765,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.c
@@ -6058,18 +6058,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device  const  *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-airo.cil.i
@@ -6053,17 +6053,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_dev_get_drvdata(struct device const *dev ) ;
 int ldv_dev_set_drvdata(struct device *dev , void *data ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.c
@@ -7449,18 +7449,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list ) 

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -7442,17 +7442,6 @@ void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 extern struct module __this_module ;
 __inline static void INIT_LIST_HEAD(struct list_head *list )

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.c
@@ -7841,18 +7841,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -7835,17 +7835,6 @@ void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 int ldv_undef_int(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const * , void const * , size_t ) ;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.c
@@ -7795,18 +7795,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern void lock_acquire(struct lockdep_map * , unsigned int  , int  , int  , int  ,

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -7789,17 +7789,6 @@ struct ldv_thread {
 long ldv__builtin_expect(long exp , long c ) ;
 void *ldv_malloc_unknown_size(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern void lock_acquire(struct lockdep_map * , unsigned int , int , int , int ,

--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -4152,18 +4152,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_139(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -7322,18 +7322,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_136(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_141(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -7309,17 +7309,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_136(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_141(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -5400,18 +5400,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 void ldv_linux_block_request_put_blk_rq(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -5388,17 +5388,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 void ldv_linux_block_request_put_blk_rq(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -5320,18 +5320,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -5307,17 +5307,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -4353,18 +4353,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -4341,17 +4341,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -4752,18 +4752,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u32 __fswab32(__u32 val ) 
 { 
   int tmp ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -4740,17 +4740,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u32 __fswab32(__u32 val )
 {
   int tmp ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -5160,18 +5160,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 struct request_queue *ldv_linux_block_queue_request_queue(void) ;
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -5148,17 +5148,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 struct request_queue *ldv_linux_block_queue_request_queue(void) ;
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -4587,18 +4587,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) ;
 void ldv_linux_block_request_put_blk_rq(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -4575,17 +4575,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) ;
 void ldv_linux_block_request_put_blk_rq(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -4752,18 +4752,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -4740,17 +4740,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -4251,18 +4251,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -4238,17 +4238,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -4503,18 +4503,6 @@ int ldv_linux_usb_dev_atomic_add_return(int i , atomic_t *v ) ;
 void ldv_linux_kernel_sched_completion_init_completion_done_of_fw_card(void) ;
 void ldv_linux_kernel_sched_completion_wait_for_completion_done_of_fw_card(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -4490,17 +4490,6 @@ int ldv_linux_usb_dev_atomic_add_return(int i , atomic_t *v ) ;
 void ldv_linux_kernel_sched_completion_init_completion_done_of_fw_card(void) ;
 void ldv_linux_kernel_sched_completion_wait_for_completion_done_of_fw_card(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -6132,18 +6132,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device  const  *dev ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -6119,17 +6119,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device const *dev )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -6367,18 +6367,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device  const  *dev ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -6354,17 +6354,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device const *dev )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -4287,18 +4287,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_sync_of_wiimote_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_sync_of_wiimote_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -4275,17 +4275,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_sync_of_wiimote_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_sync_of_wiimote_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -5071,18 +5071,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_116(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_hid_open_mut(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -5059,17 +5059,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_116(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_hid_open_mut(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -4012,18 +4012,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -3999,17 +3999,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -4216,18 +4216,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -4203,17 +4203,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -5382,18 +5382,6 @@ static void ldv_ldv_check_final_state_101(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -5369,17 +5369,6 @@ static void ldv_ldv_check_final_state_101(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 extern int printk(char const * , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -4523,18 +4523,6 @@ static void ldv_ldv_check_final_state_143(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -4510,17 +4510,6 @@ static void ldv_ldv_check_final_state_143(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -6403,18 +6403,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -6389,17 +6389,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -4386,18 +4386,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -4374,17 +4374,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -4394,18 +4394,6 @@ static void ldv_ldv_check_final_state_110(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static int ldv_mutex_lock_interruptible_99(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_101(struct mutex *ldv_func_arg1 ) ;
 int ldv_linux_kernel_locking_mutex_mutex_lock_interruptible_or_killable_sysfs_mutex_of_elants_data(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -4381,17 +4381,6 @@ static void ldv_ldv_check_final_state_110(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static int ldv_mutex_lock_interruptible_99(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_101(struct mutex *ldv_func_arg1 ) ;
 int ldv_linux_kernel_locking_mutex_mutex_lock_interruptible_or_killable_sysfs_mutex_of_elants_data(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -4316,18 +4316,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_mutex_of_input_dev(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -4304,17 +4304,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_mutex_of_input_dev(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -5104,18 +5104,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 static int ldv_mutex_lock_interruptible_96(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -5092,17 +5092,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 static int ldv_mutex_lock_interruptible_96(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -7018,18 +7018,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -7005,17 +7005,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -4108,18 +4108,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -4096,17 +4096,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -7739,18 +7739,6 @@ static void ldv_ldv_check_final_state_127(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -7726,17 +7726,6 @@ static void ldv_ldv_check_final_state_127(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -5673,18 +5673,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -5660,17 +5660,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -7489,18 +7489,6 @@ static void ldv_ldv_check_final_state_142(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_121(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_127(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -7476,17 +7476,6 @@ static void ldv_ldv_check_final_state_142(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_121(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_127(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -6358,18 +6358,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_uvc_device(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -6343,17 +6343,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_uvc_device(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -4555,18 +4555,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -4543,17 +4543,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -4500,18 +4500,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -4488,17 +4488,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -5014,18 +5014,6 @@ static void ldv_ldv_check_final_state_122(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -5002,17 +5002,6 @@ static void ldv_ldv_check_final_state_122(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -4729,18 +4729,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -4717,17 +4717,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -3996,18 +3996,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -3984,17 +3984,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -4546,18 +4546,6 @@ static void ldv_ldv_check_final_state_121(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -4533,17 +4533,6 @@ static void ldv_ldv_check_final_state_121(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -3942,18 +3942,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_86(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_88(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_91(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -3930,17 +3930,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_86(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_88(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_91(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -4990,18 +4990,6 @@ void *ldv_err_ptr(long error ) ;
 long ldv_ptr_err(void const   *ptr ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u16 __fswab16(__u16 val ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -4978,17 +4978,6 @@ void *ldv_err_ptr(long error ) ;
 long ldv_ptr_err(void const *ptr ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u16 __fswab16(__u16 val )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -6646,18 +6646,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -6632,17 +6632,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -6459,18 +6459,6 @@ static void ldv_ldv_check_final_state_134(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_cpu_ops pv_cpu_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -6446,17 +6446,6 @@ static void ldv_ldv_check_final_state_134(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_cpu_ops pv_cpu_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -6273,18 +6273,6 @@ static void ldv_ldv_check_final_state_172(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -6260,17 +6260,6 @@ static void ldv_ldv_check_final_state_172(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -7118,18 +7118,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 int ldv_linux_net_rtnetlink_rtnl_is_locked(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -7104,17 +7104,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 int ldv_linux_net_rtnetlink_rtnl_is_locked(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -7199,18 +7199,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -7186,17 +7186,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -7686,18 +7686,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -7672,17 +7672,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -7620,18 +7620,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -7607,17 +7607,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -6257,18 +6257,6 @@ static void ldv_ldv_check_final_state_150(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -6244,17 +6244,6 @@ static void ldv_ldv_check_final_state_150(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -6043,18 +6043,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -6029,17 +6029,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -6226,18 +6226,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -6213,17 +6213,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -7948,18 +7948,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -7935,17 +7935,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -7237,18 +7237,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned int readl(void const volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -7224,17 +7224,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
 __inline static unsigned int readl(void const volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -7755,18 +7755,6 @@ void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -7742,17 +7742,6 @@ void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -7552,18 +7552,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -7539,17 +7539,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -6753,18 +6753,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -6740,17 +6740,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -6806,18 +6806,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -6793,17 +6793,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -6397,18 +6397,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -6384,17 +6384,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -6383,18 +6383,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -6370,17 +6370,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -7608,18 +7608,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_157(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_159(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_167(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -7595,17 +7595,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_157(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_159(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_167(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -7735,18 +7735,6 @@ static void ldv_ldv_check_final_state_140(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 void ldv_linux_net_rtnetlink_before_ieee80211_unregister_hw(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -7722,17 +7722,6 @@ static void ldv_ldv_check_final_state_140(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 void ldv_linux_net_rtnetlink_before_ieee80211_unregister_hw(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -9126,18 +9126,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -9112,17 +9112,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const * , void const * , size_t ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -4493,18 +4493,6 @@ static void ldv_ldv_check_final_state_129(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static __u64 __fswab64(__u64 val ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -4481,17 +4481,6 @@ static void ldv_ldv_check_final_state_129(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static __u64 __fswab64(__u64 val )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -5796,18 +5796,6 @@ static void ldv_ldv_check_final_state_117(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -5784,17 +5784,6 @@ static void ldv_ldv_check_final_state_117(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 extern int printk(char const * , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -6427,18 +6427,6 @@ static void ldv_ldv_check_final_state_118(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -6415,17 +6415,6 @@ static void ldv_ldv_check_final_state_118(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -5548,18 +5548,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern int sprintf(char * , char const   *  , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -5536,17 +5536,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern int sprintf(char * , char const * , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -8874,18 +8874,6 @@ int ldv_register_class(void)
 }
 void *ldv_err_ptr(long error ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int variable_test_bit(long nr , unsigned long const volatile   *addr ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -8861,17 +8861,6 @@ int ldv_register_class(void)
 }
 void *ldv_err_ptr(long error ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int variable_test_bit(long nr , unsigned long const volatile *addr )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -6608,18 +6608,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void print_hex_dump(char const   * , char const   * , int  , int  , int  ,
                            void const   * , size_t  , bool  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -6596,17 +6596,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const * , ...) ;
 extern void print_hex_dump(char const * , char const * , int , int , int ,
                            void const * , size_t , bool ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -5776,18 +5776,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -5764,17 +5764,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -5539,18 +5539,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_int_mtx_of_NOT_ARG_SIGN(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -5527,17 +5527,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_int_mtx_of_NOT_ARG_SIGN(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -6520,18 +6520,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -6508,17 +6508,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -7105,18 +7105,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -7093,17 +7093,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile *addr )

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -8395,18 +8395,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_185(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -8382,17 +8382,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_185(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -10344,18 +10344,6 @@ static void ldv_ldv_check_final_state_212(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -10331,17 +10331,6 @@ static void ldv_ldv_check_final_state_212(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -5134,18 +5134,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -5122,17 +5122,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -5005,18 +5005,6 @@ int ldv_register_class(void)
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -4993,17 +4993,6 @@ int ldv_register_class(void)
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int test_and_set_bit(long nr , unsigned long volatile *addr )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -6851,18 +6851,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 unsigned int oz_dbg_mask ;
 void oz_apps_init(void) ;
 void oz_apps_term(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -6837,17 +6837,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 unsigned int oz_dbg_mask ;
 void oz_apps_init(void) ;
 void oz_apps_term(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -4161,18 +4161,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_135(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -4149,17 +4149,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_135(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -4316,18 +4316,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device  const  * , char const   * 
                               , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -4303,17 +4303,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device const * , char const *
                               , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -4332,18 +4332,6 @@ static void ldv_ldv_check_final_state_144(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device  const  * , char const   * 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -4319,17 +4319,6 @@ static void ldv_ldv_check_final_state_144(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device const * , char const *

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -4293,18 +4293,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void __dynamic_pr_debug(struct _ddebug * , char const   *  , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -4280,17 +4280,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const * , ...) ;
 extern void __dynamic_pr_debug(struct _ddebug * , char const * , ...) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -4336,18 +4336,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -4323,17 +4323,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -4144,18 +4144,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -4132,17 +4132,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -4143,18 +4143,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -4131,17 +4131,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -4328,18 +4328,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -4316,17 +4316,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -4126,18 +4126,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_111(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_113(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -4114,17 +4114,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_111(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_113(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -5103,18 +5103,6 @@ static void ldv_ldv_check_final_state_124(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static int ffs(int x ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -5090,17 +5090,6 @@ static void ldv_ldv_check_final_state_124(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static int ffs(int x )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -4590,18 +4590,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -4578,17 +4578,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -4831,18 +4831,6 @@ static void ldv_ldv_check_final_state_119(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -4819,17 +4819,6 @@ static void ldv_ldv_check_final_state_119(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -4780,18 +4780,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_fb_info(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_lock_of_fb_info(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -4768,17 +4768,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_fb_info(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_lock_of_fb_info(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -4113,18 +4113,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -4101,17 +4101,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -4509,18 +4509,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -4497,17 +4497,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile *addr )
 {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -6997,18 +6997,6 @@ int ldv_filter_err_code(int ret_val ) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_92(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_i_mutex_of_inode(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_i_mutex_of_inode(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -6984,17 +6984,6 @@ int ldv_filter_err_code(int ret_val ) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_92(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_i_mutex_of_inode(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_i_mutex_of_inode(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -7960,18 +7960,6 @@ static void ldv_ldv_check_final_state_132(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 struct nfs_rpc_ops  const  nfs_v2_clientops ;
 struct rpc_version  const  nfs_version2 ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -7947,17 +7947,6 @@ static void ldv_ldv_check_final_state_132(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 struct nfs_rpc_ops const nfs_v2_clientops ;
 struct rpc_version const nfs_version2 ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -4384,18 +4384,6 @@ int ldv_register_class(void)
 void ldv_linux_usb_dev_atomic_dec(atomic_t *v ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int constant_test_bit(long nr , unsigned long const volatile   *addr ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -4372,17 +4372,6 @@ int ldv_register_class(void)
 void ldv_linux_usb_dev_atomic_dec(atomic_t *v ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int constant_test_bit(long nr , unsigned long const volatile *addr )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -3543,18 +3543,6 @@ static void ldv_ldv_check_final_state_87(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_83(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_torture_mutex(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_torture_mutex(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -3532,17 +3532,6 @@ static void ldv_ldv_check_final_state_87(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_83(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_torture_mutex(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_torture_mutex(struct mutex *lock ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -6905,18 +6905,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 extern unsigned long this_cpu_off ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -6892,17 +6892,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 extern unsigned long this_cpu_off ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -6974,18 +6974,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -6961,17 +6961,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -6954,18 +6954,6 @@ static void ldv_ldv_check_final_state_159(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_unlock(void) ;
 void ldv_linux_net_sock_before_release_sock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -6941,17 +6941,6 @@ static void ldv_ldv_check_final_state_159(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_unlock(void) ;
 void ldv_linux_net_sock_before_release_sock(void) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -4243,18 +4243,6 @@ static void ldv_ldv_check_final_state_113(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -4231,17 +4231,6 @@ static void ldv_ldv_check_final_state_113(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -4485,18 +4485,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 static void ldv_ldv_check_final_state_105(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -4473,17 +4473,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 static void ldv_ldv_check_final_state_105(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -5313,18 +5313,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -5300,17 +5300,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags )
-{
-  void *tmp ;
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -4152,18 +4152,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_139(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -7322,18 +7322,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_136(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_141(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -5400,18 +5400,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 void ldv_linux_block_request_put_blk_rq(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -5320,18 +5320,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -4353,18 +4353,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -4752,18 +4752,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u32 __fswab32(__u32 val ) 
 { 
   int tmp ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -5160,18 +5160,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 struct request_queue *ldv_linux_block_queue_request_queue(void) ;
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -4587,18 +4587,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) ;
 struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) ;
 void ldv_linux_block_request_put_blk_rq(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -4752,18 +4752,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_123(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4251,18 +4251,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -4503,18 +4503,6 @@ int ldv_linux_usb_dev_atomic_add_return(int i , atomic_t *v ) ;
 void ldv_linux_kernel_sched_completion_init_completion_done_of_fw_card(void) ;
 void ldv_linux_kernel_sched_completion_wait_for_completion_done_of_fw_card(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -6132,18 +6132,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device  const  *dev ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -6367,18 +6367,6 @@ static void ldv_ldv_check_final_state_114(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void *dev_get_drvdata(struct device  const  *dev ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -4287,18 +4287,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_sync_of_wiimote_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_sync_of_wiimote_state(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -5071,18 +5071,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_116(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_hid_open_mut(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4012,18 +4012,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4216,18 +4216,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -5382,18 +5382,6 @@ static void ldv_ldv_check_final_state_101(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -4523,18 +4523,6 @@ static void ldv_ldv_check_final_state_143(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -6403,18 +6403,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_146(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -4386,18 +4386,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -4394,18 +4394,6 @@ static void ldv_ldv_check_final_state_110(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static int ldv_mutex_lock_interruptible_99(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_101(struct mutex *ldv_func_arg1 ) ;
 int ldv_linux_kernel_locking_mutex_mutex_lock_interruptible_or_killable_sysfs_mutex_of_elants_data(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -4316,18 +4316,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_mutex_of_input_dev(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -5104,18 +5104,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 static int ldv_mutex_lock_interruptible_96(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -7018,18 +7018,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4108,18 +4108,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7739,18 +7739,6 @@ static void ldv_ldv_check_final_state_127(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_121(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_fe_lock_of_mxl111sf_state(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -5673,18 +5673,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -7489,18 +7489,6 @@ static void ldv_ldv_check_final_state_142(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_121(struct mutex *ldv_func_arg1 ) ;
 static int ldv_mutex_lock_interruptible_127(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -6358,18 +6358,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_uvc_device(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -4555,18 +4555,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -4500,18 +4500,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -5014,18 +5014,6 @@ static void ldv_ldv_check_final_state_122(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_104(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -4729,18 +4729,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_ts_ctxlock_of_gru_thread_state(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -3996,18 +3996,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_95(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4546,18 +4546,6 @@ static void ldv_ldv_check_final_state_121(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_100(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -3942,18 +3942,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_86(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_88(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_91(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -4990,18 +4990,6 @@ void *ldv_err_ptr(long error ) ;
 long ldv_ptr_err(void const   *ptr ) ;
 void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static __u16 __fswab16(__u16 val ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -6646,18 +6646,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -6459,18 +6459,6 @@ static void ldv_ldv_check_final_state_134(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_cpu_ops pv_cpu_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6273,18 +6273,6 @@ static void ldv_ldv_check_final_state_172(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -7118,18 +7118,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 int ldv_linux_net_rtnetlink_rtnl_is_locked(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7199,18 +7199,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -7686,18 +7686,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -7620,18 +7620,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6257,18 +6257,6 @@ static void ldv_ldv_check_final_state_150(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6043,18 +6043,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6226,18 +6226,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_134(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -7948,18 +7948,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7237,18 +7237,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 __inline static unsigned int readl(void const volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -7755,18 +7755,6 @@ void *ldv_kzalloc(size_t size , gfp_t flags ) ;
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -7552,18 +7552,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -6753,18 +6753,6 @@ static void ldv_ldv_check_final_state_152(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -6806,18 +6806,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -6397,18 +6397,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_unlock(void) ;
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -6383,18 +6383,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -7608,18 +7608,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_157(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_159(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_167(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7735,18 +7735,6 @@ static void ldv_ldv_check_final_state_140(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_net_rtnetlink_past_rtnl_lock(void) ;
 void ldv_linux_net_rtnetlink_past_rtnl_unlock(void) ;
 void ldv_linux_net_rtnetlink_before_ieee80211_unregister_hw(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -9126,18 +9126,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void __bad_percpu_size(void) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -4493,18 +4493,6 @@ static void ldv_ldv_check_final_state_129(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static __u64 __fswab64(__u64 val ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -5796,18 +5796,6 @@ static void ldv_ldv_check_final_state_117(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 extern int printk(char const   *  , ...) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -6427,18 +6427,6 @@ static void ldv_ldv_check_final_state_118(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_103(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_105(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -5548,18 +5548,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern int sprintf(char * , char const   *  , ...) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -8874,18 +8874,6 @@ int ldv_register_class(void)
 }
 void *ldv_err_ptr(long error ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int variable_test_bit(long nr , unsigned long const volatile   *addr ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -6608,18 +6608,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern int printk(char const   *  , ...) ;
 extern void print_hex_dump(char const   * , char const   * , int  , int  , int  ,
                            void const   * , size_t  , bool  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -5776,18 +5776,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -5539,18 +5539,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_int_mtx_of_NOT_ARG_SIGN(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -6520,18 +6520,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -7105,18 +7105,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern struct pv_irq_ops pv_irq_ops ;
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -8395,18 +8395,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_185(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_aen_queue_lock_of_pmcraid_instance(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -10344,18 +10344,6 @@ static void ldv_ldv_check_final_state_212(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -5134,18 +5134,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_module_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -5005,18 +5005,6 @@ int ldv_register_class(void)
 void *ldv_linux_arch_io_io_mem_remap(void) ;
 void ldv_linux_arch_io_io_mem_unmap(void) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int test_and_set_bit(long nr , unsigned long volatile   *addr ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -6851,18 +6851,6 @@ static void ldv_ldv_check_final_state_123(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 unsigned int oz_dbg_mask ;
 void oz_apps_init(void) ;
 void oz_apps_term(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -4161,18 +4161,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_130(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_131(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_135(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -4316,18 +4316,6 @@ static void ldv_ldv_check_final_state_147(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device  const  * , char const   * 
                               , ...) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -4332,18 +4332,6 @@ static void ldv_ldv_check_final_state_144(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void __dynamic_dev_dbg(struct _ddebug * , struct device  const  * , char const   * 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -4293,18 +4293,6 @@ static void ldv_ldv_check_final_state_151(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void __dynamic_pr_debug(struct _ddebug * , char const   *  , ...) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4336,18 +4336,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_94(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_96(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_102(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -4144,18 +4144,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_110(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -4143,18 +4143,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_106(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_125(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -4328,18 +4328,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_read_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_read_unlock(void) ;
 extern struct module __this_module ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -4126,18 +4126,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_109(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_111(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_113(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -5103,18 +5103,6 @@ static void ldv_ldv_check_final_state_124(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static int ffs(int x ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -4590,18 +4590,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 int ldv_linux_kernel_module_try_module_get(struct module *module ) ;
 void ldv_linux_kernel_module_module_put(struct module *module ) ;
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -4831,18 +4831,6 @@ static void ldv_ldv_check_final_state_119(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_108(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -4780,18 +4780,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_lock_of_fb_info(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_lock_of_fb_info(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4113,18 +4113,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_98(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_114(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_118(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4509,18 +4509,6 @@ void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 __inline static void set_bit(long nr , unsigned long volatile   *addr ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -6997,18 +6997,6 @@ int ldv_filter_err_code(int ret_val ) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_92(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_i_mutex_of_inode(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_i_mutex_of_inode(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7960,18 +7960,6 @@ static void ldv_ldv_check_final_state_132(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 extern struct module __this_module ;
 struct nfs_rpc_ops  const  nfs_v2_clientops ;
 struct rpc_version  const  nfs_version2 ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4384,18 +4384,6 @@ int ldv_register_class(void)
 void ldv_linux_usb_dev_atomic_dec(atomic_t *v ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 __inline static int constant_test_bit(long nr , unsigned long const volatile   *addr ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -3543,18 +3543,6 @@ static void ldv_ldv_check_final_state_87(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
 extern void ldv_after_alloc(void * ) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_83(struct mutex *ldv_func_arg1 ) ;
 void ldv_linux_kernel_locking_mutex_mutex_lock_torture_mutex(struct mutex *lock ) ;
 void ldv_linux_kernel_locking_mutex_mutex_unlock_torture_mutex(struct mutex *lock ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -6905,18 +6905,6 @@ int ldv_register_class(void)
 }
 }
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 extern unsigned long this_cpu_off ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -6974,18 +6974,6 @@ static void ldv_ldv_check_final_state_160(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_lock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_bh_rcu_read_unlock_bh(void) ;
 void ldv_linux_kernel_rcu_update_lock_rcu_read_lock(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6954,18 +6954,6 @@ static void ldv_ldv_check_final_state_159(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 void ldv_linux_kernel_locking_rwlock_write_lock(void) ;
 void ldv_linux_kernel_locking_rwlock_write_unlock(void) ;
 void ldv_linux_net_sock_before_release_sock(void) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -4243,18 +4243,6 @@ static void ldv_ldv_check_final_state_113(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4485,18 +4485,6 @@ static void ldv_ldv_check_final_state_104(void) ;
 static void ldv_ldv_check_final_state_105(void) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_97(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_99(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_101(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -5313,18 +5313,6 @@ static void ldv_ldv_check_final_state_169(void) ;
 void ldv_free(void *s ) ;
 void *ldv_xmalloc(size_t size ) ;
 void *ldv_malloc_unknown_size(void) ;
-void *ldv_alloc_macro(gfp_t flags ) 
-{ 
-  void *tmp ;
-
-  {
-  {
-  ldv_check_alloc_flags(flags);
-  tmp = ldv_malloc_unknown_size();
-  }
-  return (tmp);
-}
-}
 static void ldv_mutex_lock_122(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_126(struct mutex *ldv_func_arg1 ) ;
 static void ldv_mutex_lock_132(struct mutex *ldv_func_arg1 ) ;


### PR DESCRIPTION
Removes one of the uses of external_alloc, which is implemented using
__VERIFIER_nondet_pointer. As ldv_alloc_macro is never actually called,
removing the definition is sufficient to get rid of this particular use of
__VERIFIER_nondet_pointer.

The changes were done using the following command:
```
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^void \*ldv_alloc_macro\(gfp_t flags \)/) {
       if(/;$/) { $p = 1; } else { $p = 2; }
     }
     elsif($p == 2 || $p == 3) { if(/^\}$/) { $p++; } }
     else { print; }
   }' \
  c/ldv-*/*.[ci]
```
