### PR TITLE
Implement alloc_skb using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.c
@@ -11345,7 +11345,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--nicstar.ko-entry_point.cil.out.i
@@ -10856,7 +10856,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.c
@@ -13413,7 +13413,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
@@ -12879,7 +12879,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.c
@@ -9474,7 +9474,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point.cil.out.i
@@ -9155,7 +9155,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.c
@@ -9611,7 +9611,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--w6692.ko-entry_point.cil.out.i
@@ -9256,7 +9256,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.c
@@ -17198,7 +17198,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
@@ -16203,7 +16203,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.c
@@ -28480,7 +28480,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -26461,7 +26461,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.c
@@ -33570,7 +33570,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
@@ -31000,7 +31000,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.c
@@ -30052,7 +30052,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -27852,7 +27852,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
@@ -36789,7 +36789,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -34038,7 +34038,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -48427,7 +48427,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -44511,7 +44511,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.c
@@ -9426,7 +9426,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
@@ -9126,7 +9126,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
@@ -11652,7 +11652,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
@@ -11121,7 +11121,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
@@ -9981,7 +9981,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
@@ -9884,7 +9884,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -30649,7 +30649,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -28663,7 +28663,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
@@ -34484,7 +34484,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -31808,7 +31808,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
@@ -15341,7 +15341,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -14681,7 +14681,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
@@ -8750,7 +8750,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
@@ -8548,7 +8548,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.c
@@ -11595,7 +11595,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--slicoss--slicoss.ko-entry_point.cil.out.i
@@ -11033,7 +11033,7 @@ __inline static struct sk_buff *alloc_skb(unsigned int size , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct sk_buff)),
thus using ldv_malloc is perfectly safe. This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^__inline static struct sk_buff \*alloc_skb\(unsigned int size , gfp_t flags \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct sk_buff));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
