### PR TITLE
Implement ldv_alloc_urb using ldv_malloc

### DIFF
--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.c
@@ -7217,7 +7217,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.i
@@ -6882,7 +6882,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.c
@@ -5245,7 +5245,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.i
@@ -5091,7 +5091,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.c
@@ -6213,7 +6213,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.i
@@ -5923,7 +5923,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
@@ -13197,7 +13197,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
@@ -12448,7 +12448,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.c
@@ -7620,7 +7620,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.i
@@ -7386,7 +7386,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.c
@@ -9009,7 +9009,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
@@ -8622,7 +8622,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.c
@@ -8110,7 +8110,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.i
@@ -7753,7 +7753,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
@@ -26345,7 +26345,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -25039,7 +25039,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.c
@@ -14803,7 +14803,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
@@ -14213,7 +14213,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.c
@@ -9636,7 +9636,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
@@ -9125,7 +9125,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
@@ -9986,7 +9986,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
@@ -9477,7 +9477,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.c
@@ -9956,7 +9956,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
@@ -9581,7 +9581,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.c
@@ -8868,7 +8868,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.i
@@ -8480,7 +8480,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.c
@@ -14174,7 +14174,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
@@ -13449,7 +13449,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.c
@@ -9700,7 +9700,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.i
@@ -9386,7 +9386,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.c
@@ -14471,7 +14471,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.i
@@ -13636,7 +13636,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.c
@@ -6666,28 +6666,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void) 
-{ 
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-
-    }
-  } else {
-
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
@@ -6452,25 +6452,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void)
-{
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-    }
-  } else {
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.c
@@ -7342,7 +7342,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
@@ -7142,7 +7142,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.c
@@ -7595,7 +7595,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.i
@@ -7377,7 +7377,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.c
@@ -7331,7 +7331,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.i
@@ -7138,7 +7138,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.c
@@ -7012,6 +7012,7 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void) 
 { 
   struct urb *value ;
@@ -7019,7 +7020,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.i
@@ -6839,13 +6839,14 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void)
 {
   struct urb *value ;
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.c
@@ -6778,7 +6778,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.i
@@ -6610,7 +6610,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.c
@@ -9629,7 +9629,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.i
@@ -9161,7 +9161,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.c
@@ -8529,7 +8529,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.i
@@ -8270,7 +8270,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.c
@@ -9285,7 +9285,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.i
@@ -9016,7 +9016,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.c
@@ -8740,7 +8740,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.i
@@ -8464,7 +8464,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.c
@@ -21125,6 +21125,7 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void) 
 { 
   struct urb *value ;
@@ -21132,7 +21133,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.i
@@ -19985,13 +19985,14 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void)
 {
   struct urb *value ;
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.c
@@ -7250,28 +7250,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void) 
-{ 
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-
-    }
-  } else {
-
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.i
@@ -7152,25 +7152,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void)
-{
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-    }
-  } else {
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.c
@@ -11649,7 +11649,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
@@ -11119,7 +11119,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.c
@@ -3802,28 +3802,7 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void) 
-{ 
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-
-    }
-  } else {
-
-  }
-  return (usb_urb);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.i
@@ -3743,25 +3743,7 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void)
-{
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-    }
-  } else {
-  }
-  return (usb_urb);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.c
@@ -5428,7 +5428,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.i
@@ -5241,7 +5241,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.c
@@ -5187,7 +5187,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.i
@@ -5023,7 +5023,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -7679,7 +7679,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -7289,7 +7289,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.c
@@ -4497,28 +4497,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void) 
-{ 
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-
-    }
-  } else {
-
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.i
@@ -4375,25 +4375,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void)
-{
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-    }
-  } else {
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.c
@@ -9888,7 +9888,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
@@ -9248,7 +9248,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.c
@@ -4951,28 +4951,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void) 
-{ 
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-
-    }
-  } else {
-
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.i
@@ -4831,25 +4831,6 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
-struct urb *ldv_alloc_urb(void)
-{
-  struct urb *value ;
-  void *tmp ;
-  int tmp___0 ;
-  {
-  tmp = ldv_undef_ptr();
-  value = tmp;
-  tmp___0 = ldv_undef_int();
-  if (tmp___0) {
-    if ((unsigned long )value != (unsigned long )((struct urb *)0)) {
-      usb_urb = value;
-    } else {
-    }
-  } else {
-  }
-  return (usb_urb);
-}
-}
 void ldv_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
@@ -8562,7 +8562,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
@@ -8162,7 +8162,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -6751,6 +6751,7 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void) 
 { 
   struct urb *value ;
@@ -6758,7 +6759,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -6581,13 +6581,14 @@ void ldv_usb_put_intf(void)
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_alloc_urb(void)
 {
   struct urb *value ;
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -8598,7 +8598,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -8187,7 +8187,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -18873,7 +18873,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -17297,7 +17297,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -4185,7 +4185,7 @@ struct urb *ldv_alloc_urb(void)
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -4086,7 +4086,7 @@ struct urb *ldv_alloc_urb(void)
   void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   value = (struct urb *)tmp;
   tmp___0 = ldv_undef_int();
   if (tmp___0 != 0) {


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct urb)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct urb \*ldv_alloc_urb\(void\) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct urb));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
