### PR TITLE
Implement dma_zalloc_coherent using ldv_zalloc

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.c
@@ -12995,7 +12995,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--idt77252.ko-entry_point.cil.out.i
@@ -12306,7 +12306,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
@@ -16572,7 +16572,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
@@ -15731,7 +15731,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
@@ -18061,7 +18061,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
@@ -17053,7 +17053,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.c
@@ -12989,7 +12989,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -12182,7 +12182,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.c
@@ -18699,7 +18699,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
@@ -17783,7 +17783,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.c
@@ -11848,7 +11848,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--pcnet32.ko-entry_point.cil.out.i
@@ -11201,7 +11201,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.c
@@ -11592,7 +11592,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--alx--alx.ko-entry_point.cil.out.i
@@ -11010,7 +11010,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.c
@@ -12784,7 +12784,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
@@ -12110,7 +12110,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
@@ -21775,7 +21775,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -20358,7 +20358,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.c
@@ -15217,7 +15217,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
@@ -14344,7 +14344,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -28469,7 +28469,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -26451,7 +26451,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
@@ -11517,7 +11517,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
@@ -11020,7 +11020,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -13651,7 +13651,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -13120,7 +13120,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
@@ -17607,7 +17607,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -16361,7 +16361,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -19861,7 +19861,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -18573,7 +18573,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.c
@@ -9491,7 +9491,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point.cil.out.i
@@ -9172,7 +9172,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.c
@@ -9917,7 +9917,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--ali-ircc.ko-entry_point.cil.out.i
@@ -9568,7 +9568,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.c
@@ -10121,7 +10121,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--via-ircc.ko-entry_point.cil.out.i
@@ -9775,7 +9775,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
@@ -10224,7 +10224,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
@@ -9794,7 +9794,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
@@ -14835,7 +14835,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
@@ -14035,7 +14035,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -30638,7 +30638,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -28653,7 +28653,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
@@ -24754,7 +24754,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -23303,7 +23303,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
@@ -16821,7 +16821,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -15860,7 +15860,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.c
@@ -11622,7 +11622,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
@@ -11178,7 +11178,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -21670,7 +21670,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -20439,7 +20439,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.c
@@ -25721,7 +25721,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -24463,7 +24463,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
@@ -11584,7 +11584,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
@@ -11023,7 +11023,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
@@ -15728,7 +15728,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
@@ -14675,7 +14675,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
@@ -5013,7 +5013,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
@@ -4871,7 +4871,7 @@ __inline static void *dma_zalloc_coherent(struct device *dev , size_t size , dma
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(size);
   return (tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known, thus using ldv_zalloc is
perfectly safe, and also more consistent as it will ensure
zero-initialisation. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_zalloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^__inline static void \*dma_zalloc_coherent\(struct device \*dev , size_t size , dma_addr_t \*dma_handle , ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_zalloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_zalloc(size);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
