### PR TITLE
Replace two uses of external_allocated_data by ldv_malloc

### DIFF
--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.c
@@ -5639,12 +5639,11 @@ void ldv_platform_instance_release_3_3(int (*arg0)(struct platform_device * ) , 
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 void *ldv_pm_ops_scenario_4(void *arg0 ) 
 { 
   struct device *ldv_4_device_device ;
   struct dev_pm_ops *ldv_4_pm_ops_dev_pm_ops ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -5653,10 +5652,8 @@ void *ldv_pm_ops_scenario_4(void *arg0 )
 
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_device_device = (struct device *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_pm_ops_dev_pm_ops = (struct dev_pm_ops *)tmp___0;
+  ldv_4_device_device = ldv_malloc(sizeof(struct device));
+  ldv_4_pm_ops_dev_pm_ops = ldv_malloc(sizeof(struct dev_pm_ops));
   ldv_free(arg0);
   }
   goto ldv_do_4;
@@ -6249,7 +6246,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *malloc(size_t  ) ;
 extern void *calloc(size_t  , size_t  ) ;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko.cil.i
@@ -5450,12 +5450,11 @@ void ldv_platform_instance_release_3_3(int (*arg0)(struct platform_device * ) , 
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 void *ldv_pm_ops_scenario_4(void *arg0 )
 {
   struct device *ldv_4_device_device ;
   struct dev_pm_ops *ldv_4_pm_ops_dev_pm_ops ;
-  void *tmp ;
-  void *tmp___0 ;
   int tmp___1 ;
   int tmp___2 ;
   int tmp___3 ;
@@ -5463,10 +5462,8 @@ void *ldv_pm_ops_scenario_4(void *arg0 )
   int tmp___5 ;
   {
   {
-  tmp = external_allocated_data();
-  ldv_4_device_device = (struct device *)tmp;
-  tmp___0 = external_allocated_data();
-  ldv_4_pm_ops_dev_pm_ops = (struct dev_pm_ops *)tmp___0;
+  ldv_4_device_device = ldv_malloc(sizeof(struct device));
+  ldv_4_pm_ops_dev_pm_ops = ldv_malloc(sizeof(struct dev_pm_ops));
   ldv_free(arg0);
   }
   goto ldv_do_4;
@@ -5985,7 +5982,6 @@ void ldv__builtin_trap(void)
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 void *ldv_calloc(size_t nmemb , size_t size ) ;
 extern void *malloc(size_t ) ;
 extern void *calloc(size_t , size_t ) ;


### PR DESCRIPTION
external_allocated_data is implemented using __VERIFIER_nondet_pointer,
which has an unspecified semantics. Instead, allocate memory using
ldv_malloc. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767), but may turn the debate into one
about the initialisation state of the object.
