### PR TITLE
Implement ldv_linux_usb_urb_usb_alloc_urb using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -9466,7 +9466,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -15707,25 +15707,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -14864,23 +14864,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -17957,25 +17957,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -16809,23 +16809,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -22088,25 +22088,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -20516,23 +20516,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -9144,25 +9144,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -8605,23 +8605,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -16276,25 +16276,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -15138,23 +15138,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -20842,25 +20842,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -19452,23 +19452,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -10296,25 +10296,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -9732,23 +9732,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -12706,25 +12706,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -11880,23 +11880,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -15984,25 +15984,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -14879,23 +14879,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -22028,25 +22028,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -20384,23 +20384,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -22248,25 +22248,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -20694,23 +20694,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -27602,25 +27602,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -25575,23 +25575,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -30027,25 +30027,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -27888,23 +27888,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -17778,7 +17778,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -16515,7 +16515,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -9967,25 +9967,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -9330,23 +9330,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -17112,25 +17112,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -16000,23 +16000,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -34259,25 +34259,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -31614,23 +31614,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -11392,25 +11392,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -10647,23 +10647,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -20431,25 +20431,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -19185,23 +19185,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -11536,7 +11536,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -10812,7 +10812,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -10212,25 +10212,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -9613,23 +9613,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -13431,7 +13431,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -12493,7 +12493,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -29116,25 +29116,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -26988,23 +26988,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -31719,25 +31719,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -29274,23 +29274,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -9665,25 +9665,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -9090,23 +9090,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -19043,25 +19043,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -17946,23 +17946,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -14512,7 +14512,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -13583,7 +13583,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -13431,7 +13431,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -12824,7 +12824,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -26685,7 +26685,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -24665,7 +24665,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -12344,25 +12344,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -11492,23 +11492,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -10144,25 +10144,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -9545,23 +9545,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -22479,25 +22479,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -20912,23 +20912,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -35628,25 +35628,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -32737,23 +32737,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -16497,25 +16497,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -15260,23 +15260,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -13498,25 +13498,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -12617,23 +12617,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -9273,25 +9273,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -8677,23 +8677,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -38098,25 +38098,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -35341,23 +35341,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -13261,25 +13261,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -12549,23 +12549,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -13270,25 +13270,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -12658,23 +12658,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -13699,25 +13699,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -12962,23 +12962,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -18747,25 +18747,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -17578,23 +17578,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -18515,25 +18515,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -17430,23 +17430,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -49308,25 +49308,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -45563,23 +45563,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -26351,25 +26351,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -24662,23 +24662,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -13372,25 +13372,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -12645,23 +12645,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -12947,25 +12947,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -12198,23 +12198,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -13233,25 +13233,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -12513,23 +12513,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -24764,25 +24764,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -23190,23 +23190,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -19674,25 +19674,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -18557,23 +18557,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -31710,25 +31710,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -29542,23 +29542,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -27825,25 +27825,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -25827,23 +25827,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -14114,25 +14114,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -13392,23 +13392,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -16560,25 +16560,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -15571,23 +15571,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -19884,25 +19884,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -18525,23 +18525,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -12543,7 +12543,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -11910,7 +11910,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -16240,7 +16240,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -15389,7 +15389,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -22141,25 +22141,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -20907,23 +20907,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -39576,7 +39576,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -37167,7 +37167,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -9903,7 +9903,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -9342,7 +9342,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -23253,25 +23253,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -21732,23 +21732,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -27308,25 +27308,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -25393,23 +25393,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -20580,25 +20580,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -19301,23 +19301,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -32838,25 +32838,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -30792,23 +30792,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -27820,25 +27820,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -25879,23 +25879,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -26183,25 +26183,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -24291,23 +24291,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -17028,25 +17028,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -15963,23 +15963,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -23316,25 +23316,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -21723,23 +21723,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -41846,25 +41846,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -38878,23 +38878,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -21781,25 +21781,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -20519,23 +20519,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -72611,25 +72611,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -67166,23 +67166,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -20080,25 +20080,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -18713,23 +18713,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -25317,7 +25317,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -23358,7 +23358,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -24244,7 +24244,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -22504,7 +22504,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -10261,7 +10261,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -9604,7 +9604,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -13339,25 +13339,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -12402,23 +12402,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -13412,25 +13412,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -12462,23 +12462,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -12866,25 +12866,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -11990,23 +11990,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -15424,7 +15424,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -14341,7 +14341,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -9211,7 +9211,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -8646,7 +8646,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -8925,7 +8925,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -8380,7 +8380,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -9559,7 +9559,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -8973,7 +8973,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -8596,7 +8596,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -8093,7 +8093,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -27315,7 +27315,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -25374,7 +25374,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -19665,25 +19665,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -18287,23 +18287,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -10976,25 +10976,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -10343,23 +10343,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -12278,7 +12278,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -11551,7 +11551,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -10347,25 +10347,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -9681,23 +9681,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -19531,25 +19531,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -18155,23 +18155,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -24152,25 +24152,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -22510,23 +22510,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -34017,25 +34017,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -31656,23 +31656,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -16491,25 +16491,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -15410,23 +15410,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -8526,25 +8526,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -7936,23 +7936,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -30060,25 +30060,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -27925,23 +27925,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -12978,25 +12978,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -12324,23 +12324,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -24063,25 +24063,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -22443,23 +22443,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -13784,25 +13784,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -12763,23 +12763,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -12989,25 +12989,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -12060,23 +12060,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -34464,25 +34464,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -31792,23 +31792,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state = 0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
-{
-  void *arbitrary_memory ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb )
 {
   {

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -9466,7 +9466,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -15707,25 +15707,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -17957,25 +17957,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -22088,25 +22088,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -9144,25 +9144,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -16276,25 +16276,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -20842,25 +20842,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -10296,25 +10296,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -12706,25 +12706,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15984,25 +15984,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -22028,25 +22028,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -22248,25 +22248,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -27602,25 +27602,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -30028,25 +30028,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -17778,7 +17778,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -9968,25 +9968,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17112,25 +17112,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -34259,25 +34259,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -11392,25 +11392,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -20431,25 +20431,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -11536,7 +11536,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -10212,25 +10212,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -13431,7 +13431,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -29116,25 +29116,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -31719,25 +31719,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -9665,25 +9665,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -19043,25 +19043,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -14512,7 +14512,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -13431,7 +13431,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -26685,7 +26685,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -12344,25 +12344,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -10144,25 +10144,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -22479,25 +22479,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -35628,25 +35628,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16497,25 +16497,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13498,25 +13498,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -9273,25 +9273,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -38098,25 +38098,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -13261,25 +13261,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -13270,25 +13270,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13699,25 +13699,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -18747,25 +18747,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18515,25 +18515,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -49308,25 +49308,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -26351,25 +26351,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13372,25 +13372,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12947,25 +12947,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13233,25 +13233,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -24764,25 +24764,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -19674,25 +19674,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -31710,25 +31710,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -27825,25 +27825,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -14114,25 +14114,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -16560,25 +16560,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -19884,25 +19884,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -12543,7 +12543,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -16240,7 +16240,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -22141,25 +22141,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -39576,7 +39576,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -9903,7 +9903,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -23253,25 +23253,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -27308,25 +27308,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -20580,25 +20580,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -32838,25 +32838,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -27820,25 +27820,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -26183,25 +26183,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -17028,25 +17028,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -23316,25 +23316,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -41846,25 +41846,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -21781,25 +21781,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -72611,25 +72611,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -20080,25 +20080,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -25317,7 +25317,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -24244,7 +24244,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -10261,7 +10261,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -13340,25 +13340,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -13412,25 +13412,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -12874,7 +12874,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15424,7 +15424,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -9211,7 +9211,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -8925,7 +8925,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -9559,7 +9559,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -8596,7 +8596,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -27315,7 +27315,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -19665,25 +19665,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -10976,25 +10976,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -12278,7 +12278,7 @@ struct urb *ldv_linux_usb_urb_usb_alloc_urb(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -10347,25 +10347,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -19531,25 +19531,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -24152,25 +24152,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -34017,25 +34017,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16491,25 +16491,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -8526,25 +8526,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -30060,25 +30060,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -12978,25 +12978,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -24063,25 +24063,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -13784,25 +13784,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12989,25 +12989,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -34464,25 +34464,6 @@ void ldv_linux_usb_register_check_return_value_probe(int retval )
 void ldv_assert_linux_usb_urb__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_urb__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_urb_urb_state  =    0;
-struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) 
-{ 
-  void *arbitrary_memory ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  arbitrary_memory = tmp;
-  }
-  if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {
-    return ((struct urb *)arbitrary_memory);
-  } else {
-
-  }
-  ldv_linux_usb_urb_urb_state = ldv_linux_usb_urb_urb_state + 1;
-  return ((struct urb *)arbitrary_memory);
-}
-}
 void ldv_linux_usb_urb_usb_free_urb(struct urb *urb ) 
 { 
 


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented
using __VERIFIER_nondet_pointer. The size is known (sizeof(struct urb)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct urb \*ldv_linux_usb_urb_usb_alloc_urb\(void\) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct urb));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
