### PR TITLE
Verifythis: fix memory leaks

### DIFF
--- a/c/MemSafety-Arrays.set
+++ b/c/MemSafety-Arrays.set
@@ -1,3 +1,9 @@
 array-memsafety/*.yml
 array-examples/*.yml
 array-memsafety-realloc/*.yml
+verifythis/duplets.yml
+verifythis/elimination_max.yml
+verifythis/lcp.yml
+verifythis/prefixsum_iter.yml
+verifythis/elimination_max_rec.yml
+verifythis/elimination_max_rec_onepoint.yml

--- a/c/MemSafety-MemCleanup.set
+++ b/c/MemSafety-MemCleanup.set
@@ -4,3 +4,7 @@ forester-heap/*.yml
 list-properties/*.yml
 list-ext3-properties/*.yml
 memsafety-bftpd/*.yml
+verifythis/prefixsum_rec.yml
+verifythis/tree_max.yml
+verifythis/tree_del_iter.yml
+verifythis/tree_del_rec.yml

--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -6,13 +6,3 @@ locks/*.yml
 memsafety-ext3/*.yml
 pthread-memsafety/*.yml
 memsafety-bftpd/*.yml
-verifythis/duplets.yml
-verifythis/elimination_max.yml
-verifythis/lcp.yml
-verifythis/prefixsum_iter.yml
-verifythis/tree_del_iter.yml
-verifythis/prefixsum_rec.yml
-verifythis/tree_del_rec.yml
-verifythis/tree_max.yml
-verifythis/elimination_max_rec.yml
-verifythis/elimination_max_rec_onepoint.yml

--- a/c/verifythis/duplets.c
+++ b/c/verifythis/duplets.c
@@ -2,6 +2,7 @@
  * only a single pair of duplicates here. */
 
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) {
     if(!cond) __VERIFIER_error();
@@ -54,4 +55,6 @@ int main() {
     __VERIFIER_assert(0 <= j && j < n);
     __VERIFIER_assert(i != j);
     __VERIFIER_assert(a[i] == a[j]);
+    free(a);
+    return 0;
 }

--- a/c/verifythis/elimination_max.c
+++ b/c/verifythis/elimination_max.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
@@ -38,6 +39,7 @@ int main() {
     for(i=0; i<n; i++) {
         __VERIFIER_assert(a[i] <= a[x]);
     }
+    free(a);
 
     return x;
 }

--- a/c/verifythis/elimination_max_rec.c
+++ b/c/verifythis/elimination_max_rec.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
@@ -37,6 +38,8 @@ int main() {
     __VERIFIER_assume(n >= 0);
     int *a = calloc(n, sizeof(int));
     int x = check(0, n-1, a, n);
+
+    free(a);
     return x;
 }
 

--- a/c/verifythis/elimination_max_rec_onepoint.c
+++ b/c/verifythis/elimination_max_rec_onepoint.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
@@ -41,6 +42,8 @@ int main() {
     int ai = a[i];
     int ax = a[x];
     __VERIFIER_assert(ai <= ax);
+
+    free(a);
     return x;
 }
 

--- a/c/verifythis/lcp.c
+++ b/c/verifythis/lcp.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_assume(int);
 
@@ -36,4 +37,7 @@ int main() {
     __VERIFIER_assume(x >= 0 && y >= 0);
     int l = lcp(a, n, x, y);
     check(a, n, x, y, l);
+
+    free(a);
+    return 0;
 }

--- a/c/verifythis/prefixsum_iter.c
+++ b/c/verifythis/prefixsum_iter.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_assume(int);
 
@@ -65,4 +66,8 @@ int main() {
     int space = upsweep(a, n);
     downsweep(a, n, space);
     check(a0, a, n);
+
+    free(a);
+    free(a0);
+    return 0;
 }

--- a/c/verifythis/prefixsum_rec.c
+++ b/c/verifythis/prefixsum_rec.c
@@ -1,4 +1,5 @@
 extern void *calloc(unsigned int nmemb, unsigned int size);
+extern void free(void *);
 extern int __VERIFIER_nondet_int(void);
 extern void __VERIFIER_assume(int);
 
@@ -57,4 +58,8 @@ int main() {
     a[n-1] = 0;
     downsweep(a, n/2-1, n-1);
     check(a0, a, n);
+
+    free(a);
+    free(a0);
+    return 0;
 }

--- a/c/verifythis/prefixsum_rec.yml
+++ b/c/verifythis/prefixsum_rec.yml
@@ -3,7 +3,7 @@ format_version: '1.0'
 input_files: 'prefixsum_rec.c'
 
 properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false

--- a/c/verifythis/tree_del_iter.c
+++ b/c/verifythis/tree_del_iter.c
@@ -97,6 +97,8 @@ void task(struct node *t) {
     int i;
     for(i=0; i<m; i++)
         __VERIFIER_assert(x[i+1] == y[i]);
+    free(x);
+    free(y);
 }
 
 int main() {

--- a/c/verifythis/tree_del_iter.yml
+++ b/c/verifythis/tree_del_iter.yml
@@ -3,7 +3,7 @@ format_version: '1.0'
 input_files: 'tree_del_iter.c'
 
 properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false

--- a/c/verifythis/tree_del_rec.c
+++ b/c/verifythis/tree_del_rec.c
@@ -89,6 +89,8 @@ void task(struct node *t) {
     int i;
     for(i=0; i<m; i++)
         __VERIFIER_assert(x[i+1] == y[i]);
+    free(x);
+    free(y);
 }
 
 int main() {

--- a/c/verifythis/tree_del_rec.yml
+++ b/c/verifythis/tree_del_rec.yml
@@ -3,7 +3,7 @@ format_version: '1.0'
 input_files: 'tree_del_rec.c'
 
 properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false

--- a/c/verifythis/tree_max.yml
+++ b/c/verifythis/tree_max.yml
@@ -3,7 +3,7 @@ format_version: '1.0'
 input_files: 'tree_max.c'
 
 properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false


### PR DESCRIPTION
There is no `free()` after allocation on heap, that means the memtrack property is violated. Where `__VERIFIER_error()` (for memsafety `abort()`) is reachable, the memcleanup property is violated. According to PR #923 by @mikhailramalho:
```
verifythis/prefixsum_rec.c
verifythis/tree_del_iter.c
verifythis/tree_del_rec.c
verifythis/tree_max.c
```
This PR fixed invalid memtracks in tasks except `verifythis/tree_max.c`.

I suggest move the benchmarks into a better sub-category, because `MemSafety-Other` is for these tasks that don't fit anywhere. Benchmarks with arrays -> `MemSafety-Arrays` and for safe trees -> `MemSafety-Heap`, but there is memcleanup violation -> `MemSafety-MemCleanup`.

@gernst 