### PR TITLE
Implement ldv_usb_alloc_urb_* using ldv_malloc

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.c
@@ -12096,7 +12096,7 @@ struct urb *ldv_usb_alloc_urb_63(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12106,7 +12106,7 @@ struct urb *ldv_usb_alloc_urb_64(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12116,7 +12116,7 @@ struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12126,7 +12126,7 @@ struct urb *ldv_usb_alloc_urb_66(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12136,7 +12136,7 @@ struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12146,7 +12146,7 @@ struct urb *ldv_usb_alloc_urb_68(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--isdn--gigaset--bas_gigaset.ko-entry_point.cil.out.i
@@ -11469,7 +11469,7 @@ struct urb *ldv_usb_alloc_urb_63(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11478,7 +11478,7 @@ struct urb *ldv_usb_alloc_urb_64(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11487,7 +11487,7 @@ struct urb *ldv_usb_alloc_urb_65(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11496,7 +11496,7 @@ struct urb *ldv_usb_alloc_urb_66(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11505,7 +11505,7 @@ struct urb *ldv_usb_alloc_urb_67(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11514,7 +11514,7 @@ struct urb *ldv_usb_alloc_urb_68(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.c
@@ -8723,7 +8723,7 @@ struct urb *ldv_usb_alloc_urb_46(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cpia2--cpia2.ko-entry_point.cil.out.i
@@ -8384,7 +8384,7 @@ struct urb *ldv_usb_alloc_urb_46(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
@@ -19067,7 +19067,7 @@ struct urb *ldv_usb_alloc_urb_188(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -19098,7 +19098,7 @@ struct urb *ldv_usb_alloc_urb_191(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -29576,7 +29576,7 @@ struct urb *ldv_usb_alloc_urb_381(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -18116,7 +18116,7 @@ struct urb *ldv_usb_alloc_urb_188(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -18144,7 +18144,7 @@ struct urb *ldv_usb_alloc_urb_191(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -28030,7 +28030,7 @@ struct urb *ldv_usb_alloc_urb_381(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
@@ -10166,7 +10166,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -10198,7 +10198,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
@@ -9703,7 +9703,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9732,7 +9732,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.c
@@ -13949,13 +13949,14 @@ void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_f
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_usb_alloc_urb_133(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -15825,7 +15826,7 @@ struct urb *ldv_usb_alloc_urb_202(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.i
@@ -13279,12 +13279,13 @@ void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_f
   return (tmp);
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_usb_alloc_urb_133(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -14992,7 +14993,7 @@ struct urb *ldv_usb_alloc_urb_202(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
@@ -14378,7 +14378,7 @@ struct urb *ldv_usb_alloc_urb_44(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -14388,7 +14388,7 @@ struct urb *ldv_usb_alloc_urb_45(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -14398,7 +14398,7 @@ struct urb *ldv_usb_alloc_urb_46(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
@@ -13611,7 +13611,7 @@ struct urb *ldv_usb_alloc_urb_44(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -13620,7 +13620,7 @@ struct urb *ldv_usb_alloc_urb_45(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -13629,7 +13629,7 @@ struct urb *ldv_usb_alloc_urb_46(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
@@ -12611,7 +12611,7 @@ struct urb *ldv_usb_alloc_urb_88(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12631,7 +12631,7 @@ struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12681,7 +12681,7 @@ struct urb *ldv_usb_alloc_urb_95(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12691,7 +12691,7 @@ struct urb *ldv_usb_alloc_urb_96(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12711,7 +12711,7 @@ struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
@@ -12258,7 +12258,7 @@ struct urb *ldv_usb_alloc_urb_88(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12276,7 +12276,7 @@ struct urb *ldv_usb_alloc_urb_90(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12321,7 +12321,7 @@ struct urb *ldv_usb_alloc_urb_95(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12330,7 +12330,7 @@ struct urb *ldv_usb_alloc_urb_96(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12348,7 +12348,7 @@ struct urb *ldv_usb_alloc_urb_98(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
@@ -10895,7 +10895,7 @@ struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -20004,7 +20004,7 @@ struct urb *ldv_usb_alloc_urb_301(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -20014,7 +20014,7 @@ struct urb *ldv_usb_alloc_urb_302(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -10667,7 +10667,7 @@ struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -18899,7 +18899,7 @@ struct urb *ldv_usb_alloc_urb_301(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -18908,7 +18908,7 @@ struct urb *ldv_usb_alloc_urb_302(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
@@ -22410,7 +22410,7 @@ struct urb *ldv_usb_alloc_urb_377(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -22451,7 +22451,7 @@ struct urb *ldv_usb_alloc_urb_381(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -22504,7 +22504,7 @@ struct urb *ldv_usb_alloc_urb_386(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -22619,7 +22619,7 @@ struct urb *ldv_usb_alloc_urb_396(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
@@ -21061,7 +21061,7 @@ struct urb *ldv_usb_alloc_urb_377(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -21098,7 +21098,7 @@ struct urb *ldv_usb_alloc_urb_381(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -21146,7 +21146,7 @@ struct urb *ldv_usb_alloc_urb_386(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -21244,7 +21244,7 @@ struct urb *ldv_usb_alloc_urb_396(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.c
@@ -11248,7 +11248,7 @@ struct urb *ldv_usb_alloc_urb_141(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11258,7 +11258,7 @@ struct urb *ldv_usb_alloc_urb_142(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--gdm724x--gdmulte.ko-entry_point.cil.out.i
@@ -10792,7 +10792,7 @@ struct urb *ldv_usb_alloc_urb_141(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -10801,7 +10801,7 @@ struct urb *ldv_usb_alloc_urb_142(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.c
@@ -10145,7 +10145,7 @@ struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -10155,7 +10155,7 @@ struct urb *ldv_usb_alloc_urb_43(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -10165,7 +10165,7 @@ struct urb *ldv_usb_alloc_urb_44(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--vt6656--vt6656_stage.ko-entry_point.cil.out.i
@@ -9879,7 +9879,7 @@ struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9888,7 +9888,7 @@ struct urb *ldv_usb_alloc_urb_43(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9897,7 +9897,7 @@ struct urb *ldv_usb_alloc_urb_44(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -8671,7 +8671,7 @@ struct urb *ldv_usb_alloc_urb_34(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8692,7 +8692,7 @@ struct urb *ldv_usb_alloc_urb_36(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8702,7 +8702,7 @@ struct urb *ldv_usb_alloc_urb_37(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -8226,7 +8226,7 @@ struct urb *ldv_usb_alloc_urb_34(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8245,7 +8245,7 @@ struct urb *ldv_usb_alloc_urb_36(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8254,7 +8254,7 @@ struct urb *ldv_usb_alloc_urb_37(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
@@ -16481,7 +16481,7 @@ struct urb *ldv_usb_alloc_urb_25(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
@@ -15351,7 +15351,7 @@ struct urb *ldv_usb_alloc_urb_25(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
@@ -9402,7 +9402,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9433,7 +9433,7 @@ struct urb *ldv_usb_alloc_urb_34(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9464,7 +9464,7 @@ struct urb *ldv_usb_alloc_urb_37(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9495,7 +9495,7 @@ struct urb *ldv_usb_alloc_urb_40(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
@@ -8938,7 +8938,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8966,7 +8966,7 @@ struct urb *ldv_usb_alloc_urb_34(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8994,7 +8994,7 @@ struct urb *ldv_usb_alloc_urb_37(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9022,7 +9022,7 @@ struct urb *ldv_usb_alloc_urb_40(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.c
@@ -12108,7 +12108,7 @@ struct urb *ldv_usb_alloc_urb_27(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12128,7 +12128,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12148,7 +12148,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -12158,7 +12158,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--io_edgeport.ko-entry_point.cil.out.i
@@ -11341,7 +11341,7 @@ struct urb *ldv_usb_alloc_urb_27(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11359,7 +11359,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11377,7 +11377,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -11386,7 +11386,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.c
@@ -9466,7 +9466,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9526,7 +9526,7 @@ struct urb *ldv_usb_alloc_urb_35(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -9536,7 +9536,7 @@ struct urb *ldv_usb_alloc_urb_36(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--mos7840.ko-entry_point.cil.out.i
@@ -8926,7 +8926,7 @@ struct urb *ldv_usb_alloc_urb_29(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8980,7 +8980,7 @@ struct urb *ldv_usb_alloc_urb_35(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -8989,7 +8989,7 @@ struct urb *ldv_usb_alloc_urb_36(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--storage--uas.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--storage--uas.ko-entry_point.cil.out.c
@@ -7548,13 +7548,14 @@ int ldv_scsi_add_host_with_dma_29(struct Scsi_Host *shost , struct device *dev ,
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_usb_alloc_urb_30(int ldv_func_arg1 , gfp_t flags ) 
 { 
   void *tmp ;
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -7564,7 +7565,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -7574,7 +7575,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--storage--uas.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--storage--uas.ko-entry_point.cil.out.i
@@ -7248,12 +7248,13 @@ int ldv_scsi_add_host_with_dma_29(struct Scsi_Host *shost , struct device *dev ,
   return (ldv_func_res);
 }
 }
+void *ldv_malloc(size_t size ) ;
 struct urb *ldv_usb_alloc_urb_30(int ldv_func_arg1 , gfp_t flags )
 {
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -7262,7 +7263,7 @@ struct urb *ldv_usb_alloc_urb_31(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }
@@ -7271,7 +7272,7 @@ struct urb *ldv_usb_alloc_urb_32(int ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct urb));
   return ((struct urb *)tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (sizeof(struct urb)), thus
using ldv_malloc is perfectly safe. This is in preparation of removing
uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^struct urb \*ldv_usb_alloc_urb_\d+(___\d+)?\(int ldv_func_arg1 , gfp_t flags \) ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(sizeof(struct urb));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
