### PR TITLE
Implement ldv_interface_to_usbdev using ldv_malloc

### DIFF
--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.c
@@ -7315,7 +7315,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point.cil.out.i
@@ -6962,7 +6962,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.c
@@ -5343,7 +5343,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point.cil.out.i
@@ -5171,7 +5171,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.c
@@ -6311,7 +6311,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point.cil.out.i
@@ -6003,7 +6003,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
@@ -13295,7 +13295,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
@@ -12528,7 +12528,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.c
@@ -7718,7 +7718,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--gigaset--usb_gigaset.ko-entry_point.cil.out.i
@@ -7466,7 +7466,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.c
@@ -9107,7 +9107,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--isdn--hisax--hisax_st5481.ko-entry_point.cil.out.i
@@ -8702,7 +8702,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.c
@@ -8208,7 +8208,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point.cil.out.i
@@ -7833,7 +7833,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
@@ -26443,7 +26443,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -25119,7 +25119,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.c
@@ -14901,7 +14901,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--dvb-usb--dvb-usb-dib0700.ko-entry_point.cil.out.i
@@ -14293,7 +14293,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.c
@@ -9734,7 +9734,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
@@ -9205,7 +9205,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
@@ -10084,7 +10084,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
@@ -9557,7 +9557,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.c
@@ -10054,7 +10054,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stk1160--stk1160.ko-entry_point.cil.out.i
@@ -9661,7 +9661,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.c
@@ -8966,7 +8966,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--stkwebcam--stkwebcam.ko-entry_point.cil.out.i
@@ -8560,7 +8560,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.c
@@ -14272,7 +14272,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
@@ -13529,7 +13529,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.c
@@ -9798,7 +9798,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point.cil.out.i
@@ -9466,7 +9466,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.c
@@ -14569,7 +14569,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--usbvision--usbvision.ko-entry_point.cil.out.i
@@ -13716,7 +13716,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.c
@@ -6765,22 +6765,6 @@ int ldv_submit_urb(struct urb *urb )
   return (res);
 }
 }
-struct usb_device *ldv_interface_to_usbdev(void) 
-{ 
-  void *result ;
-  void *tmp ;
-
-  {
-  tmp = ldv_undef_ptr();
-  result = tmp;
-  if ((unsigned long )result != (unsigned long )((void *)0)) {
-
-  } else {
-    ldv_stop___0();
-  }
-  return (result);
-}
-}
 struct usb_device *ldv_get_dev(struct usb_device *data ) 
 { 
   int tmp ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--arcnet--com90xx.ko-entry_point.cil.out.i
@@ -6533,20 +6533,6 @@ int ldv_submit_urb(struct urb *urb )
   return (res);
 }
 }
-struct usb_device *ldv_interface_to_usbdev(void)
-{
-  void *result ;
-  void *tmp ;
-  {
-  tmp = ldv_undef_ptr();
-  result = tmp;
-  if ((unsigned long )result != (unsigned long )((void *)0)) {
-  } else {
-    ldv_stop___0();
-  }
-  return (result);
-}
-}
 struct usb_device *ldv_get_dev(struct usb_device *data )
 {
   int tmp ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.c
@@ -7440,7 +7440,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--ems_usb.ko-entry_point.cil.out.i
@@ -7222,7 +7222,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.c
@@ -7693,7 +7693,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--esd_usb2.ko-entry_point.cil.out.i
@@ -7457,7 +7457,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.c
@@ -7429,7 +7429,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--can--usb--usb_8dev.ko-entry_point.cil.out.i
@@ -7218,7 +7218,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.c
@@ -7117,7 +7117,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--cdc_mbim.ko-entry_point.cil.out.i
@@ -6925,7 +6925,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.c
@@ -6876,7 +6876,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--ipheth.ko-entry_point.cil.out.i
@@ -6690,7 +6690,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.c
@@ -9727,7 +9727,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--usb--smsc95xx.ko-entry_point.cil.out.i
@@ -9241,7 +9241,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.c
@@ -8627,7 +8627,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--libertas--usb8xxx.ko-entry_point.cil.out.i
@@ -8350,7 +8350,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.c
@@ -9383,7 +9383,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--mwifiex--mwifiex_usb.ko-entry_point.cil.out.i
@@ -9096,7 +9096,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.c
@@ -8838,7 +8838,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--p54--p54usb.ko-entry_point.cil.out.i
@@ -8544,7 +8544,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.c
@@ -21230,7 +21230,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--rtlwifi--rtl8192se--rtl8192se.ko-entry_point.cil.out.i
@@ -20071,7 +20071,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.c
@@ -7349,22 +7349,6 @@ int ldv_submit_urb(struct urb *urb )
   return (res);
 }
 }
-struct usb_device *ldv_interface_to_usbdev(void) 
-{ 
-  void *result ;
-  void *tmp ;
-
-  {
-  tmp = ldv_undef_ptr();
-  result = tmp;
-  if ((unsigned long )result != (unsigned long )((void *)0)) {
-
-  } else {
-    ldv_stop___0();
-  }
-  return (result);
-}
-}
 struct usb_device *ldv_get_dev(struct usb_device *data ) 
 { 
   int tmp ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--net--wireless--ti--wlcore--wlcore_spi.ko-entry_point.cil.out.i
@@ -7233,20 +7233,6 @@ int ldv_submit_urb(struct urb *urb )
   return (res);
 }
 }
-struct usb_device *ldv_interface_to_usbdev(void)
-{
-  void *result ;
-  void *tmp ;
-  {
-  tmp = ldv_undef_ptr();
-  result = tmp;
-  if ((unsigned long )result != (unsigned long )((void *)0)) {
-  } else {
-    ldv_stop___0();
-  }
-  return (result);
-}
-}
 struct usb_device *ldv_get_dev(struct usb_device *data )
 {
   int tmp ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.c
@@ -11747,7 +11747,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
@@ -11199,7 +11199,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.c
@@ -3907,7 +3907,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--go7007--go7007-loader.ko-entry_point.cil.out.i
@@ -3829,7 +3829,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.c
@@ -5526,7 +5526,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_imon.ko-entry_point.cil.out.i
@@ -5321,7 +5321,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.c
@@ -5285,7 +5285,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--media--lirc--lirc_sasem.ko-entry_point.cil.out.i
@@ -5103,7 +5103,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -7777,7 +7777,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -7369,7 +7369,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.c
@@ -4602,7 +4602,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--misc--idmouse.ko-entry_point.cil.out.i
@@ -4461,7 +4461,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.c
@@ -9986,7 +9986,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--serial--usbserial.ko-entry_point.cil.out.i
@@ -9328,7 +9328,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.c
@@ -5056,7 +5056,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--usb--wusbcore--wusb-cbaf.ko-entry_point.cil.out.i
@@ -4917,7 +4917,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result != (unsigned long )((void *)0)) {
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
@@ -8660,7 +8660,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_2a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
@@ -8242,7 +8242,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -6856,7 +6856,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-47dffc7-1-144_2a-drivers--net--usb--cdc-phonet.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -6667,7 +6667,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -8696,7 +8696,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_2a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -8267,7 +8267,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -18971,7 +18971,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -17377,7 +17377,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -4283,7 +4283,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -4166,7 +4166,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   void *result ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct usb_device));
   result = tmp;
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     ldv_stop();


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct
usb_device)), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct usb_device \*ldv_interface_to_usbdev\(void\) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct usb_device));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
