### PR TITLE
Implement ldv_linux_block_genhd_alloc_disk using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7871,26 +7871,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -14119,26 +14119,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -13493,24 +13493,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -16348,6 +16348,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -16355,7 +16356,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -18045,7 +18046,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -15419,13 +15419,14 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 {
   struct gendisk *res ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -16881,7 +16882,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -20488,7 +20488,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -19134,7 +19134,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -7529,6 +7529,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -7536,7 +7537,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -9232,7 +9233,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -7209,13 +7209,14 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 {
   struct gendisk *res ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -8677,7 +8678,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -14673,7 +14673,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -13753,7 +13753,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -19242,7 +19242,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -18070,7 +18070,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -8691,7 +8691,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -8345,7 +8345,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -11103,7 +11103,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -10495,7 +10495,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -14394,26 +14394,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -13506,24 +13506,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -20440,26 +20440,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -19013,24 +19013,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -20658,26 +20658,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -19321,24 +19321,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -26012,26 +26012,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -24202,24 +24202,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -28435,26 +28435,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -26513,24 +26513,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -16187,26 +16187,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -15142,24 +15142,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -8374,26 +8374,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -7954,24 +7954,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -15518,26 +15518,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -14623,24 +14623,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -32658,7 +32658,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -30231,7 +30231,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -9801,26 +9801,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -9273,24 +9273,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -18827,7 +18827,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -17799,7 +17799,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -9941,26 +9941,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -9435,24 +9435,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -8621,26 +8621,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -8239,24 +8239,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -11836,26 +11836,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -11116,24 +11116,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -27514,7 +27514,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -25604,7 +25604,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -30132,26 +30132,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -27904,24 +27904,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -8073,26 +8073,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -7715,24 +7715,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -17450,26 +17450,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -16570,24 +16570,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -12917,26 +12917,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -12206,24 +12206,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -11834,26 +11834,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -11445,24 +11445,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -25091,26 +25091,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -23289,24 +23289,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -10741,7 +10741,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -10107,7 +10107,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -8539,7 +8539,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -8158,7 +8158,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -20891,26 +20891,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -19541,24 +19541,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -34039,26 +34039,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -31365,24 +31365,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -14906,26 +14906,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -13886,24 +13886,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -11905,26 +11905,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -11241,24 +11241,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -7682,26 +7682,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -7303,24 +7303,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -36495,7 +36495,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -33956,7 +33956,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -11670,26 +11670,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -11175,24 +11175,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -11679,26 +11679,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -11284,24 +11284,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -12110,26 +12110,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -11590,24 +11590,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -17160,26 +17160,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -16208,24 +16208,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -16929,26 +16929,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -16061,24 +16061,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -47724,26 +47724,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -44196,24 +44196,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -24765,26 +24765,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -23293,24 +23293,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -11783,26 +11783,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -11273,24 +11273,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -11359,26 +11359,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -10827,24 +10827,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -11644,26 +11644,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -11141,24 +11141,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -23178,26 +23178,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -21821,24 +21821,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -18089,26 +18089,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -17189,24 +17189,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -30125,26 +30125,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -28174,24 +28174,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -26242,26 +26242,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -24461,24 +24461,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -12524,26 +12524,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -12019,24 +12019,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -14971,26 +14971,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -14199,24 +14199,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -18295,26 +18295,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -17153,24 +17153,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -10953,26 +10953,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -10538,24 +10538,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -14649,26 +14649,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -14016,24 +14016,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -20552,26 +20552,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -19535,24 +19535,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -37978,26 +37978,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -35787,24 +35787,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -8306,26 +8306,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -7963,24 +7963,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -21640,6 +21640,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -21647,7 +21648,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -23341,7 +23342,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -20338,13 +20338,14 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 {
   struct gendisk *res ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -21804,7 +21805,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -25706,7 +25706,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -24009,7 +24009,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -18978,7 +18978,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -17917,7 +17917,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -31238,7 +31238,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -29410,7 +29410,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -26208,6 +26208,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -26215,7 +26216,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -27908,7 +27909,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -24486,13 +24486,14 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 {
   struct gendisk *res ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -25951,7 +25952,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -24582,7 +24582,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -22908,7 +22908,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -15426,7 +15426,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -14579,7 +14579,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -21714,7 +21714,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -20339,7 +20339,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -40245,7 +40245,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -37495,7 +37495,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -20179,7 +20179,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -19135,7 +19135,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -71010,7 +71010,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -65783,7 +65783,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -18476,7 +18476,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -17327,7 +17327,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -23721,26 +23721,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -21980,24 +21980,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -22649,26 +22649,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -21127,24 +21127,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -8666,26 +8666,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -8227,24 +8227,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -11748,26 +11748,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -11028,24 +11028,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -11822,26 +11822,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -11089,24 +11089,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -11275,26 +11275,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -10616,24 +10616,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -13828,26 +13828,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -12963,24 +12963,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -7617,26 +7617,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -7270,24 +7270,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -7330,26 +7330,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -7003,24 +7003,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -7963,26 +7963,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -7595,24 +7595,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -7002,26 +7002,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -6717,24 +6717,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -25719,26 +25719,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -23996,24 +23996,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -18074,26 +18074,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -16913,24 +16913,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -9383,26 +9383,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -8967,24 +8967,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10687,26 +10687,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -10178,24 +10178,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -8759,26 +8759,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -8310,24 +8310,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -17942,26 +17942,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -16783,24 +16783,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -22564,26 +22564,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -21139,24 +21139,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -32425,26 +32425,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -30281,24 +30281,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -14902,26 +14902,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -14038,24 +14038,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -6934,26 +6934,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -6561,24 +6561,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -28469,26 +28469,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -26551,24 +26551,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -11386,26 +11386,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -10949,24 +10949,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -22476,26 +22476,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -21073,24 +21073,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -12192,26 +12192,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -11388,24 +11388,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -11396,26 +11396,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -10684,24 +10684,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -32874,26 +32874,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -30419,24 +30419,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state = 0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
-{
-  struct gendisk *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void)
 {
   {

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7871,26 +7871,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -14119,26 +14119,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -16348,6 +16348,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -16355,7 +16356,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -18045,7 +18046,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -20488,7 +20488,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -7529,6 +7529,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -7536,7 +7537,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -9232,7 +9233,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -14673,7 +14673,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -19242,7 +19242,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -8691,7 +8691,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -11103,7 +11103,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14394,26 +14394,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -20440,26 +20440,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -20658,26 +20658,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -26012,26 +26012,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -28435,26 +28435,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 
@@ -30136,7 +30117,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -16187,26 +16187,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8374,26 +8374,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 
@@ -10076,7 +10057,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15518,26 +15518,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -32658,7 +32658,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -9801,26 +9801,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -18827,7 +18827,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -9941,26 +9941,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -8621,26 +8621,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -11836,26 +11836,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -27514,7 +27514,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -30132,26 +30132,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8073,26 +8073,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17450,26 +17450,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -12917,26 +12917,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -11834,26 +11834,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -25091,26 +25091,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -10741,7 +10741,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -8539,7 +8539,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -20891,26 +20891,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -34039,26 +34039,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14906,26 +14906,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11905,26 +11905,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -7682,26 +7682,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -36495,7 +36495,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -11670,26 +11670,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -11679,26 +11679,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12110,26 +12110,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -17160,26 +17160,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16929,26 +16929,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -47724,26 +47724,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -24765,26 +24765,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11783,26 +11783,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11359,26 +11359,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11644,26 +11644,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -23178,26 +23178,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18089,26 +18089,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -30125,26 +30125,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -26242,26 +26242,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -12524,26 +12524,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -14971,26 +14971,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -18295,26 +18295,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -10953,26 +10953,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -14649,26 +14649,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -20552,26 +20552,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -37978,26 +37978,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -8306,26 +8306,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -21640,6 +21640,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -21647,7 +21648,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -23341,7 +23342,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -25706,7 +25706,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -18978,7 +18978,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -31238,7 +31238,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -26208,6 +26208,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
+void *ldv_malloc(size_t size ) ;
 struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
 { 
   struct gendisk *res ;
@@ -26215,7 +26216,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }
@@ -27908,7 +27909,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -24582,7 +24582,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -15426,7 +15426,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -21714,7 +21714,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -40245,7 +40245,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -20179,7 +20179,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -71010,7 +71010,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -18476,7 +18476,7 @@ struct gendisk *ldv_linux_block_genhd_alloc_disk(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct gendisk));
   res = (struct gendisk *)tmp;
   ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -23721,26 +23721,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -22649,26 +22649,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -8666,26 +8666,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -11748,26 +11748,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 
@@ -13448,7 +13429,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -11822,26 +11822,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -11275,26 +11275,7 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
+void *ldv_malloc(size_t size ) ;
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 
@@ -12975,7 +12956,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *external_allocated_data(void) ;
 extern void *malloc(size_t  ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13828,26 +13828,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -7617,26 +7617,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -7330,26 +7330,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -7963,26 +7963,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -7002,26 +7002,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -25719,26 +25719,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -18074,26 +18074,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -9383,26 +9383,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10687,26 +10687,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8759,26 +8759,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17942,26 +17942,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -22564,26 +22564,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -32425,26 +32425,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14902,26 +14902,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -6934,26 +6934,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -28469,26 +28469,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -11386,26 +11386,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -22476,26 +22476,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -12192,26 +12192,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11396,26 +11396,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -32874,26 +32874,6 @@ void ldv_assert_linux_block_genhd__free_before_allocation(int expr ) ;
 void ldv_assert_linux_block_genhd__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_genhd__use_before_allocation(int expr ) ;
 static int ldv_linux_block_genhd_disk_state  =    0;
-struct gendisk *ldv_linux_block_genhd_alloc_disk(void) 
-{ 
-  struct gendisk *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct gendisk *)tmp;
-  ldv_assert_linux_block_genhd__double_allocation(ldv_linux_block_genhd_disk_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct gendisk *)0)) {
-    ldv_linux_block_genhd_disk_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_genhd_add_disk(void) 
 { 
 


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct gendisk)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct gendisk \*ldv_linux_block_genhd_alloc_disk\(void\) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct gendisk));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
