### PR TITLE
Implement ldv___get_free_pages_* using ldv_malloc

### DIFF
--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.c
@@ -7792,6 +7792,7 @@ void ldv_free_irq_21(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_22(gfp_t flags , unsigned int ldv_func_arg2 ) 
 { 
   unsigned long tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
@@ -7470,6 +7470,7 @@ void ldv_free_irq_21(unsigned int ldv_func_arg1 , void *ldv_func_arg2 )
   return;
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_22(gfp_t flags , unsigned int ldv_func_arg2 )
 {
   unsigned long tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point.cil.out.c
@@ -9071,6 +9071,7 @@ void *ldv_kmem_cache_alloc_60(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_64(gfp_t flags , unsigned int ldv_func_arg2 ) 
 { 
   unsigned long tmp ;
@@ -12805,7 +12806,6 @@ void solo_disp_exit(struct solo_dev *solo_dev )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--staging--media--solo6x10--solo6x10.ko-entry_point.cil.out.i
@@ -8751,6 +8751,7 @@ void *ldv_kmem_cache_alloc_60(struct kmem_cache *ldv_func_arg1 , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_64(gfp_t flags , unsigned int ldv_func_arg2 )
 {
   unsigned long tmp ;
@@ -12192,7 +12193,6 @@ void solo_disp_exit(struct solo_dev *solo_dev )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.c
@@ -8678,6 +8678,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_20(gfp_t flags , unsigned int ldv_func_arg2 ) 
 { 
   unsigned long tmp ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--rocket.ko-entry_point.cil.out.i
@@ -8206,6 +8206,7 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
   return ((void *)0);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_20(gfp_t flags , unsigned int ldv_func_arg2 )
 {
   unsigned long tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.c
@@ -18132,7 +18132,7 @@ unsigned long ldv___get_free_pages_28(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--cciss.ko-entry_point.cil.out.i
@@ -17115,7 +17115,7 @@ unsigned long ldv___get_free_pages_28(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.c
@@ -16428,7 +16428,7 @@ unsigned long ldv___get_free_pages_146(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.i
@@ -15640,7 +15640,7 @@ unsigned long ldv___get_free_pages_146(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.c
@@ -14839,7 +14839,7 @@ unsigned long ldv___get_free_pages_43(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -17059,7 +17059,7 @@ unsigned long ldv___get_free_pages_114(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -18390,7 +18390,7 @@ unsigned long ldv___get_free_pages_161(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -19072,7 +19072,7 @@ unsigned long ldv___get_free_pages_216(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -20570,7 +20570,7 @@ unsigned long ldv___get_free_pages_269(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -21770,7 +21770,7 @@ unsigned long ldv___get_free_pages_320(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -22202,7 +22202,7 @@ unsigned long ldv___get_free_pages_367(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -22647,7 +22647,7 @@ unsigned long ldv___get_free_pages_414(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -24247,7 +24247,7 @@ unsigned long ldv___get_free_pages_461(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -25315,7 +25315,7 @@ unsigned long ldv___get_free_pages_510(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -25678,7 +25678,7 @@ unsigned long ldv___get_free_pages_559(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
@@ -14082,7 +14082,7 @@ unsigned long ldv___get_free_pages_43(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -16134,7 +16134,7 @@ unsigned long ldv___get_free_pages_114(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -17322,7 +17322,7 @@ unsigned long ldv___get_free_pages_161(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -17927,7 +17927,7 @@ unsigned long ldv___get_free_pages_216(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -19281,7 +19281,7 @@ unsigned long ldv___get_free_pages_269(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -20375,7 +20375,7 @@ unsigned long ldv___get_free_pages_320(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -20773,7 +20773,7 @@ unsigned long ldv___get_free_pages_367(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -21177,7 +21177,7 @@ unsigned long ldv___get_free_pages_414(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -22627,7 +22627,7 @@ unsigned long ldv___get_free_pages_461(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -23585,7 +23585,7 @@ unsigned long ldv___get_free_pages_510(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -23915,7 +23915,7 @@ unsigned long ldv___get_free_pages_559(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.c
@@ -58658,7 +58658,7 @@ unsigned long ldv___get_free_pages_776(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -53711,7 +53711,7 @@ unsigned long ldv___get_free_pages_776(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.c
@@ -28331,7 +28331,7 @@ unsigned long ldv___get_free_pages_428(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -26567,7 +26567,7 @@ unsigned long ldv___get_free_pages_428(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.c
@@ -11572,7 +11572,7 @@ unsigned long ldv___get_free_pages_38(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.i
@@ -11006,7 +11006,7 @@ unsigned long ldv___get_free_pages_38(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.c
@@ -22418,7 +22418,7 @@ unsigned long ldv___get_free_pages_31(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.i
@@ -20922,7 +20922,7 @@ unsigned long ldv___get_free_pages_31(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.c
@@ -13796,13 +13796,14 @@ void *ldv_dma_pool_alloc_35(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_36(gfp_t flags , unsigned int ldv_func_arg2 ) 
 { 
   void *tmp ;
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -13812,7 +13813,7 @@ unsigned long ldv___get_free_pages_37(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.i
@@ -13075,12 +13075,13 @@ void *ldv_dma_pool_alloc_35(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 unsigned long ldv___get_free_pages_36(gfp_t flags , unsigned int ldv_func_arg2 )
 {
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }
@@ -13089,7 +13090,7 @@ unsigned long ldv___get_free_pages_37(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.c
@@ -36174,7 +36174,7 @@ unsigned long ldv___get_free_pages_190(gfp_t flags , unsigned int ldv_func_arg2 
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.i
@@ -33952,7 +33952,7 @@ unsigned long ldv___get_free_pages_190(gfp_t flags , unsigned int ldv_func_arg2 
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.c
@@ -10640,7 +10640,7 @@ unsigned long ldv___get_free_pages_70(gfp_t flags , unsigned int ldv_func_arg2 )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--unisys--visorbus--visorbus.ko-entry_point.cil.out.i
@@ -10217,7 +10217,7 @@ unsigned long ldv___get_free_pages_70(gfp_t flags , unsigned int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));
   return ((unsigned long )tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (the second argument is the
order, which is the 2-logarithm of the number of pages, and a page
usually is 4K), thus using ldv_malloc is perfectly safe. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^unsigned long ldv___get_free_pages_\d+\(gfp_t flags , unsigned int ldv_func_arg2 \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(4096UL * (1 << ldv_func_arg2));\n";
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
