### PR TITLE
Implement ldv_linux_usb_coherent_usb_alloc_coherent using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -9111,14 +9111,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -15358,14 +15358,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -14562,13 +14562,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -17608,14 +17608,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -16507,13 +16507,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -21739,14 +21739,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -20214,13 +20214,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -8795,14 +8795,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -8303,13 +8303,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -15927,14 +15927,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -14836,13 +14836,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -20493,14 +20493,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -19150,13 +19150,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -9947,14 +9947,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -9430,13 +9430,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -12357,14 +12357,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -11578,13 +11578,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -15635,14 +15635,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -14577,13 +14577,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -21679,14 +21679,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -20082,13 +20082,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -21899,14 +21899,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -20392,13 +20392,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -27253,14 +27253,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -25273,13 +25273,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -29678,14 +29678,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -27586,13 +27586,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -4968,7 +4968,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10128,7 +10128,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10147,7 +10147,7 @@ static void *ldv_usb_alloc_coherent_124(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10166,7 +10166,7 @@ static void *ldv_usb_alloc_coherent_125(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -17423,14 +17423,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -4964,7 +4964,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -9672,7 +9672,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -9690,7 +9690,7 @@ static void *ldv_usb_alloc_coherent_124(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -9708,7 +9708,7 @@ static void *ldv_usb_alloc_coherent_125(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -16208,13 +16208,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -9618,14 +9618,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -9028,13 +9028,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -16763,14 +16763,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -15698,13 +15698,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -33910,14 +33910,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -31312,13 +31312,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -11043,14 +11043,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -10345,13 +10345,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -20082,14 +20082,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -18883,13 +18883,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -4280,7 +4280,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -9240,7 +9240,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -9277,7 +9277,7 @@ static void *ldv_usb_alloc_coherent_121(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11181,14 +11181,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -4276,7 +4276,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -8824,7 +8824,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8859,7 +8859,7 @@ static void *ldv_usb_alloc_coherent_121(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10505,13 +10505,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -9863,14 +9863,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -9311,13 +9311,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -4215,7 +4215,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -11319,7 +11319,7 @@ static void *ldv_usb_alloc_coherent_106(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13076,14 +13076,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -4211,7 +4211,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10664,7 +10664,7 @@ static void *ldv_usb_alloc_coherent_106(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -12186,13 +12186,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -28767,14 +28767,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -26686,13 +26686,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -31370,14 +31370,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -28972,13 +28972,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -9316,14 +9316,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -8788,13 +8788,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -18695,14 +18695,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -17645,13 +17645,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -5577,7 +5577,7 @@ void ldv_linux_mmc_sdio_func_check_final_state(void) ;
 void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -11619,7 +11619,7 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11767,7 +11767,7 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -14156,14 +14156,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -5572,7 +5572,7 @@ void ldv_linux_mmc_sdio_func_check_final_state(void) ;
 void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -11068,7 +11068,7 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11198,7 +11198,7 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13275,13 +13275,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -13076,14 +13076,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -12517,13 +12517,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -17745,7 +17745,7 @@ static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) ;
 long ldv_is_err(void const   *ptr ) ;
 void ldv_linux_usb_coherent_usb_free_coherent(void *addr ) ;
@@ -20323,7 +20323,7 @@ static void *ldv_usb_alloc_coherent_104(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -26330,14 +26330,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -16697,7 +16697,7 @@ static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) ;
 long ldv_is_err(void const *ptr ) ;
 void ldv_linux_usb_coherent_usb_free_coherent(void *addr ) ;
@@ -19000,7 +19000,7 @@ static void *ldv_usb_alloc_coherent_104(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -24358,13 +24358,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -11995,14 +11995,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -11190,13 +11190,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -9795,14 +9795,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -9243,13 +9243,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -22130,14 +22130,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -20610,13 +20610,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -35279,14 +35279,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -32435,13 +32435,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -16148,14 +16148,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -14958,13 +14958,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -13149,14 +13149,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -12315,13 +12315,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -8924,14 +8924,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -8375,13 +8375,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -37749,14 +37749,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -35039,13 +35039,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -12912,14 +12912,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -12247,13 +12247,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -12921,14 +12921,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -12356,13 +12356,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -13350,14 +13350,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -12660,13 +12660,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -18398,14 +18398,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -17276,13 +17276,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -18166,14 +18166,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -17128,13 +17128,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -48959,14 +48959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -45261,13 +45261,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -26002,14 +26002,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -24360,13 +24360,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -13023,14 +13023,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -12343,13 +12343,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -12598,14 +12598,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -11896,13 +11896,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -12884,14 +12884,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -12211,13 +12211,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -24415,14 +24415,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -22888,13 +22888,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -19325,14 +19325,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -18255,13 +18255,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -31361,14 +31361,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -29240,13 +29240,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -27476,14 +27476,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -25525,13 +25525,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -13765,14 +13765,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -13090,13 +13090,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -16211,14 +16211,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -15269,13 +15269,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -19535,14 +19535,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -18223,13 +18223,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -6282,7 +6282,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10249,7 +10249,7 @@ static void *ldv_usb_alloc_coherent_142(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10268,7 +10268,7 @@ static void *ldv_usb_alloc_coherent_143(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -12188,14 +12188,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -6277,7 +6277,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -9927,7 +9927,7 @@ static void *ldv_usb_alloc_coherent_142(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -9945,7 +9945,7 @@ static void *ldv_usb_alloc_coherent_143(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11603,13 +11603,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -7502,7 +7502,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -13464,7 +13464,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13899,7 +13899,7 @@ static void *ldv_usb_alloc_coherent_165(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -15885,14 +15885,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -7497,7 +7497,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -12995,7 +12995,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13371,7 +13371,7 @@ static void *ldv_usb_alloc_coherent_165(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -15082,13 +15082,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -21792,14 +21792,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -20605,13 +20605,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -39220,14 +39220,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -36859,13 +36859,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -9548,14 +9548,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -9035,13 +9035,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -22904,14 +22904,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -21430,13 +21430,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -26959,14 +26959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -25091,13 +25091,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -20231,14 +20231,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -18999,13 +18999,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -32489,14 +32489,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -30490,13 +30490,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -27471,14 +27471,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -25577,13 +25577,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -25834,14 +25834,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -23989,13 +23989,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -16679,14 +16679,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -15661,13 +15661,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -22967,14 +22967,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -21421,13 +21421,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -41497,14 +41497,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -38576,13 +38576,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -21432,14 +21432,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -20217,13 +20217,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -72262,14 +72262,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -66864,13 +66864,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -19731,14 +19731,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -18411,13 +18411,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -24961,14 +24961,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -23050,13 +23050,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -23888,14 +23888,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -22196,13 +22196,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -9906,14 +9906,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -9297,13 +9297,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -12990,14 +12990,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -12100,13 +12100,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -13063,14 +13063,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -12160,13 +12160,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -12517,14 +12517,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -11688,13 +11688,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -15068,14 +15068,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -14033,13 +14033,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -4040,7 +4040,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6836,7 +6836,7 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8856,14 +8856,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -4036,7 +4036,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6601,7 +6601,7 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8339,13 +8339,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -8570,14 +8570,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -8073,13 +8073,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -9204,14 +9204,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -8666,13 +8666,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -4020,7 +4020,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6345,7 +6345,7 @@ static void *ldv_usb_alloc_coherent_105(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -6382,7 +6382,7 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8241,14 +8241,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -4016,7 +4016,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6147,7 +6147,7 @@ static void *ldv_usb_alloc_coherent_105(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -6182,7 +6182,7 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -7786,13 +7786,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -26959,14 +26959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -25066,13 +25066,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -19316,14 +19316,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -17985,13 +17985,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -10627,14 +10627,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -10041,13 +10041,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -4676,7 +4676,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10215,7 +10215,7 @@ static void *ldv_usb_alloc_coherent_113(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11923,14 +11923,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -4672,7 +4672,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -9767,7 +9767,7 @@ static void *ldv_usb_alloc_coherent_113(struct usb_device *ldv_func_arg1 , size_
   long tmp___0 ;
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11244,13 +11244,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -9998,14 +9998,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -9379,13 +9379,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -19182,14 +19182,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -17853,13 +17853,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -23803,14 +23803,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -22208,13 +22208,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -33668,14 +33668,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -31354,13 +31354,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -16142,14 +16142,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -15108,13 +15108,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -8177,14 +8177,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -7634,13 +7634,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -29711,14 +29711,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -27623,13 +27623,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -12629,14 +12629,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -12022,13 +12022,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -23714,14 +23714,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -22141,13 +22141,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -13435,14 +13435,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -12461,13 +12461,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -12640,14 +12640,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -11758,13 +11758,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -34115,14 +34115,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -31490,13 +31490,13 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state = 0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void)
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size )
 {
   void *arbitrary_memory ;
   void *tmp ;
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -9111,14 +9111,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -15358,14 +15358,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -17608,14 +17608,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -21739,14 +21739,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -8795,14 +8795,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -15927,14 +15927,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -20493,14 +20493,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -9947,14 +9947,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -12357,14 +12357,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15635,14 +15635,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -21679,14 +21679,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -21899,14 +21899,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -27253,14 +27253,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -29679,14 +29679,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -4968,7 +4968,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10128,7 +10128,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10147,7 +10147,7 @@ static void *ldv_usb_alloc_coherent_124(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10166,7 +10166,7 @@ static void *ldv_usb_alloc_coherent_125(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -17423,14 +17423,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -9619,14 +9619,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16763,14 +16763,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -33910,14 +33910,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -11043,14 +11043,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -20082,14 +20082,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -4280,7 +4280,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -9240,7 +9240,7 @@ static void *ldv_usb_alloc_coherent_119(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -9277,7 +9277,7 @@ static void *ldv_usb_alloc_coherent_121(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11181,14 +11181,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -9863,14 +9863,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -4215,7 +4215,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -11319,7 +11319,7 @@ static void *ldv_usb_alloc_coherent_106(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13076,14 +13076,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -28767,14 +28767,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -31370,14 +31370,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -9316,14 +9316,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18695,14 +18695,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -5577,7 +5577,7 @@ void ldv_linux_mmc_sdio_func_check_final_state(void) ;
 void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -11619,7 +11619,7 @@ static void *ldv_usb_alloc_coherent_99(struct usb_device *ldv_func_arg1 , size_t
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11767,7 +11767,7 @@ static void *ldv_usb_alloc_coherent_111(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -14156,14 +14156,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -13076,14 +13076,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -17745,7 +17745,7 @@ static void ldv_mutex_unlock_122(struct mutex *ldv_func_arg1 )
   return;
 }
 }
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 struct urb *ldv_linux_usb_urb_usb_alloc_urb(void) ;
 long ldv_is_err(void const   *ptr ) ;
 void ldv_linux_usb_coherent_usb_free_coherent(void *addr ) ;
@@ -20323,7 +20323,7 @@ static void *ldv_usb_alloc_coherent_104(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -26330,14 +26330,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -11995,14 +11995,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -9795,14 +9795,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -22130,14 +22130,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -35279,14 +35279,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16148,14 +16148,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13149,14 +13149,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -8924,14 +8924,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -37749,14 +37749,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -12912,14 +12912,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -12921,14 +12921,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13350,14 +13350,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -18398,14 +18398,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -18166,14 +18166,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -48959,14 +48959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -26002,14 +26002,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -13023,14 +13023,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12598,14 +12598,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12884,14 +12884,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -24415,14 +24415,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -19325,14 +19325,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -31361,14 +31361,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -27476,14 +27476,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -13765,14 +13765,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -16211,14 +16211,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -19535,14 +19535,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -6282,7 +6282,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10249,7 +10249,7 @@ static void *ldv_usb_alloc_coherent_142(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -10268,7 +10268,7 @@ static void *ldv_usb_alloc_coherent_143(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -12188,14 +12188,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -7502,7 +7502,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -13464,7 +13464,7 @@ static void *ldv_usb_alloc_coherent_123(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -13899,7 +13899,7 @@ static void *ldv_usb_alloc_coherent_165(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -15885,14 +15885,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -21792,14 +21792,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -39220,14 +39220,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -9548,14 +9548,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -22904,14 +22904,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -26959,14 +26959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -20231,14 +20231,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -32489,14 +32489,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -27471,14 +27471,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -25834,14 +25834,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -16679,14 +16679,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -22967,14 +22967,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -41497,14 +41497,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -21432,14 +21432,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -72262,14 +72262,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -19731,14 +19731,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -24961,14 +24961,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -23888,14 +23888,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -9906,14 +9906,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -12991,14 +12991,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -13063,14 +13063,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -12518,14 +12518,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -15068,14 +15068,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -4040,7 +4040,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6836,7 +6836,7 @@ static void *ldv_usb_alloc_coherent_103(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8856,14 +8856,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -8570,14 +8570,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -9204,14 +9204,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -4020,7 +4020,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -6345,7 +6345,7 @@ static void *ldv_usb_alloc_coherent_105(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -6382,7 +6382,7 @@ static void *ldv_usb_alloc_coherent_107(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -8241,14 +8241,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -26959,14 +26959,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -19316,14 +19316,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -10627,14 +10627,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -4676,7 +4676,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
 void *ldv_linux_usb_gadget_create_class(void) ;
 int ldv_linux_usb_gadget_register_class(void) ;
@@ -10215,7 +10215,7 @@ static void *ldv_usb_alloc_coherent_113(struct usb_device *ldv_func_arg1 , size_
 
   {
   {
-  tmp = ldv_linux_usb_coherent_usb_alloc_coherent();
+  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);
   res = tmp;
   tmp___0 = ldv_is_err((void const   *)res);
   ldv_assume(tmp___0 == 0L);
@@ -11923,14 +11923,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -9998,14 +9998,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -19182,14 +19182,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -23803,14 +23803,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -33668,14 +33668,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -16142,14 +16142,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -8177,14 +8177,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -29711,14 +29711,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -12629,14 +12629,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -23714,14 +23714,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -13435,14 +13435,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -12640,14 +12640,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -34115,14 +34115,14 @@ void ldv_linux_net_sock_check_final_state(void)
 void ldv_assert_linux_usb_coherent__less_initial_decrement(int expr ) ;
 void ldv_assert_linux_usb_coherent__more_initial_at_exit(int expr ) ;
 int ldv_linux_usb_coherent_coherent_state  =    0;
-void *ldv_linux_usb_coherent_usb_alloc_coherent(void) 
+void *ldv_linux_usb_coherent_usb_alloc_coherent(size_t size ) 
 { 
   void *arbitrary_memory ;
   void *tmp ;
 
   {
   {
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   arbitrary_memory = tmp;
   }
   if ((unsigned long )arbitrary_memory == (unsigned long )((void *)0)) {


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size needs to be passed in from the call
sites in ldv_usb_alloc_coherent_*. This is in preparation of removing
uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^void \*ldv_linux_usb_coherent_usb_alloc_coherent\(void\) ?(;)?$/) {
       $p = 2;
       if(!defined($1) && $d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
       }
       s/\(void\)/(size_t size )/;
     }
     elsif(/^static void \*ldv_usb_alloc_coherent_\d+\(struct usb_device \*ldv_func_arg1 , size_t ldv_func_arg2 , ?$/) {
       $p = 3;
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(size);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     elsif($p == 3) {
       if(/^  tmp = ldv_linux_usb_coherent_usb_alloc_coherent\(\);$/) {
         print "  tmp = ldv_linux_usb_coherent_usb_alloc_coherent(ldv_func_arg2);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
