### PR TITLE
Make ldv_linux_usb_gadget_create_class work without ldv_undef_ptr

### DIFF
--- a/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -4053,7 +4053,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4110,7 +4110,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9259,14 +9259,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c
@@ -7223,7 +7223,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7279,7 +7279,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15506,14 +15506,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.i
@@ -7218,7 +7218,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7267,7 +7267,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14688,13 +14688,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c
@@ -5296,7 +5296,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5352,7 +5352,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17735,14 +17735,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -5292,7 +5292,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5341,7 +5341,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16614,13 +16614,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.c
@@ -5210,7 +5210,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5267,7 +5267,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21867,14 +21867,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--nvme.ko.cil.i
@@ -5205,7 +5205,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5255,7 +5255,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20322,13 +20322,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c
@@ -4260,7 +4260,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4315,7 +4315,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8922,14 +8922,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.i
@@ -4256,7 +4256,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4304,7 +4304,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8410,13 +8410,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c
@@ -4675,7 +4675,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4727,7 +4727,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16055,14 +16055,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -4671,7 +4671,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -4716,7 +4716,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14944,13 +14944,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.c
@@ -5058,7 +5058,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5114,7 +5114,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20621,14 +20621,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--skd.ko.cil.i
@@ -5054,7 +5054,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5103,7 +5103,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19258,13 +19258,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c
@@ -4492,7 +4492,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4547,7 +4547,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10075,14 +10075,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.i
@@ -4488,7 +4488,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4536,7 +4536,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9538,13 +9538,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c
@@ -4655,7 +4655,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4710,7 +4710,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12485,14 +12485,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.i
@@ -4651,7 +4651,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4699,7 +4699,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11686,13 +11686,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c
@@ -4154,7 +4154,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4209,7 +4209,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15783,14 +15783,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.i
@@ -4149,7 +4149,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4197,7 +4197,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14703,13 +14703,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -4419,7 +4419,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4471,7 +4471,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21827,14 +21827,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -4414,7 +4414,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -4459,7 +4459,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20208,13 +20208,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c
@@ -6036,7 +6036,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6092,7 +6092,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22047,14 +22047,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -6031,7 +6031,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6080,7 +6080,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20518,13 +20518,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -6271,7 +6271,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6327,7 +6327,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27401,14 +27401,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -6266,7 +6266,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6315,7 +6315,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25399,13 +25399,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c
@@ -4195,7 +4195,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4250,7 +4250,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29826,14 +29826,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.i
@@ -4191,7 +4191,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4239,7 +4239,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27712,13 +27712,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c
@@ -4970,7 +4970,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5027,7 +5027,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17571,14 +17571,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.i
@@ -4966,7 +4966,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5016,7 +5016,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16334,13 +16334,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c
@@ -3916,7 +3916,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3972,7 +3972,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9766,14 +9766,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.i
@@ -3911,7 +3911,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3960,7 +3960,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9154,13 +9154,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c
@@ -4121,7 +4121,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4177,7 +4177,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16911,14 +16911,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.i
@@ -4116,7 +4116,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4165,7 +4165,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15824,13 +15824,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c
@@ -5287,7 +5287,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5344,7 +5344,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -34038,14 +34038,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.i
@@ -5282,7 +5282,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5332,7 +5332,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31420,13 +31420,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c
@@ -4426,7 +4426,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4482,7 +4482,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11191,14 +11191,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.i
@@ -4421,7 +4421,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4470,7 +4470,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10471,13 +10471,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c
@@ -6295,7 +6295,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_unregister_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -6352,7 +6352,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20210,14 +20210,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.i
@@ -6289,7 +6289,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_unregister_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -6339,7 +6339,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18991,13 +18991,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c
@@ -4282,7 +4282,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4339,7 +4339,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11329,14 +11329,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.i
@@ -4278,7 +4278,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4328,7 +4328,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10631,13 +10631,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c
@@ -4298,7 +4298,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4354,7 +4354,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10011,14 +10011,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.i
@@ -4293,7 +4293,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4342,7 +4342,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9437,13 +9437,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c
@@ -4217,7 +4217,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4274,7 +4274,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13224,14 +13224,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.i
@@ -4213,7 +4213,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4263,7 +4263,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12312,13 +12312,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -5003,7 +5003,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5058,7 +5058,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -28895,14 +28895,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -4999,7 +4999,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5047,7 +5047,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -26794,13 +26794,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c
@@ -6923,7 +6923,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -6981,7 +6981,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31518,14 +31518,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.i
@@ -6918,7 +6918,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -6969,7 +6969,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29098,13 +29098,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c
@@ -4013,7 +4013,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4071,7 +4071,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9464,14 +9464,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i
@@ -4009,7 +4009,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4060,7 +4060,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8914,13 +8914,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c
@@ -7645,7 +7645,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7701,7 +7701,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18843,14 +18843,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.i
@@ -7640,7 +7640,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7689,7 +7689,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17771,13 +17771,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c
@@ -5579,7 +5579,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5635,7 +5635,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14304,14 +14304,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -5574,7 +5574,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5623,7 +5623,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13401,13 +13401,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c
@@ -7392,7 +7392,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7449,7 +7449,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13224,14 +13224,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.i
@@ -7387,7 +7387,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7437,7 +7437,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12643,13 +12643,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c
@@ -6258,7 +6258,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6314,7 +6314,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -26478,14 +26478,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.i
@@ -6251,7 +6251,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6300,7 +6300,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24484,13 +24484,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c
@@ -4455,7 +4455,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4510,7 +4510,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12123,14 +12123,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.i
@@ -4451,7 +4451,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4499,7 +4499,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11298,13 +11298,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c
@@ -4401,7 +4401,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4456,7 +4456,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9923,14 +9923,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.i
@@ -4397,7 +4397,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4445,7 +4445,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9351,13 +9351,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c
@@ -4913,7 +4913,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4972,7 +4972,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22278,14 +22278,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.i
@@ -4909,7 +4909,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4961,7 +4961,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20736,13 +20736,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c
@@ -4640,7 +4640,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4695,7 +4695,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -35427,14 +35427,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.i
@@ -4636,7 +4636,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4684,7 +4684,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -32561,13 +32561,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c
@@ -3905,7 +3905,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3960,7 +3960,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16296,14 +16296,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.i
@@ -3901,7 +3901,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3949,7 +3949,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15084,13 +15084,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c
@@ -4447,7 +4447,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4503,7 +4503,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13297,14 +13297,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i
@@ -4442,7 +4442,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4491,7 +4491,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12441,13 +12441,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c
@@ -3846,7 +3846,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3901,7 +3901,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9072,14 +9072,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.i
@@ -3842,7 +3842,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3890,7 +3890,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8501,13 +8501,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c
@@ -4910,7 +4910,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4962,7 +4962,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -37877,14 +37877,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.i
@@ -4906,7 +4906,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -4951,7 +4951,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -35147,13 +35147,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c
@@ -6545,7 +6545,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6601,7 +6601,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13060,14 +13060,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.i
@@ -6539,7 +6539,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6588,7 +6588,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12373,13 +12373,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c
@@ -6367,7 +6367,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6422,7 +6422,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13069,14 +13069,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.i
@@ -6362,7 +6362,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6410,7 +6410,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12482,13 +12482,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c
@@ -6178,7 +6178,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6234,7 +6234,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13498,14 +13498,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.i
@@ -6173,7 +6173,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6222,7 +6222,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12786,13 +12786,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c
@@ -7019,7 +7019,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7075,7 +7075,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18546,14 +18546,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.i
@@ -7013,7 +7013,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7062,7 +7062,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17402,13 +17402,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c
@@ -7100,7 +7100,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7156,7 +7156,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18314,14 +18314,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -7095,7 +7095,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7144,7 +7144,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17254,13 +17254,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c
@@ -7585,7 +7585,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7641,7 +7641,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -49107,14 +49107,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.i
@@ -7579,7 +7579,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7628,7 +7628,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -45387,13 +45387,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c
@@ -7523,7 +7523,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7579,7 +7579,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -26150,14 +26150,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -7518,7 +7518,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7567,7 +7567,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24486,13 +24486,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c
@@ -6162,7 +6162,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6218,7 +6218,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13171,14 +13171,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -6157,7 +6157,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6206,7 +6206,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12469,13 +12469,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c
@@ -5948,7 +5948,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6004,7 +6004,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12746,14 +12746,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.i
@@ -5942,7 +5942,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5991,7 +5991,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12022,13 +12022,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c
@@ -6131,7 +6131,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6187,7 +6187,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13032,14 +13032,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -6126,7 +6126,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6175,7 +6175,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12337,13 +12337,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c
@@ -7849,7 +7849,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7905,7 +7905,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24563,14 +24563,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.i
@@ -7844,7 +7844,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7893,7 +7893,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23014,13 +23014,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c
@@ -7160,7 +7160,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -7212,7 +7212,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19473,14 +19473,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.i
@@ -7155,7 +7155,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -7200,7 +7200,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18381,13 +18381,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c
@@ -7675,7 +7675,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -7727,7 +7727,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31509,14 +31509,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.i
@@ -7670,7 +7670,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -7715,7 +7715,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29366,13 +29366,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c
@@ -7448,7 +7448,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7504,7 +7504,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27624,14 +27624,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.i
@@ -7443,7 +7443,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7492,7 +7492,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25651,13 +25651,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c
@@ -6661,7 +6661,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6716,7 +6716,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13913,14 +13913,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.i
@@ -6656,7 +6656,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6704,7 +6704,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13216,13 +13216,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -6701,7 +6701,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -6759,7 +6759,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16359,14 +16359,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -6696,7 +6696,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -6747,7 +6747,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15395,13 +15395,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.c
@@ -6305,7 +6305,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6360,7 +6360,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19683,14 +19683,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--team--team.ko.cil.i
@@ -6300,7 +6300,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6348,7 +6348,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18349,13 +18349,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c
@@ -6284,7 +6284,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6341,7 +6341,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12336,14 +12336,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.i
@@ -6279,7 +6279,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6329,7 +6329,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11729,13 +11729,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c
@@ -7504,7 +7504,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7561,7 +7561,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16033,14 +16033,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.i
@@ -7499,7 +7499,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7549,7 +7549,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15208,13 +15208,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c
@@ -7641,7 +7641,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7697,7 +7697,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21940,14 +21940,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -7636,7 +7636,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7685,7 +7685,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20731,13 +20731,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c
@@ -9049,7 +9049,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -9101,7 +9101,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -39368,14 +39368,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.i
@@ -9043,7 +9043,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -9088,7 +9088,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -36985,13 +36985,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.c
@@ -4390,7 +4390,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4447,7 +4447,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9696,14 +9696,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--nfc--port100.ko.cil.i
@@ -4386,7 +4386,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4436,7 +4436,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9161,13 +9161,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c
@@ -5702,7 +5702,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5758,7 +5758,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23031,14 +23031,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.i
@@ -5698,7 +5698,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5747,7 +5747,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21537,13 +21537,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c
@@ -6327,7 +6327,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -6385,7 +6385,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27087,14 +27087,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.i
@@ -6323,7 +6323,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -6374,7 +6374,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25199,13 +25199,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c
@@ -5449,7 +5449,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5505,7 +5505,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20359,14 +20359,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.i
@@ -5445,7 +5445,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5494,7 +5494,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19107,13 +19107,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c
@@ -8796,7 +8796,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -8848,7 +8848,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -32617,14 +32617,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.i
@@ -8791,7 +8791,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -8836,7 +8836,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -30598,13 +30598,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c
@@ -6531,7 +6531,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6583,7 +6583,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27598,14 +27598,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.i
@@ -6527,7 +6527,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -6572,7 +6572,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25684,13 +25684,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c
@@ -5668,7 +5668,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5724,7 +5724,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25962,14 +25962,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.i
@@ -5664,7 +5664,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5713,7 +5713,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24097,13 +24097,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c
@@ -5432,7 +5432,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major___0 ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -5490,7 +5490,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16807,14 +16807,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i
@@ -5428,7 +5428,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major___0 ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -5479,7 +5479,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15769,13 +15769,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c
@@ -6420,7 +6420,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6476,7 +6476,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23095,14 +23095,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.i
@@ -6416,7 +6416,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6465,7 +6465,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21529,13 +21529,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c
@@ -7004,7 +7004,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7060,7 +7060,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -41625,14 +41625,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.i
@@ -7000,7 +7000,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7049,7 +7049,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -38684,13 +38684,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c
@@ -8286,7 +8286,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -8345,7 +8345,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21560,14 +21560,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -8281,7 +8281,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -8333,7 +8333,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20325,13 +20325,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c
@@ -10223,7 +10223,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -10279,7 +10279,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -72390,14 +72390,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.i
@@ -10218,7 +10218,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -10267,7 +10267,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -66972,13 +66972,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -5028,7 +5028,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -5086,7 +5086,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19859,14 +19859,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -5024,7 +5024,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -5075,7 +5075,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18519,13 +18519,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c
@@ -4926,7 +4926,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4978,7 +4978,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25109,14 +25109,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.i
@@ -4922,7 +4922,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -4967,7 +4967,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23176,13 +23176,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c
@@ -6762,7 +6762,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6817,7 +6817,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24036,14 +24036,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.i
@@ -6756,7 +6756,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6804,7 +6804,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22322,13 +22322,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c
@@ -4061,7 +4061,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4118,7 +4118,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10054,14 +10054,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.i
@@ -4057,7 +4057,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4107,7 +4107,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9423,13 +9423,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c
@@ -4213,7 +4213,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4269,7 +4269,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13138,14 +13138,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.i
@@ -4208,7 +4208,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4257,7 +4257,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12226,13 +12226,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c
@@ -4231,7 +4231,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4287,7 +4287,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13211,14 +13211,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.i
@@ -4226,7 +4226,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4275,7 +4275,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12286,13 +12286,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c
@@ -4194,7 +4194,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4250,7 +4250,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12665,14 +12665,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.i
@@ -4189,7 +4189,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4238,7 +4238,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11814,13 +11814,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c
@@ -4239,7 +4239,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4295,7 +4295,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15216,14 +15216,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.i
@@ -4234,7 +4234,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4283,7 +4283,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14159,13 +14159,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c
@@ -4042,7 +4042,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4099,7 +4099,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9004,14 +9004,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.i
@@ -4038,7 +4038,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4088,7 +4088,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8465,13 +8465,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c
@@ -4045,7 +4045,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4102,7 +4102,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8718,14 +8718,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.i
@@ -4041,7 +4041,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4091,7 +4091,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8199,13 +8199,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c
@@ -4224,7 +4224,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4281,7 +4281,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9352,14 +9352,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.i
@@ -4220,7 +4220,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4270,7 +4270,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8792,13 +8792,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c
@@ -4022,7 +4022,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4079,7 +4079,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8389,14 +8389,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.i
@@ -4018,7 +4018,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4068,7 +4068,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -7912,13 +7912,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c
@@ -5009,7 +5009,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5065,7 +5065,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27107,14 +27107,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.i
@@ -5004,7 +5004,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5053,7 +5053,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25192,13 +25192,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c
@@ -4493,7 +4493,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -4551,7 +4551,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19464,14 +19464,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -4489,7 +4489,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -4540,7 +4540,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18111,13 +18111,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c
@@ -4735,7 +4735,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4791,7 +4791,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10775,14 +10775,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -4731,7 +4731,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4780,7 +4780,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10167,13 +10167,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c
@@ -4678,7 +4678,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4735,7 +4735,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12071,14 +12071,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.i
@@ -4674,7 +4674,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4724,7 +4724,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11370,13 +11370,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c
@@ -4015,7 +4015,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4071,7 +4071,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10146,14 +10146,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.i
@@ -4011,7 +4011,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4060,7 +4060,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9505,13 +9505,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c
@@ -4411,7 +4411,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4467,7 +4467,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19330,14 +19330,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.i
@@ -4407,7 +4407,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4456,7 +4456,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17979,13 +17979,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c
@@ -6915,7 +6915,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6967,7 +6967,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23951,14 +23951,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.i
@@ -6910,7 +6910,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -6955,7 +6955,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22334,13 +22334,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c
@@ -7871,7 +7871,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7926,7 +7926,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -33816,14 +33816,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.i
@@ -7866,7 +7866,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7914,7 +7914,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31480,13 +31480,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c
@@ -4305,7 +4305,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4357,7 +4357,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16290,14 +16290,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.i
@@ -4301,7 +4301,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -4346,7 +4346,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15234,13 +15234,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c
@@ -3453,7 +3453,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3508,7 +3508,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8325,14 +8325,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.i
@@ -3450,7 +3450,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3498,7 +3498,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -7760,13 +7760,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -6828,7 +6828,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6880,7 +6880,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29859,14 +29859,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -6823,7 +6823,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void)
 {
@@ -6868,7 +6868,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27749,13 +27749,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c
@@ -6879,7 +6879,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6934,7 +6934,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12777,14 +12777,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -6874,7 +6874,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6922,7 +6922,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12148,13 +12148,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.c
@@ -6860,7 +6860,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6915,7 +6915,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23862,14 +23862,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--rose--rose.ko.cil.i
@@ -6855,7 +6855,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6903,7 +6903,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22267,13 +22267,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c
@@ -4154,7 +4154,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4209,7 +4209,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13583,14 +13583,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.i
@@ -4150,7 +4150,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4198,7 +4198,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12587,13 +12587,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c
@@ -4397,7 +4397,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4452,7 +4452,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12788,14 +12788,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.i
@@ -4393,7 +4393,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4441,7 +4441,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11884,13 +11884,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c
@@ -5216,7 +5216,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5272,7 +5272,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -34263,14 +34263,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.i
@@ -5211,7 +5211,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5260,7 +5260,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31616,13 +31616,11 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget = 0;
-void *ldv_linux_usb_gadget_create_class(void)
+void *ldv_linux_usb_gadget_create_class(void *is_got )
 {
-  void *is_got ;
   long tmp ;
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const *)is_got);
   }

--- a/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
+++ b/c/ldv-multiproperty-todo/linux-4.0-rc1---drivers--usb--misc--adutux.ko_true-unreach-call.cil.c
@@ -4053,7 +4053,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4110,7 +4110,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9259,14 +9259,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko_false-unreach-call.cil.c
@@ -7223,7 +7223,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7279,7 +7279,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15506,14 +15506,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.c
@@ -5296,7 +5296,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5352,7 +5352,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17735,14 +17735,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko_false-unreach-call.cil.c
@@ -5210,7 +5210,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5267,7 +5267,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21867,14 +21867,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko_false-unreach-call.cil.c
@@ -4260,7 +4260,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4315,7 +4315,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8922,14 +8922,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.c
@@ -4675,7 +4675,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4727,7 +4727,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16055,14 +16055,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko_false-unreach-call.cil.c
@@ -5058,7 +5058,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5114,7 +5114,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20621,14 +20621,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko_false-unreach-call.cil.c
@@ -4492,7 +4492,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4547,7 +4547,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10075,14 +10075,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko_false-unreach-call.cil.c
@@ -4655,7 +4655,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4710,7 +4710,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12485,14 +12485,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4154,7 +4154,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4209,7 +4209,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15783,14 +15783,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -4419,7 +4419,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4471,7 +4471,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21827,14 +21827,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.c
@@ -6036,7 +6036,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6092,7 +6092,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22047,14 +22047,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -6271,7 +6271,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6327,7 +6327,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27401,14 +27401,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -4195,7 +4195,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4250,7 +4250,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29826,14 +29826,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko_false-unreach-call.cil.c
@@ -4970,7 +4970,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5027,7 +5027,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -17571,14 +17571,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -3916,7 +3916,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3972,7 +3972,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9766,14 +9766,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4121,7 +4121,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4177,7 +4177,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16911,14 +16911,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko_false-unreach-call.cil.c
@@ -5287,7 +5287,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -5344,7 +5344,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -34038,14 +34038,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko_false-unreach-call.cil.c
@@ -4426,7 +4426,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4482,7 +4482,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11191,14 +11191,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko_false-unreach-call.cil.c
@@ -6295,7 +6295,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_unregister_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
@@ -6352,7 +6352,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20210,14 +20210,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -4282,7 +4282,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4339,7 +4339,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -11329,14 +11329,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko_false-unreach-call.cil.c
@@ -4298,7 +4298,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4354,7 +4354,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10011,14 +10011,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -4217,7 +4217,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4274,7 +4274,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13224,14 +13224,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -5003,7 +5003,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5058,7 +5058,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -28895,14 +28895,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko_false-unreach-call.cil.c
@@ -6923,7 +6923,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -6981,7 +6981,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31518,14 +31518,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4013,7 +4013,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4071,7 +4071,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9464,14 +9464,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7645,7 +7645,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7701,7 +7701,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18843,14 +18843,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -5579,7 +5579,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5635,7 +5635,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -14304,14 +14304,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko_false-unreach-call.cil.c
@@ -7392,7 +7392,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7449,7 +7449,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13224,14 +13224,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -6258,7 +6258,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6314,7 +6314,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -26478,14 +26478,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko_false-unreach-call.cil.c
@@ -4455,7 +4455,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4510,7 +4510,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12123,14 +12123,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko_false-unreach-call.cil.c
@@ -4401,7 +4401,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4456,7 +4456,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9923,14 +9923,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko_false-unreach-call.cil.c
@@ -4913,7 +4913,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -4972,7 +4972,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -22278,14 +22278,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko_false-unreach-call.cil.c
@@ -4640,7 +4640,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4695,7 +4695,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -35427,14 +35427,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -3905,7 +3905,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3960,7 +3960,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16296,14 +16296,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4447,7 +4447,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4503,7 +4503,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13297,14 +13297,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko_false-unreach-call.cil.c
@@ -3846,7 +3846,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3901,7 +3901,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9072,14 +9072,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko_false-unreach-call.cil.c
@@ -4910,7 +4910,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4962,7 +4962,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -37877,14 +37877,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko_false-unreach-call.cil.c
@@ -6545,7 +6545,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6601,7 +6601,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13060,14 +13060,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko_false-unreach-call.cil.c
@@ -6367,7 +6367,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6422,7 +6422,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13069,14 +13069,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6178,7 +6178,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6234,7 +6234,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13498,14 +13498,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko_false-unreach-call.cil.c
@@ -7019,7 +7019,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7075,7 +7075,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18546,14 +18546,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7100,7 +7100,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7156,7 +7156,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -18314,14 +18314,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko_false-unreach-call.cil.c
@@ -7585,7 +7585,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7641,7 +7641,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -49107,14 +49107,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.c
@@ -7523,7 +7523,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7579,7 +7579,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -26150,14 +26150,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6162,7 +6162,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6218,7 +6218,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13171,14 +13171,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -5948,7 +5948,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6004,7 +6004,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12746,14 +12746,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6131,7 +6131,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6187,7 +6187,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13032,14 +13032,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko_false-unreach-call.cil.c
@@ -7849,7 +7849,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7905,7 +7905,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24563,14 +24563,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7160,7 +7160,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -7212,7 +7212,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19473,14 +19473,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko_false-unreach-call.cil.c
@@ -7675,7 +7675,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -7727,7 +7727,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -31509,14 +31509,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko_false-unreach-call.cil.c
@@ -7448,7 +7448,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7504,7 +7504,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27624,14 +27624,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko_false-unreach-call.cil.c
@@ -6661,7 +6661,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6716,7 +6716,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13913,14 +13913,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -6701,7 +6701,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -6759,7 +6759,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16359,14 +16359,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko_false-unreach-call.cil.c
@@ -6305,7 +6305,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6360,7 +6360,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19683,14 +19683,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko_false-unreach-call.cil.c
@@ -6284,7 +6284,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6341,7 +6341,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12336,14 +12336,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko_false-unreach-call.cil.c
@@ -7504,7 +7504,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7561,7 +7561,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16033,14 +16033,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7641,7 +7641,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7697,7 +7697,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21940,14 +21940,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko_false-unreach-call.cil.c
@@ -9049,7 +9049,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -9101,7 +9101,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -39368,14 +39368,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko_false-unreach-call.cil.c
@@ -4390,7 +4390,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4447,7 +4447,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9696,14 +9696,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -5702,7 +5702,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5758,7 +5758,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23031,14 +23031,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko_false-unreach-call.cil.c
@@ -6327,7 +6327,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -6385,7 +6385,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27087,14 +27087,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko_false-unreach-call.cil.c
@@ -5449,7 +5449,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5505,7 +5505,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -20359,14 +20359,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko_false-unreach-call.cil.c
@@ -8796,7 +8796,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -8848,7 +8848,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -32617,14 +32617,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko_false-unreach-call.cil.c
@@ -6531,7 +6531,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6583,7 +6583,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27598,14 +27598,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko_false-unreach-call.cil.c
@@ -5668,7 +5668,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5724,7 +5724,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25962,14 +25962,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko_false-unreach-call.cil.c
@@ -5432,7 +5432,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 int ldv_linux_usb_gadget_register_chrdev(int major___0 ) ;
 void ldv_linux_usb_gadget_unregister_chrdev_region(void) ;
@@ -5490,7 +5490,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16807,14 +16807,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko_false-unreach-call.cil.c
@@ -6420,7 +6420,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6476,7 +6476,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23095,14 +23095,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko_false-unreach-call.cil.c
@@ -7004,7 +7004,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7060,7 +7060,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -41625,14 +41625,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.c
@@ -8286,7 +8286,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -8345,7 +8345,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -21560,14 +21560,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko_false-unreach-call.cil.c
@@ -10223,7 +10223,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -10279,7 +10279,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -72390,14 +72390,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -5028,7 +5028,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev_region(void) ;
@@ -5086,7 +5086,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19859,14 +19859,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko_false-unreach-call.cil.c
@@ -4926,7 +4926,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4978,7 +4978,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -25109,14 +25109,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko_false-unreach-call.cil.c
@@ -6762,7 +6762,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6817,7 +6817,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -24036,14 +24036,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko_false-unreach-call.cil.c
@@ -4061,7 +4061,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4118,7 +4118,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10054,14 +10054,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko_false-unreach-call.cil.c
@@ -4213,7 +4213,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4269,7 +4269,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13138,14 +13138,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko_false-unreach-call.cil.c
@@ -4231,7 +4231,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4287,7 +4287,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13211,14 +13211,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko_false-unreach-call.cil.c
@@ -4194,7 +4194,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4250,7 +4250,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12665,14 +12665,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4239,7 +4239,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4295,7 +4295,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -15216,14 +15216,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -4042,7 +4042,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4099,7 +4099,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9004,14 +9004,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko_false-unreach-call.cil.c
@@ -4045,7 +4045,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4102,7 +4102,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8718,14 +8718,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko_false-unreach-call.cil.c
@@ -4224,7 +4224,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4281,7 +4281,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -9352,14 +9352,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko_false-unreach-call.cil.c
@@ -4022,7 +4022,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4079,7 +4079,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8389,14 +8389,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko_false-unreach-call.cil.c
@@ -5009,7 +5009,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5065,7 +5065,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -27107,14 +27107,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.c
@@ -4493,7 +4493,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_destroy_class(struct class *cls ) ;
 int ldv_linux_usb_gadget_register_chrdev(int major ) ;
@@ -4551,7 +4551,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19464,14 +19464,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.c
@@ -4735,7 +4735,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4791,7 +4791,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10775,14 +10775,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko_false-unreach-call.cil.c
@@ -4678,7 +4678,7 @@ void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void *ldv_linux_usb_coherent_usb_alloc_coherent(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4735,7 +4735,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12071,14 +12071,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4015,7 +4015,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4071,7 +4071,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -10146,14 +10146,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4411,7 +4411,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4467,7 +4467,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -19330,14 +19330,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko_false-unreach-call.cil.c
@@ -6915,7 +6915,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6967,7 +6967,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23951,14 +23951,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -7871,7 +7871,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -7926,7 +7926,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -33816,14 +33816,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4305,7 +4305,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -4357,7 +4357,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -16290,14 +16290,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko_false-unreach-call.cil.c
@@ -3453,7 +3453,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -3508,7 +3508,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -8325,14 +8325,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -6828,7 +6828,7 @@ void ldv_linux_kernel_rcu_update_lock_bh_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_sched_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_update_lock_check_for_read_section(void) ;
 void ldv_linux_kernel_rcu_srcu_check_for_read_section(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_check_alloc_nonatomic(void) 
 { 
@@ -6880,7 +6880,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -29859,14 +29859,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.c
@@ -6879,7 +6879,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6934,7 +6934,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12777,14 +12777,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -6860,7 +6860,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -6915,7 +6915,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -23862,14 +23862,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko_false-unreach-call.cil.c
@@ -4154,7 +4154,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4209,7 +4209,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -13583,14 +13583,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko_true-unreach-call.cil.c_false-unreach-call.cil.c
@@ -4397,7 +4397,7 @@ void ldv_linux_net_register_reset_error_counter(void) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -4452,7 +4452,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -12788,14 +12788,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko_false-unreach-call.cil.c
@@ -5216,7 +5216,7 @@ void ldv_linux_net_register_check_return_value_probe(int retval ) ;
 void ldv_linux_net_rtnetlink_check_final_state(void) ;
 void ldv_linux_net_sock_check_final_state(void) ;
 void ldv_linux_usb_coherent_check_final_state(void) ;
-void *ldv_linux_usb_gadget_create_class(void) ;
+void *ldv_linux_usb_gadget_create_class(void *is_got ) ;
 int ldv_linux_usb_gadget_register_class(void) ;
 void ldv_linux_usb_gadget_check_final_state(void) ;
 void ldv_linux_usb_register_reset_error_counter(void) ;
@@ -5272,7 +5272,7 @@ void *ldv_create_class(void)
   {
   tmp = ldv_linux_drivers_base_class_create_class();
   res1 = tmp;
-  tmp___0 = ldv_linux_usb_gadget_create_class();
+  tmp___0 = ldv_linux_usb_gadget_create_class(res1);
   res2 = tmp___0;
   ldv_assume((unsigned long )res1 == (unsigned long )res2);
   }
@@ -34263,14 +34263,12 @@ void ldv_assert_linux_usb_gadget__double_usb_gadget_deregistration(int expr ) ;
 void ldv_assert_linux_usb_gadget__double_usb_gadget_registration(int expr ) ;
 void ldv_assert_linux_usb_gadget__usb_gadget_registered_at_exit(int expr ) ;
 int ldv_linux_usb_gadget_usb_gadget  =    0;
-void *ldv_linux_usb_gadget_create_class(void) 
+void *ldv_linux_usb_gadget_create_class(void *is_got ) 
 { 
-  void *is_got ;
   long tmp ;
 
   {
   {
-  is_got = ldv_undef_ptr();
   ldv_assume((int )((long )is_got));
   tmp = ldv_is_err((void const   *)is_got);
   }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. In this case, make sure ldv_create_class will
work by passing along the expected pointer.  This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^void \*ldv_linux_usb_gadget_create_class\(void\) ?;?$/) {
       $p = 2;
       s/\(void\)/(void *is_got )/
     }
     elsif(/^void \*ldv_create_class\(void\) ?$/) {
       $p = 3;
     }
     if($p == 2) {
       if(/^  void \*is_got ;$/) { next; }
       elsif(/^  is_got = ldv_undef_ptr\(\);$/) { next; }
       elsif(/^\}$/) { $p = 1; }
     }
     elsif($p == 3) {
       if(/^  tmp___0 = ldv_linux_usb_gadget_create_class\(\);$/) {
         print "  tmp___0 = ldv_linux_usb_gadget_create_class(res1);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
