### PR TITLE
Implement ldv_linux_block_queue_request_queue using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7925,26 +7925,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -14173,26 +14173,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -13538,24 +13538,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -16432,7 +16432,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -15491,7 +15491,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -20563,7 +20563,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -19198,7 +19198,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -7613,7 +7613,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -7281,7 +7281,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -14748,7 +14748,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -13817,7 +13817,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -19316,7 +19316,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -18133,7 +18133,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -8766,7 +8766,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -8409,7 +8409,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -11178,7 +11178,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -10559,7 +10559,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -14449,26 +14449,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -13552,24 +13552,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -20494,26 +20494,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -19058,24 +19058,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -20712,26 +20712,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -19366,24 +19366,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -26066,26 +26066,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -24247,24 +24247,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -28491,26 +28491,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -26560,24 +26560,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -16240,26 +16240,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -15186,24 +15186,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -8430,26 +8430,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -8001,24 +8001,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -15574,26 +15574,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -14670,24 +14670,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -32733,7 +32733,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -30295,7 +30295,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -9857,26 +9857,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -9320,24 +9320,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -18902,7 +18902,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -17863,7 +17863,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -9994,26 +9994,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -9479,24 +9479,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -8677,26 +8677,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -8286,24 +8286,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -11889,26 +11889,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -11160,24 +11160,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -27588,7 +27588,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -25667,7 +25667,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -30185,26 +30185,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -27948,24 +27948,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -8128,26 +8128,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -7761,24 +7761,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -17506,26 +17506,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -16617,24 +16617,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -12969,26 +12969,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -12249,24 +12249,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -11889,26 +11889,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -11491,24 +11491,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -25144,26 +25144,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -23333,24 +23333,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -10816,7 +10816,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -10171,7 +10171,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -8614,7 +8614,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -8222,7 +8222,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -20945,26 +20945,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -19586,24 +19586,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -34094,26 +34094,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -31411,24 +31411,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -14960,26 +14960,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -13931,24 +13931,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -11961,26 +11961,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -11288,24 +11288,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -7737,26 +7737,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -7349,24 +7349,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -36569,7 +36569,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -34019,7 +34019,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -11725,26 +11725,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -11221,24 +11221,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -11735,26 +11735,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -11331,24 +11331,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -12165,26 +12165,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -11636,24 +11636,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -17215,26 +17215,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -16254,24 +16254,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -16983,26 +16983,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -16106,24 +16106,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -47777,26 +47777,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -44240,24 +44240,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -24819,26 +24819,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -23338,24 +23338,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -11838,26 +11838,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -11319,24 +11319,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -11413,26 +11413,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -10872,24 +10872,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -11699,26 +11699,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -11187,24 +11187,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -23232,26 +23232,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -21866,24 +21866,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -18142,26 +18142,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -17233,24 +17233,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -30179,26 +30179,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -28219,24 +28219,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -26294,26 +26294,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -24504,24 +24504,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -12579,26 +12579,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -12065,24 +12065,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -15024,26 +15024,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -14243,24 +14243,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -18349,26 +18349,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -17198,24 +17198,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -11004,26 +11004,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -10580,24 +10580,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -14701,26 +14701,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -14059,24 +14059,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -20607,26 +20607,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -19581,24 +19581,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -38033,26 +38033,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -35833,24 +35833,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -8360,26 +8360,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -8008,24 +8008,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -21724,7 +21724,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -20410,7 +20410,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -25781,7 +25781,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -24073,7 +24073,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -19053,7 +19053,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -17981,7 +17981,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -31313,7 +31313,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -29474,7 +29474,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -26292,7 +26292,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -24558,7 +24558,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -24657,7 +24657,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -22972,7 +22972,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -15501,7 +15501,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -14643,7 +14643,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -21789,7 +21789,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -20403,7 +20403,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -40320,7 +40320,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -37559,7 +37559,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -20254,7 +20254,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -19199,7 +19199,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -71085,7 +71085,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -65847,7 +65847,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -18550,7 +18550,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -17390,7 +17390,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -23776,26 +23776,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -22026,24 +22026,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -22702,26 +22702,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -21171,24 +21171,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -8720,26 +8720,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -8272,24 +8272,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -11804,26 +11804,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -11075,24 +11075,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -11877,26 +11877,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -11135,24 +11135,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -11331,26 +11331,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -10663,24 +10663,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -13883,26 +13883,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -13009,24 +13009,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -7670,26 +7670,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -7314,24 +7314,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -7384,26 +7384,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -7048,24 +7048,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -8017,26 +8017,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -7640,24 +7640,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -7055,26 +7055,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -6761,24 +6761,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -25774,26 +25774,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -24042,24 +24042,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -18129,26 +18129,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -16959,24 +16959,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -9439,26 +9439,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -9014,24 +9014,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10739,26 +10739,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -10221,24 +10221,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -8814,26 +8814,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -8356,24 +8356,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -17997,26 +17997,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -16829,24 +16829,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -22617,26 +22617,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -21183,24 +21183,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -32480,26 +32480,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -30327,24 +30327,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -14956,26 +14956,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -14083,24 +14083,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -6989,26 +6989,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -6607,24 +6607,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -28523,26 +28523,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -26596,24 +26596,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -11442,26 +11442,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -10996,24 +10996,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -22529,26 +22529,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -21117,24 +21117,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -12247,26 +12247,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -11434,24 +11434,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -11452,26 +11452,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -10731,24 +10731,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -32930,26 +32930,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -30466,24 +30466,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state = 0;
-struct request_queue *ldv_linux_block_queue_request_queue(void)
-{
-  struct request_queue *res ;
-  void *tmp ;
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void)
 {
   {

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7925,26 +7925,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -14173,26 +14173,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -16432,7 +16432,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -20563,7 +20563,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -7613,7 +7613,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -14748,7 +14748,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -19316,7 +19316,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -8766,7 +8766,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -11178,7 +11178,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14449,26 +14449,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -20494,26 +20494,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -20712,26 +20712,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -26066,26 +26066,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -28492,26 +28492,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -16240,26 +16240,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8431,26 +8431,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15574,26 +15574,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -32733,7 +32733,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -9857,26 +9857,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -18902,7 +18902,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -9994,26 +9994,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -8677,26 +8677,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -11889,26 +11889,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -27588,7 +27588,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -30185,26 +30185,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8128,26 +8128,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17506,26 +17506,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -12969,26 +12969,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -11889,26 +11889,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -25144,26 +25144,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -10816,7 +10816,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -8614,7 +8614,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -20945,26 +20945,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -34094,26 +34094,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14960,26 +14960,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11961,26 +11961,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -7737,26 +7737,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -36569,7 +36569,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -11725,26 +11725,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -11735,26 +11735,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12165,26 +12165,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -17215,26 +17215,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16983,26 +16983,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -47777,26 +47777,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -24819,26 +24819,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11838,26 +11838,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11413,26 +11413,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11699,26 +11699,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -23232,26 +23232,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18142,26 +18142,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -30179,26 +30179,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -26294,26 +26294,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -12579,26 +12579,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -15024,26 +15024,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -18349,26 +18349,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -11004,26 +11004,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -14701,26 +14701,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -20607,26 +20607,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -38033,26 +38033,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -8360,26 +8360,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -21724,7 +21724,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -25781,7 +25781,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -19053,7 +19053,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -31313,7 +31313,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -26292,7 +26292,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -24657,7 +24657,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -15501,7 +15501,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -21789,7 +21789,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -40320,7 +40320,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -20254,7 +20254,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -71085,7 +71085,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -18550,7 +18550,7 @@ struct request_queue *ldv_linux_block_queue_request_queue(void)
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request_queue));
   res = (struct request_queue *)tmp;
   ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -23776,26 +23776,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -22702,26 +22702,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -8720,26 +8720,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -11805,26 +11805,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -11877,26 +11877,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -11332,26 +11332,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13883,26 +13883,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -7670,26 +7670,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -7384,26 +7384,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -8017,26 +8017,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -7055,26 +7055,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -25774,26 +25774,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -18129,26 +18129,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -9439,26 +9439,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10739,26 +10739,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8814,26 +8814,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17997,26 +17997,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -22617,26 +22617,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -32480,26 +32480,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14956,26 +14956,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -6989,26 +6989,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -28523,26 +28523,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -11442,26 +11442,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -22529,26 +22529,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -12247,26 +12247,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11452,26 +11452,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -32930,26 +32930,6 @@ void ldv_assert_linux_block_queue__double_allocation(int expr ) ;
 void ldv_assert_linux_block_queue__more_initial_at_exit(int expr ) ;
 void ldv_assert_linux_block_queue__use_before_allocation(int expr ) ;
 static int ldv_linux_block_queue_queue_state  =    0;
-struct request_queue *ldv_linux_block_queue_request_queue(void) 
-{ 
-  struct request_queue *res ;
-  void *tmp ;
-
-  {
-  {
-  tmp = ldv_undef_ptr();
-  res = (struct request_queue *)tmp;
-  ldv_assert_linux_block_queue__double_allocation(ldv_linux_block_queue_queue_state == 0);
-  }
-  if ((unsigned long )res != (unsigned long )((struct request_queue *)0)) {
-    ldv_linux_block_queue_queue_state = 1;
-    return (res);
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_queue_blk_cleanup_queue(void) 
 { 
 


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct
request_queue)), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct request_queue \*ldv_linux_block_queue_request_queue\(void\) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct request_queue));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
