### PR TITLE
Fix property violations due to overflow

### DIFF
--- a/c/array-fpi/eqn1.c
+++ b/c/array-fpi/eqn1.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/eqn2.c
+++ b/c/array-fpi/eqn2.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/eqn3.c
+++ b/c/array-fpi/eqn3.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/eqn4.c
+++ b/c/array-fpi/eqn4.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/eqn5.c
+++ b/c/array-fpi/eqn5.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifcomp.c
+++ b/c/array-fpi/ifcomp.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 	long long *c = malloc(sizeof(long long)*N);

--- a/c/array-fpi/ifeqn1.c
+++ b/c/array-fpi/ifeqn1.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifeqn2.c
+++ b/c/array-fpi/ifeqn2.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifeqn3.c
+++ b/c/array-fpi/ifeqn3.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifeqn4.c
+++ b/c/array-fpi/ifeqn4.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifeqn5.c
+++ b/c/array-fpi/ifeqn5.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ifncomp.c
+++ b/c/array-fpi/ifncomp.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 	long long *c = malloc(sizeof(long long)*N);

--- a/c/array-fpi/indp1.c
+++ b/c/array-fpi/indp1.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(int)*N);
 
 	for(i=0;i<N;i++)

--- a/c/array-fpi/indp3.c
+++ b/c/array-fpi/indp3.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 
 	for(i=0;i<N;i++)

--- a/c/array-fpi/indp4.c
+++ b/c/array-fpi/indp4.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 
 	for(i=0;i<N;i++)

--- a/c/array-fpi/indp5.c
+++ b/c/array-fpi/indp5.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long sum[1];
 

--- a/c/array-fpi/ncomp.c
+++ b/c/array-fpi/ncomp.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 	long long *c = malloc(sizeof(long long)*N);

--- a/c/array-fpi/nsqm-if.c
+++ b/c/array-fpi/nsqm-if.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/nsqm.c
+++ b/c/array-fpi/nsqm.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/pcomp.c
+++ b/c/array-fpi/pcomp.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 	long long *c = malloc(sizeof(long long)*N);

--- a/c/array-fpi/sqm-if.c
+++ b/c/array-fpi/sqm-if.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/sqm.c
+++ b/c/array-fpi/sqm.c
@@ -19,7 +19,7 @@ int main()
 	if(N <= 0) return 1;
 	__VERIFIER_assume(N <= 2147483647/sizeof(int));
 
-	int i;
+	long long i;
 	long long *a = malloc(sizeof(long long)*N);
 	long long *b = malloc(sizeof(long long)*N);
 

--- a/c/array-fpi/ss1.c
+++ b/c/array-fpi/ss1.c
@@ -43,6 +43,6 @@ int main()
 		sum[0] = sum[0] + a[i];
 	}
 
-	__VERIFIER_assert(sum[0] == N*(N+2));
+	__VERIFIER_assert(sum[0] == (long long)N*(N+2));
 	return 1;
 }

--- a/c/array-fpi/ss2.c
+++ b/c/array-fpi/ss2.c
@@ -56,7 +56,7 @@ int main()
 
 	for(i=0; i<N; i++)
 	{
-		__VERIFIER_assert(a[i] == N*(N+2));
+		__VERIFIER_assert(a[i] == (long long)N*(N+2));
 	}
 	return 1;
 }

--- a/c/array-fpi/ss3.c
+++ b/c/array-fpi/ss3.c
@@ -49,6 +49,6 @@ int main()
 		sum[0] = sum[0] + a[i];
 	}
 
-	__VERIFIER_assert(sum[0] == N*(N+1));
+	__VERIFIER_assert(sum[0] == (long long)N*(N+1));
 	return 1;
 }

--- a/c/array-fpi/ss4.c
+++ b/c/array-fpi/ss4.c
@@ -45,6 +45,6 @@ int main()
 		sum[0] = sum[0] + a[i];
 	}
 
-	__VERIFIER_assert(sum[0] == N*(N+1));
+	__VERIFIER_assert(sum[0] == (long long)N*(N+1));
 	return 1;
 }

--- a/c/array-fpi/ssina.c
+++ b/c/array-fpi/ssina.c
@@ -52,7 +52,7 @@ int main()
 
 	for(i=0; i<N; i++)
 	{
-		__VERIFIER_assert(a[i] == (N+1) * (N+1));
+		__VERIFIER_assert(a[i] == (long long)(N+1) * (N+1));
 	}
 	return 1;
 }


### PR DESCRIPTION
Fixes several programs from PR #824 to ensure that integer overflow does not cause property violation. Changed the data type of the loop counter variable and cast expressions in assertion from int to long long to avoid overflows. 