### PR TITLE
Implement kmalloc using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
@@ -11324,7 +11324,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
@@ -10837,7 +10837,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
@@ -13392,7 +13392,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
@@ -12860,7 +12860,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
@@ -16551,7 +16551,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
@@ -15712,7 +15712,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
@@ -18040,7 +18040,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
@@ -17034,7 +17034,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.c
@@ -16372,7 +16372,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
@@ -15345,7 +15345,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point.cil.out.c
@@ -10558,7 +10558,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--char--ipmi--ipmi_msghandler.ko-entry_point.cil.out.i
@@ -9925,7 +9925,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.c
@@ -8235,7 +8235,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
@@ -7993,7 +7993,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
@@ -11758,7 +11758,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
@@ -11163,7 +11163,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.c
@@ -10161,7 +10161,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.i
@@ -9549,7 +9549,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.c
@@ -8589,7 +8589,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.i
@@ -8089,7 +8089,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.c
@@ -12391,7 +12391,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.i
@@ -11562,7 +11562,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--md-mod.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--md-mod.ko-entry_point.cil.out.c
@@ -24222,7 +24222,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--md-mod.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--md-mod.ko-entry_point.cil.out.i
@@ -22321,7 +22321,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--bt8xx--bttv.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--bt8xx--bttv.ko-entry_point.cil.out.c
@@ -14326,7 +14326,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--bt8xx--bttv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--bt8xx--bttv.ko-entry_point.cil.out.i
@@ -13547,7 +13547,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.c
@@ -8693,7 +8693,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.i
@@ -8357,7 +8357,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--memstick--core--ms_block.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--memstick--core--ms_block.ko-entry_point.cil.out.c
@@ -8645,7 +8645,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--memstick--core--ms_block.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--memstick--core--ms_block.ko-entry_point.cil.out.i
@@ -8097,7 +8097,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--mmc--host--sdhci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--mmc--host--sdhci.ko-entry_point.cil.out.c
@@ -11142,7 +11142,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--mmc--host--sdhci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--mmc--host--sdhci.ko-entry_point.cil.out.i
@@ -10412,7 +10412,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.c
@@ -21754,7 +21754,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -20339,7 +20339,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.c
@@ -14713,7 +14713,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
@@ -13968,7 +13968,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
@@ -17177,7 +17177,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
@@ -16184,7 +16184,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -17529,7 +17529,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -16502,7 +16502,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
@@ -33538,7 +33538,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
@@ -30971,7 +30971,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.c
@@ -11496,7 +11496,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgb--ixgb.ko-entry_point.cil.out.i
@@ -11001,7 +11001,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -10426,7 +10426,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -10190,7 +10190,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point.cil.out.c
@@ -11208,7 +11208,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point.cil.out.i
@@ -10662,7 +10662,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qla3xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qla3xxx.ko-entry_point.cil.out.c
@@ -12626,7 +12626,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qla3xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qla3xxx.ko-entry_point.cil.out.i
@@ -11914,7 +11914,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.c
@@ -17575,7 +17575,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -16332,7 +16332,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -18791,7 +18791,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -17617,7 +17617,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.c
@@ -9964,7 +9964,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
@@ -9519,7 +9519,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
@@ -9405,7 +9405,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
@@ -9107,7 +9107,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.c
@@ -10203,7 +10203,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--irda--vlsi_ir.ko-entry_point.cil.out.i
@@ -9775,7 +9775,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
@@ -11631,7 +11631,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
@@ -11102,7 +11102,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
@@ -14238,7 +14238,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
@@ -13485,7 +13485,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.c
@@ -14814,7 +14814,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--vmxnet3--vmxnet3.ko-entry_point.cil.out.i
@@ -14016,7 +14016,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wan--lmc--lmc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wan--lmc--lmc.ko-entry_point.cil.out.c
@@ -10006,7 +10006,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wan--lmc--lmc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wan--lmc--lmc.ko-entry_point.cil.out.i
@@ -9597,7 +9597,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point.cil.out.c
@@ -19177,7 +19177,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--airo.ko-entry_point.cil.out.i
@@ -18020,7 +18020,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.c
@@ -22261,7 +22261,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
@@ -21247,7 +21247,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -16477,7 +16477,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -15612,7 +15612,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.c
@@ -24722,7 +24722,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -23274,7 +23274,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
@@ -34452,7 +34452,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -31779,7 +31779,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl3945.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl3945.ko-entry_point.cil.out.c
@@ -17841,7 +17841,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl3945.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl3945.ko-entry_point.cil.out.i
@@ -16880,7 +16880,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl4965.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl4965.ko-entry_point.cil.out.c
@@ -25734,7 +25734,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl4965.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--iwlegacy--iwl4965.ko-entry_point.cil.out.i
@@ -24012,7 +24012,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
@@ -12750,7 +12750,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -12338,7 +12338,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.c
@@ -16789,7 +16789,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -15831,7 +15831,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
@@ -8210,7 +8210,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
@@ -7991,7 +7991,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.c
@@ -14900,7 +14900,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.i
@@ -14137,7 +14137,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
@@ -14386,7 +14386,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
@@ -13703,7 +13703,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point.cil.out.c
@@ -9779,7 +9779,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--pcmcia--pcmcia.ko-entry_point.cil.out.i
@@ -9413,7 +9413,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--aic7xxx--aic7xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--aic7xxx--aic7xxx.ko-entry_point.cil.out.c
@@ -13788,7 +13788,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--aic7xxx--aic7xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--aic7xxx--aic7xxx.ko-entry_point.cil.out.i
@@ -13103,7 +13103,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -21638,7 +21638,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -20410,7 +20410,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--device_handler--scsi_dh_rdac.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--device_handler--scsi_dh_rdac.ko-entry_point.cil.out.c
@@ -5890,7 +5890,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--device_handler--scsi_dh_rdac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--device_handler--scsi_dh_rdac.ko-entry_point.cil.out.i
@@ -5693,7 +5693,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--gdth.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--gdth.ko-entry_point.cil.out.c
@@ -13609,7 +13609,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--gdth.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--gdth.ko-entry_point.cil.out.i
@@ -12863,7 +12863,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point.cil.out.c
@@ -19567,7 +19567,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--hpsa.ko-entry_point.cil.out.i
@@ -18215,7 +18215,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ips.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ips.ko-entry_point.cil.out.c
@@ -13536,7 +13536,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ips.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ips.ko-entry_point.cil.out.i
@@ -12691,7 +12691,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.c
@@ -5273,7 +5273,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.i
@@ -5080,7 +5080,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--osst.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--osst.ko-entry_point.cil.out.c
@@ -12821,7 +12821,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--osst.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--osst.ko-entry_point.cil.out.i
@@ -12044,7 +12044,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--scsi_debug.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--scsi_debug.ko-entry_point.cil.out.c
@@ -15066,7 +15066,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--scsi_debug.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--scsi_debug.ko-entry_point.cil.out.i
@@ -14170,7 +14170,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--st.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--st.ko-entry_point.cil.out.c
@@ -12379,7 +12379,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--st.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--st.ko-entry_point.cil.out.i
@@ -11621,7 +11621,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
@@ -11150,7 +11150,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
@@ -10705,7 +10705,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.c
@@ -12483,7 +12483,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -12077,7 +12077,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.c
@@ -13647,7 +13647,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -13133,7 +13133,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
@@ -11563,7 +11563,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
@@ -11004,7 +11004,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point.cil.out.c
@@ -5515,7 +5515,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point.cil.out.i
@@ -5395,7 +5395,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.c
@@ -9503,7 +9503,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.i
@@ -9192,7 +9192,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.c
@@ -10035,7 +10035,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.i
@@ -9780,7 +9780,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.c
@@ -20958,7 +20958,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.i
@@ -19958,7 +19958,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--n_r3964.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--n_r3964.ko-entry_point.cil.out.c
@@ -5161,7 +5161,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--n_r3964.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--n_r3964.ko-entry_point.cil.out.i
@@ -4959,7 +4959,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.c
@@ -15707,7 +15707,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point.cil.out.i
@@ -14656,7 +14656,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point.cil.out.c
@@ -15092,7 +15092,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclinkmp.ko-entry_point.cil.out.i
@@ -14114,7 +14114,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -8589,7 +8589,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -8152,7 +8152,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
@@ -16440,7 +16440,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
@@ -15314,7 +15314,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.c
@@ -12643,7 +12643,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
@@ -11819,7 +11819,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.c
@@ -12673,7 +12673,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.i
@@ -11847,7 +11847,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.c
@@ -10952,7 +10952,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.i
@@ -10294,7 +10294,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.c
@@ -14696,7 +14696,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
@@ -13766,7 +13766,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.c
@@ -11913,7 +11913,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.i
@@ -11091,7 +11091,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
@@ -9346,7 +9346,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
@@ -8887,7 +8887,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.c
@@ -12048,7 +12048,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.i
@@ -11287,7 +11287,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.c
@@ -9382,7 +9382,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.i
@@ -8850,7 +8850,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--aty--radeonfb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--aty--radeonfb.ko-entry_point.cil.out.c
@@ -7974,7 +7974,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--aty--radeonfb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--aty--radeonfb.ko-entry_point.cil.out.i
@@ -7655,7 +7655,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--via--viafb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--via--viafb.ko-entry_point.cil.out.c
@@ -8730,7 +8730,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--via--viafb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--video--fbdev--via--viafb.ko-entry_point.cil.out.i
@@ -8393,7 +8393,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--xen--xen-pciback--xen-pciback.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--xen--xen-pciback--xen-pciback.ko-entry_point.cil.out.c
@@ -6558,7 +6558,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--xen--xen-pciback--xen-pciback.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--xen--xen-pciback--xen-pciback.ko-entry_point.cil.out.i
@@ -6200,7 +6200,7 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known, thus using ldv_malloc is
perfectly safe. This is in preparation of removing uses of
__VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^__inline static void \*kmalloc\(size_t size , gfp_t flags \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(size);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
