### PR TITLE
Implement skb_share_check using ldv_malloc(sizeof(struct sk_buff))

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point.cil.out.c
@@ -20599,7 +20599,7 @@ __inline static struct sk_buff *skb_share_check(struct sk_buff *skb , gfp_t flag
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = __VERIFIER_nondet_bool() ? skb : ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--fm10k--fm10k.ko-entry_point.cil.out.i
@@ -19250,7 +19250,7 @@ __inline static struct sk_buff *skb_share_check(struct sk_buff *skb , gfp_t flag
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = __VERIFIER_nondet_bool() ? skb : ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--fcoe--fcoe.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--fcoe--fcoe.ko-entry_point.cil.out.c
@@ -14727,7 +14727,7 @@ __inline static struct sk_buff *skb_share_check(struct sk_buff *skb , gfp_t flag
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = __VERIFIER_nondet_bool() ? skb : ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--fcoe--fcoe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--fcoe--fcoe.ko-entry_point.cil.out.i
@@ -14107,7 +14107,7 @@ __inline static struct sk_buff *skb_share_check(struct sk_buff *skb , gfp_t flag
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = __VERIFIER_nondet_bool() ? skb : ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct sk_buff)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
	'$p = 1; $d = 0; $b = 0;
	 while(<>) {
		 if(/^void \*ldv_malloc\(size_t size \) ;$/) {
			 next if($d == 2);
			 $d = 1;
		 }
		 if(/^extern _Bool __VERIFIER_nondet_bool\(void\);$/) {
			 next if($b == 2);
			 $b = 1;
		 }
		 if(/^__inline static struct sk_buff \*skb_share_check\(struct sk_buff \*skb , gfp_t flags \) ?$/) {
			 $p = 2;
			 if($d == 0) {
				 print "void *ldv_malloc(size_t size ) ;\n";
				 $d = 2;
			 }
       if($b == 0) {
			   print "extern _Bool __VERIFIER_nondet_bool(void);\n";
         $b = 2;
       }
		 }
		 if($p == 2) {
			 if(/^  tmp = ldv_undef_ptr\(\);/) {
				 print "  tmp = __VERIFIER_nondet_bool() ? skb : ldv_malloc(sizeof(struct sk_buff));\n";
				 $p = 1;
				 next;
			 }
			 elsif(/^\}$/) { $p = 1; }
		 }
		 print;
	 }' \
	$f
done
```
