### PR TITLE
Implement ldv_usb_alloc_coherent_* using ldv_malloc

### DIFF
--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point.cil.out.c
@@ -5705,6 +5705,7 @@ int ldv_usb_submit_urb_20(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_23(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t  , gfp_t  , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_22(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t  , void * , dma_addr_t  ) ;
@@ -7889,7 +7890,6 @@ __inline static void spin_unlock_irqrestore(spinlock_t *lock , unsigned long fla
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point.cil.out.i
@@ -5663,6 +5663,7 @@ int ldv_usb_submit_urb_20(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_23(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t , gfp_t , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_22(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t , void * , dma_addr_t ) ;
@@ -7670,7 +7671,6 @@ __inline static void spin_unlock_irqrestore(spinlock_t *lock , unsigned long fla
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -4792,6 +4792,7 @@ extern void usb_kill_urb(struct urb * ) ;
 extern void usb_anchor_urb(struct urb * , struct usb_anchor * ) ;
 extern struct urb *usb_get_from_anchor(struct usb_anchor * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t  , gfp_t  , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_23(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_24(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -8273,7 +8274,6 @@ __inline static void spin_unlock_irqrestore(spinlock_t *lock , unsigned long fla
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -4693,6 +4693,7 @@ extern void usb_kill_urb(struct urb * ) ;
 extern void usb_anchor_urb(struct urb * , struct usb_anchor * ) ;
 extern struct urb *usb_get_from_anchor(struct usb_anchor * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t , gfp_t , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_23(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_24(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -7878,7 +7879,6 @@ __inline static void spin_unlock_irqrestore(spinlock_t *lock , unsigned long fla
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--misc--usbtest.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--misc--usbtest.ko-entry_point.cil.out.c
@@ -4111,6 +4111,7 @@ int ldv_usb_submit_urb_32(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern int usb_unlink_urb(struct urb * ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t  , gfp_t  , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_20(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_26(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -7413,7 +7414,6 @@ __inline static void spin_unlock_irq(spinlock_t *lock )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--misc--usbtest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--misc--usbtest.ko-entry_point.cil.out.i
@@ -4042,6 +4042,7 @@ int ldv_usb_submit_urb_32(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern int usb_unlink_urb(struct urb * ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t , gfp_t , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_20(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_26(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -7006,7 +7007,6 @@ __inline static void spin_unlock_irq(spinlock_t *lock )
   return;
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3456,6 +3456,7 @@ extern int usb_submit_urb(struct urb * , gfp_t  ) ;
 int ldv_usb_submit_urb_21(struct urb *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 int ldv_usb_submit_urb_22(struct urb *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t  , gfp_t  , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_20(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t ldv_func_arg3 , dma_addr_t *ldv_func_arg4 ) ;
 extern int usb_control_msg(struct usb_device * , unsigned int  , __u8  , __u8  , __u16  ,

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3450,6 +3450,7 @@ extern int usb_submit_urb(struct urb * , gfp_t ) ;
 int ldv_usb_submit_urb_21(struct urb *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 int ldv_usb_submit_urb_22(struct urb *ldv_func_arg1 , gfp_t ldv_func_arg2 ) ;
 extern void *usb_alloc_coherent(struct usb_device * , size_t , gfp_t , dma_addr_t * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_20(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t ldv_func_arg3 , dma_addr_t *ldv_func_arg4 ) ;
 extern int usb_control_msg(struct usb_device * , unsigned int , __u8 , __u8 , __u16 ,

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.c
@@ -19078,7 +19078,7 @@ void *ldv_usb_alloc_coherent_189(struct usb_device *ldv_func_arg1 , size_t ldv_f
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -19109,7 +19109,7 @@ void *ldv_usb_alloc_coherent_192(struct usb_device *ldv_func_arg1 , size_t ldv_f
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -18126,7 +18126,7 @@ void *ldv_usb_alloc_coherent_189(struct usb_device *ldv_func_arg1 , size_t ldv_f
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -18154,7 +18154,7 @@ void *ldv_usb_alloc_coherent_192(struct usb_device *ldv_func_arg1 , size_t ldv_f
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.c
@@ -10322,6 +10322,7 @@ int ldv_usb_submit_urb_131(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_134(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern int usb_unlink_urb(struct urb * ) ;
 extern void usb_kill_urb(struct urb * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                  gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t  , void * , dma_addr_t  ) ;
@@ -13945,7 +13946,7 @@ void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_f
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--tm6000--tm6000.ko-entry_point.cil.out.i
@@ -9984,6 +9984,7 @@ int ldv_usb_submit_urb_131(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_134(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern int usb_unlink_urb(struct urb * ) ;
 extern void usb_kill_urb(struct urb * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                  gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t , void * , dma_addr_t ) ;
@@ -13275,7 +13276,7 @@ void *ldv_usb_alloc_coherent_132(struct usb_device *ldv_func_arg1 , size_t ldv_f
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.c
@@ -9132,6 +9132,7 @@ __inline static void usb_fill_bulk_urb(struct urb *urb , struct usb_device *dev 
 struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_free_urb(struct urb * ) ;
 int ldv_usb_submit_urb_44(struct urb *ldv_func_arg1 , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_43(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t  , void * , dma_addr_t  ) ;
@@ -10906,7 +10907,7 @@ void *ldv_usb_alloc_coherent_43(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -9068,6 +9068,7 @@ __inline static void usb_fill_bulk_urb(struct urb *urb , struct usb_device *dev 
 struct urb *ldv_usb_alloc_urb_42(int ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_free_urb(struct urb * ) ;
 int ldv_usb_submit_urb_44(struct urb *ldv_func_arg1 , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_43(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 extern void usb_free_coherent(struct usb_device * , size_t , void * , dma_addr_t ) ;
@@ -10677,7 +10678,7 @@ void *ldv_usb_alloc_coherent_43(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.c
@@ -22421,7 +22421,7 @@ void *ldv_usb_alloc_coherent_378(struct usb_device *ldv_func_arg1 , size_t ldv_f
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -22462,7 +22462,7 @@ void *ldv_usb_alloc_coherent_382(struct usb_device *ldv_func_arg1 , size_t ldv_f
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--zd1211rw--zd1211rw.ko-entry_point.cil.out.i
@@ -21071,7 +21071,7 @@ void *ldv_usb_alloc_coherent_378(struct usb_device *ldv_func_arg1 , size_t ldv_f
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -21108,7 +21108,7 @@ void *ldv_usb_alloc_coherent_382(struct usb_device *ldv_func_arg1 , size_t ldv_f
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.c
@@ -4805,6 +4805,7 @@ int ldv_usb_submit_urb_39(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void usb_anchor_urb(struct urb * , struct usb_anchor * ) ;
 extern struct urb *usb_get_from_anchor(struct usb_anchor * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_33(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -8582,7 +8583,6 @@ bool ldv_queue_delayed_work_on_19(int ldv_func_arg1 , struct workqueue_struct *l
   return (ldv_func_res);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -8650,7 +8650,7 @@ void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -8661,7 +8661,7 @@ void *ldv_usb_alloc_coherent_33(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -8682,7 +8682,7 @@ void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--class--cdc-acm.ko-entry_point.cil.out.i
@@ -4710,6 +4710,7 @@ int ldv_usb_submit_urb_39(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 extern void usb_kill_urb(struct urb * ) ;
 extern void usb_anchor_urb(struct urb * , struct usb_anchor * ) ;
 extern struct urb *usb_get_from_anchor(struct usb_anchor * ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_33(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -8146,7 +8147,6 @@ bool ldv_queue_delayed_work_on_19(int ldv_func_arg1 , struct workqueue_struct *l
   return (ldv_func_res);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *tmp ;
@@ -8207,7 +8207,7 @@ void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -8217,7 +8217,7 @@ void *ldv_usb_alloc_coherent_33(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -8236,7 +8236,7 @@ void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.c
@@ -4231,6 +4231,7 @@ int ldv_usb_submit_urb_33(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_36(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_39(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_42(struct urb *ldv_func_arg1 , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -9339,7 +9340,6 @@ bool ldv_queue_delayed_work_on_19(int ldv_func_arg1 , struct workqueue_struct *l
   return (ldv_func_res);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) 
 { 
   void *tmp ;
@@ -9413,7 +9413,7 @@ void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -9444,7 +9444,7 @@ void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -9475,7 +9475,7 @@ void *ldv_usb_alloc_coherent_38(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -9506,7 +9506,7 @@ void *ldv_usb_alloc_coherent_41(struct usb_device *ldv_func_arg1 , size_t ldv_fu
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--misc--ftdi-elan.ko-entry_point.cil.out.i
@@ -4167,6 +4167,7 @@ int ldv_usb_submit_urb_33(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_36(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_39(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 int ldv_usb_submit_urb_42(struct urb *ldv_func_arg1 , gfp_t flags ) ;
+void *ldv_malloc(size_t size ) ;
 void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
                                 gfp_t flags , dma_addr_t *ldv_func_arg4 ) ;
 void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_func_arg2 ,
@@ -8881,7 +8882,6 @@ bool ldv_queue_delayed_work_on_19(int ldv_func_arg1 , struct workqueue_struct *l
   return (ldv_func_res);
 }
 }
-void *ldv_malloc(size_t size ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
   void *tmp ;
@@ -8948,7 +8948,7 @@ void *ldv_usb_alloc_coherent_32(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -8976,7 +8976,7 @@ void *ldv_usb_alloc_coherent_35(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -9004,7 +9004,7 @@ void *ldv_usb_alloc_coherent_38(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }
@@ -9032,7 +9032,7 @@ void *ldv_usb_alloc_coherent_41(struct usb_device *ldv_func_arg1 , size_t ldv_fu
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg2);
   return (tmp);
 }
 }


### PR DESCRIPTION
Removes one of the uses of ldv_undef_ptr, which is implemented using
__VERIFIER_nondet_pointer. The size is known (the second parameter of
the function, ldv_func_arg2), thus using ldv_malloc is perfectly safe.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci]
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
       $d = 1;
     }
     if(/^void \*ldv_usb_alloc_coherent_\d+\(struct usb_device \*ldv_func_arg1 , size_t ldv_func_arg2 , ?$/) {
       $p = 2;
       if($d == 0) {
         print "void *ldv_malloc(size_t size ) ;\n";
         $d = 2;
         print;
         next;
       }
     }
     if($p == 2) {
       if(/^  tmp = ldv_undef_ptr\(\);/) {
         print "  tmp = ldv_malloc(ldv_func_arg2);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```