### PR TITLE
Implement ldv_linux_block_request_blk_{get,make}_request using ldv_ma…

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7972,54 +7972,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -14221,54 +14221,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -13580,49 +13580,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -16481,7 +16481,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -16508,7 +16508,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -15534,7 +15534,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -15558,7 +15558,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -20612,7 +20612,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20639,7 +20639,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -19241,7 +19241,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19265,7 +19265,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -7662,7 +7662,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -7689,7 +7689,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -7324,7 +7324,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -7348,7 +7348,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -14797,7 +14797,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -14824,7 +14824,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -13860,7 +13860,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -13884,7 +13884,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -19365,7 +19365,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19392,7 +19392,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -18176,7 +18176,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18200,7 +18200,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -8815,7 +8815,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8842,7 +8842,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -8452,7 +8452,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8476,7 +8476,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -11227,7 +11227,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -11254,7 +11254,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -10602,7 +10602,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -10626,7 +10626,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -14497,54 +14497,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -13594,49 +13594,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -20542,54 +20542,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -19100,49 +19100,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -20760,54 +20760,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -19408,49 +19408,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -26114,54 +26114,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -24289,49 +24289,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -28539,54 +28539,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -26602,49 +26602,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -16287,54 +16287,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -15227,49 +15227,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -8478,54 +8478,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -8043,49 +8043,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -15622,54 +15622,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -14712,49 +14712,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -32782,7 +32782,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -32809,7 +32809,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -30338,7 +30338,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -30362,7 +30362,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -9905,54 +9905,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -9362,49 +9362,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -18951,7 +18951,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18978,7 +18978,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -17906,7 +17906,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -17930,7 +17930,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -10041,54 +10041,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -9520,49 +9520,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -8725,54 +8725,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -8328,49 +8328,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -11936,54 +11936,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -11201,49 +11201,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -27637,7 +27637,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -27664,7 +27664,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -25710,7 +25710,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -25734,7 +25734,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -30233,54 +30233,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -27990,49 +27990,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -8176,54 +8176,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -7803,49 +7803,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -17554,54 +17554,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -16659,49 +16659,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -13016,54 +13016,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -12290,49 +12290,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -11936,54 +11936,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -11532,49 +11532,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -25191,54 +25191,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -23374,49 +23374,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -10865,7 +10865,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -10892,7 +10892,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -10214,7 +10214,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -10238,7 +10238,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -8663,7 +8663,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8690,7 +8690,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -8265,7 +8265,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8289,7 +8289,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -20993,54 +20993,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -19628,49 +19628,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -34142,54 +34142,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -31453,49 +31453,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -15008,54 +15008,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -13973,49 +13973,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -12009,54 +12009,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -11330,49 +11330,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -7785,54 +7785,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -7391,49 +7391,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -36618,7 +36618,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -36645,7 +36645,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -34062,7 +34062,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -34086,7 +34086,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -11773,54 +11773,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -11263,49 +11263,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -11783,54 +11783,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -11373,49 +11373,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -12213,54 +12213,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -11678,49 +11678,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -17263,54 +17263,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -16296,49 +16296,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -17031,54 +17031,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -16148,49 +16148,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -47825,54 +47825,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -44282,49 +44282,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -24867,54 +24867,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -23380,49 +23380,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -11886,54 +11886,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -11361,49 +11361,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -11461,54 +11461,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -10914,49 +10914,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -11747,54 +11747,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -11229,49 +11229,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -23280,54 +23280,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -21908,49 +21908,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -18190,54 +18190,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -17275,49 +17275,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -30227,54 +30227,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -28261,49 +28261,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -26342,54 +26342,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -24546,49 +24546,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -12627,54 +12627,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -12107,49 +12107,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -15072,54 +15072,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -14285,49 +14285,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -18397,54 +18397,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -17240,49 +17240,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -11051,54 +11051,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -10621,49 +10621,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -14748,54 +14748,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -14100,49 +14100,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -20655,54 +20655,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -19623,49 +19623,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -38081,54 +38081,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -35875,49 +35875,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -8407,54 +8407,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -8049,49 +8049,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -21773,7 +21773,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -21800,7 +21800,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -20453,7 +20453,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20477,7 +20477,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -25830,7 +25830,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -25857,7 +25857,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -24116,7 +24116,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -24140,7 +24140,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -19102,7 +19102,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19129,7 +19129,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -18024,7 +18024,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18048,7 +18048,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -31362,7 +31362,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -31389,7 +31389,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -29517,7 +29517,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -29541,7 +29541,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -26341,7 +26341,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -26368,7 +26368,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -24601,7 +24601,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -24625,7 +24625,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -24706,7 +24706,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -24733,7 +24733,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -23015,7 +23015,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -23039,7 +23039,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -15550,7 +15550,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -15577,7 +15577,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -14686,7 +14686,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -14710,7 +14710,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -21838,7 +21838,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -21865,7 +21865,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -20446,7 +20446,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20470,7 +20470,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -40369,7 +40369,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -40396,7 +40396,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -37602,7 +37602,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -37626,7 +37626,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -20303,7 +20303,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20330,7 +20330,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -19242,7 +19242,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19266,7 +19266,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -71134,7 +71134,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -71161,7 +71161,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -65890,7 +65890,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -65914,7 +65914,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -18599,7 +18599,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18626,7 +18626,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -17433,7 +17433,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -17457,7 +17457,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const *)res);

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -23824,54 +23824,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -22068,49 +22068,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -22750,54 +22750,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -21213,49 +21213,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -8767,54 +8767,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -8313,49 +8313,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -11852,54 +11852,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -11117,49 +11117,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -11925,54 +11925,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -11177,49 +11177,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -11379,54 +11379,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -10705,49 +10705,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -13931,54 +13931,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -13051,49 +13051,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -7717,54 +7717,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -7355,49 +7355,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -7431,54 +7431,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -7089,49 +7089,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -8064,54 +8064,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -7681,49 +7681,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -7102,54 +7102,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -6802,49 +6802,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -25822,54 +25822,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -24084,49 +24084,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -18177,54 +18177,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -17001,49 +17001,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -9487,54 +9487,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -9056,49 +9056,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -10786,54 +10786,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -10262,49 +10262,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -8862,54 +8862,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -8398,49 +8398,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -18045,54 +18045,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -16871,49 +16871,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -22665,54 +22665,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -21225,49 +21225,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -32528,54 +32528,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -30369,49 +30369,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -15004,54 +15004,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -14125,49 +14125,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -7037,54 +7037,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -6649,49 +6649,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -28571,54 +28571,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -26638,49 +26638,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -11490,54 +11490,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -11038,49 +11038,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -22577,54 +22577,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -21159,49 +21159,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -12295,54 +12295,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -11476,49 +11476,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -11500,54 +11500,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -10773,49 +10773,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -32978,54 +32978,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -30508,49 +30508,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const *ptr ) ;
 int ldv_linux_block_request_blk_rq = 0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
-{
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void)
 {
   {

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -7972,54 +7972,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -14221,54 +14221,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -16481,7 +16481,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -16508,7 +16508,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -20612,7 +20612,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20639,7 +20639,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -7662,7 +7662,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -7689,7 +7689,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -14797,7 +14797,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -14824,7 +14824,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -19365,7 +19365,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19392,7 +19392,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -8815,7 +8815,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8842,7 +8842,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -11227,7 +11227,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -11254,7 +11254,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -14497,54 +14497,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -20542,54 +20542,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -20760,54 +20760,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -26114,54 +26114,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -28540,54 +28540,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -16287,54 +16287,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8479,54 +8479,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15622,54 +15622,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -32782,7 +32782,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -32809,7 +32809,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -9905,54 +9905,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -18951,7 +18951,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18978,7 +18978,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -10041,54 +10041,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -8725,54 +8725,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -11936,54 +11936,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -27637,7 +27637,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -27664,7 +27664,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -30233,54 +30233,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8176,54 +8176,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17554,54 +17554,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -13016,54 +13016,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -11936,54 +11936,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -25191,54 +25191,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -10865,7 +10865,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -10892,7 +10892,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -8663,7 +8663,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -8690,7 +8690,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -20993,54 +20993,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -34142,54 +34142,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15008,54 +15008,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12009,54 +12009,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -7785,54 +7785,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -36618,7 +36618,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -36645,7 +36645,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -11773,54 +11773,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -11783,54 +11783,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12213,54 +12213,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -17263,54 +17263,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -17031,54 +17031,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -47825,54 +47825,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -24867,54 +24867,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11886,54 +11886,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11461,54 +11461,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11747,54 +11747,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -23280,54 +23280,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18190,54 +18190,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -30227,54 +30227,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -26342,54 +26342,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -12627,54 +12627,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -15072,54 +15072,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -18397,54 +18397,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -11051,54 +11051,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -14748,54 +14748,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -20655,54 +20655,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -38081,54 +38081,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -8407,54 +8407,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -21773,7 +21773,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -21800,7 +21800,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -25830,7 +25830,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -25857,7 +25857,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -19102,7 +19102,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -19129,7 +19129,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -31362,7 +31362,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -31389,7 +31389,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -26341,7 +26341,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -26368,7 +26368,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -24706,7 +24706,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -24733,7 +24733,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -15550,7 +15550,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -15577,7 +15577,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -21838,7 +21838,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -21865,7 +21865,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -40369,7 +40369,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -40396,7 +40396,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -20303,7 +20303,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -20330,7 +20330,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -71134,7 +71134,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -71161,7 +71161,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -18599,7 +18599,7 @@ struct request *ldv_linux_block_request_blk_get_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   }
   if ((mask == 16U || mask == 208U) || mask == 16U) {
@@ -18626,7 +18626,7 @@ struct request *ldv_linux_block_request_blk_make_request(gfp_t mask )
   {
   {
   ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct request));
   res = (struct request *)tmp;
   ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
   tmp___0 = ldv_is_err((void const   *)res);

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -23824,54 +23824,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -22750,54 +22750,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -8767,54 +8767,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -11853,54 +11853,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -11925,54 +11925,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -11380,54 +11380,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13931,54 +13931,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -7717,54 +7717,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -7431,54 +7431,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -8064,54 +8064,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -7102,54 +7102,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -25822,54 +25822,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -18177,54 +18177,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -9487,54 +9487,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -10786,54 +10786,6 @@ void ldv_assert_linux_block_request__double_get(int expr ) ;
 void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -8862,54 +8862,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18045,54 +18045,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -22665,54 +22665,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -32528,54 +32528,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15004,54 +15004,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -7037,54 +7037,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -28571,54 +28571,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -11490,54 +11490,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -22577,54 +22577,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -12295,54 +12295,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -11500,54 +11500,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -32978,54 +32978,6 @@ void ldv_assert_linux_block_request__double_put(int expr ) ;
 void ldv_assert_linux_block_request__get_at_exit(int expr ) ;
 long ldv_is_err(void const   *ptr ) ;
 int ldv_linux_block_request_blk_rq  =    0;
-struct request *ldv_linux_block_request_blk_get_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  }
-  if ((mask == 16U || mask == 208U) || mask == 16U) {
-    {
-    ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-    }
-  } else {
-
-  }
-  if ((unsigned long )res != (unsigned long )((struct request *)0)) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
-struct request *ldv_linux_block_request_blk_make_request(gfp_t mask ) 
-{ 
-  struct request *res ;
-  void *tmp ;
-  long tmp___0 ;
-
-  {
-  {
-  ldv_assert_linux_block_request__double_get(ldv_linux_block_request_blk_rq == 0);
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
-  ldv_assume((unsigned long )res != (unsigned long )((struct request *)0));
-  tmp___0 = ldv_is_err((void const   *)res);
-  }
-  if (tmp___0 == 0L) {
-    ldv_linux_block_request_blk_rq = 1;
-  } else {
-
-  }
-  return (res);
-}
-}
 void ldv_linux_block_request_put_blk_rq(void) 
 { 
 


### PR DESCRIPTION
…lloc

Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct request)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct request \*ldv_linux_block_request_blk_(get|make)_request\(gfp_t mask \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct request));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
