### PR TITLE
Implement pci_iomap using ldv_malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
@@ -11946,9 +11946,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-uli526x.cil.i
@@ -11940,9 +11940,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -17404,9 +17404,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -31886,9 +31886,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -49562,9 +49562,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 int __VERIFIER_nondet_int(void);
 int pci_num_vf(struct pci_dev *arg0) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -17391,9 +17391,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
@@ -16660,9 +16660,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47622,9 +47622,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 int __VERIFIER_nondet_int(void);
 int pci_num_vf(struct pci_dev *arg0) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -29540,9 +29540,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -15713,9 +15713,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -26388,9 +26388,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -30764,9 +30764,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47901,9 +47901,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 int __VERIFIER_nondet_int(void);
 int pci_num_vf(struct pci_dev *arg0) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -15994,9 +15994,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -17370,9 +17370,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dec-tulip-dmfe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dec-tulip-dmfe.cil.i
@@ -12549,9 +12549,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
@@ -18587,9 +18587,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -31926,9 +31926,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -49511,9 +49511,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 int __VERIFIER_nondet_int(void);
 int pci_num_vf(struct pci_dev *arg0) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -31651,9 +31651,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -19323,9 +19323,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-via-via-rhine.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-via-via-rhine.cil.i
@@ -15314,9 +15314,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtl818x-rtl8180-rtl8180.cil.i
@@ -16654,9 +16654,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47804,9 +47804,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 int __VERIFIER_nondet_int(void);
 int pci_num_vf(struct pci_dev *arg0) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ath-ath10k-ath10k_pci.cil.i
@@ -15879,9 +15879,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -16622,9 +16622,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -31838,9 +31838,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -30716,9 +30716,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -31878,9 +31878,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -18967,9 +18967,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -22516,9 +22516,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -615,10 +615,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-uli526x_true-unreach-call.cil.env.c
@@ -422,10 +422,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -818,10 +818,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1098,10 +1098,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_num_vf

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
@@ -489,10 +489,9 @@ int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-rtl818x-rtl8180-rtl8180_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-rtl818x-rtl8180-rtl8180_true-unreach-call.cil.env.c
@@ -542,10 +542,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1125,10 +1125,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_num_vf

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
@@ -815,10 +815,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
@@ -506,10 +506,9 @@ int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -829,10 +829,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -819,10 +819,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1117,10 +1117,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_num_vf

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
@@ -498,10 +498,9 @@ int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -632,10 +632,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-dmfe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-dmfe_true-unreach-call.cil.env.c
@@ -512,10 +512,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
@@ -707,10 +707,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-uli526x_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dec-tulip-uli526x_true-unreach-call.cil.env.c
@@ -439,10 +439,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -852,10 +852,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1124,10 +1124,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_num_vf

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
@@ -848,10 +848,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -720,10 +720,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
@@ -726,10 +726,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtl818x-rtl8180-rtl8180_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtl818x-rtl8180-rtl8180_true-unreach-call.cil.env.c
@@ -559,10 +559,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1117,10 +1117,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_num_vf

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ath-ath10k-ath10k_pci_true-unreach-call.cil.env.c
@@ -498,10 +498,9 @@ int pci_enable_msi_block(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -615,10 +615,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -818,10 +818,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -819,10 +819,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -852,10 +852,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -720,10 +720,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -767,10 +767,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--cisco--enic--enic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--cisco--enic--enic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -16056,9 +16056,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ath--ath5k--ath5k.ko-ldv_main16_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ath--ath5k--ath5k.ko-ldv_main16_sequence_infinite_withcheck_stateful.cil.out.i
@@ -30800,9 +30800,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -21899,9 +21899,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
@@ -13976,9 +13976,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--misc--pch_phub.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--misc--pch_phub.ko-main.cil.out.i
@@ -3766,9 +3766,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--misc--phantom.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--misc--phantom.ko-main.cil.out.i
@@ -5108,9 +5108,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.cil.out.i
@@ -11938,9 +11938,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--vfio--pci--vfio-pci.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--vfio--pci--vfio-pci.ko-main.cil.out.i
@@ -7120,9 +7120,8 @@ bool __VERIFIER_nondet_bool(void);
 bool pci_intx_mask_supported(struct pci_dev *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main2.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main2.cil.out.i
@@ -22516,9 +22516,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--wireless--mwl8k.ko-ldv_main0.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--wireless--mwl8k.ko-ldv_main0.cil.out.i
@@ -13989,9 +13989,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--cisco--enic--enic.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--cisco--enic--enic.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -639,10 +639,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ath--ath5k--ath5k.ko-ldv_main16_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ath--ath5k--ath5k.ko-ldv_main16_sequence_infinite_withcheck_stateful.env.c
@@ -872,10 +872,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -656,10 +656,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.env.c
@@ -996,10 +996,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--pch_phub.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--pch_phub.ko-main.env.c
@@ -186,10 +186,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--phantom.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--misc--phantom.ko-main.env.c
@@ -330,10 +330,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.env.c
@@ -752,10 +752,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--vfio--pci--vfio-pci.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--vfio--pci--vfio-pci.ko-main.env.c
@@ -518,10 +518,9 @@ bool pci_intx_mask_supported(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main2_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--emulex--benet--be2net.ko-ldv_main2_true-unreach-call.env.c
@@ -767,10 +767,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--wireless--mwl8k.ko-ldv_main0_false-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--wireless--mwl8k.ko-ldv_main0_false-unreach-call.env.c
@@ -640,10 +640,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -1888,10 +1888,9 @@ struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigne
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
@@ -259,10 +259,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
@@ -72268,9 +72268,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigned int arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-video-arkfb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-video-arkfb.ko.cil.out.i
@@ -7259,9 +7259,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-2.i
@@ -12141,9 +12141,8 @@ int __VERIFIER_nondet_int(void);
 int vb2_dqbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1, bool arg2){
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2){
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1){
   return;

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.env.c
@@ -331,10 +331,9 @@ int vb2_dqbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1, bool arg2){
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2){
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-3com-typhoon.cil.i
@@ -13210,9 +13210,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
@@ -17672,9 +17672,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -27914,9 +27914,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -22343,9 +22343,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-tulip.cil.i
@@ -18618,9 +18618,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-dec-tulip-winbond-840.cil.i
@@ -12532,9 +12532,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-fealnx.cil.i
@@ -12223,9 +12223,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -31669,9 +31669,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -19339,9 +19339,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -28391,9 +28391,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -25948,9 +25948,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -20275,9 +20275,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -29799,9 +29799,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -26582,9 +26582,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -20554,9 +20554,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-icplus-ipg.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-icplus-ipg.cil.i
@@ -11294,9 +11294,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sun-cassini.cil.i
@@ -17375,9 +17375,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-via-via-rhine.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-via-via-rhine.cil.i
@@ -14370,9 +14370,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -27601,9 +27601,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-platform-marvell-ccic-cafe_ccic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-platform-marvell-ccic-cafe_ccic.cil.i
@@ -13577,9 +13577,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-atheros-atl1e-atl1e.cil.i
@@ -17656,9 +17656,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -27885,9 +27885,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -22353,9 +22353,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dlink-dl2k.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dlink-dl2k.cil.i
@@ -12776,9 +12776,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dlink-sundance.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-dlink-sundance.cil.i
@@ -13312,9 +13312,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-fealnx.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-fealnx.cil.i
@@ -12217,9 +12217,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-icplus-ipg.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-icplus-ipg.cil.i
@@ -12257,9 +12257,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e100.cil.i
@@ -15841,9 +15841,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sis-sis900.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sis-sis900.cil.i
@@ -13173,9 +13173,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-smsc-epic100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-smsc-epic100.cil.i
@@ -12674,9 +12674,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-hippi-rrunner.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-hippi-rrunner.cil.i
@@ -13002,9 +13002,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-adm8211.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-adm8211.cil.i
@@ -13842,9 +13842,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -28396,9 +28396,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-3com-3c59x.cil.i
@@ -15747,9 +15747,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -26124,9 +26124,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -20431,9 +20431,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-dec-tulip-tulip.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-dec-tulip-tulip.cil.i
@@ -17065,9 +17065,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -29975,9 +29975,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -29720,9 +29720,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-via-via-rhine.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-via-via-rhine.cil.i
@@ -14038,9 +14038,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -26738,9 +26738,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-alloc-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -27364,9 +27364,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -25398,9 +25398,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -29751,9 +29751,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-stmicro-stmmac-stmmac.cil.i
@@ -27260,9 +27260,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -25504,9 +25504,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -25838,9 +25838,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -26523,9 +26523,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-3com-3c59x.cil.i
@@ -16588,9 +16588,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -27335,9 +27335,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -21972,9 +21972,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -27318,9 +27318,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-3com-3c59x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-3com-3c59x.cil.i
@@ -14965,9 +14965,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-broadcom-bnx2.cil.i
@@ -25574,9 +25574,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-cisco-enic-enic.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-cisco-enic-enic.cil.i
@@ -20050,9 +20050,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-emulex-benet-be2net.cil.i
@@ -29927,9 +29927,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2100.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2100.cil.i
@@ -25660,9 +25660,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-3com-typhoon_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-3com-typhoon_true-unreach-call.cil.env.c
@@ -525,10 +525,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-atheros-atl1e-atl1e_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-atheros-atl1e-atl1e_true-unreach-call.cil.env.c
@@ -607,10 +607,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -827,10 +827,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -691,10 +691,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
@@ -690,10 +690,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-winbond-840_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-dec-tulip-winbond-840_true-unreach-call.cil.env.c
@@ -541,10 +541,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-fealnx_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-fealnx_true-unreach-call.cil.env.c
@@ -492,10 +492,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-stmicro-stmmac-stmmac_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-stmicro-stmmac-stmmac_false-unreach-call.cil.env.c
@@ -831,10 +831,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -694,10 +694,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -705,10 +705,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -853,10 +853,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -709,10 +709,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -852,10 +852,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -723,10 +723,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -701,10 +701,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-icplus-ipg_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-icplus-ipg_true-unreach-call.cil.env.c
@@ -473,10 +473,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -697,10 +697,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
@@ -702,10 +702,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -699,10 +699,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-platform-marvell-ccic-cafe_ccic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-platform-marvell-ccic-cafe_ccic_true-unreach-call.cil.env.c
@@ -350,10 +350,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-atheros-atl1e-atl1e_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-atheros-atl1e-atl1e_true-unreach-call.cil.env.c
@@ -624,10 +624,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -853,10 +853,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -708,10 +708,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dlink-dl2k_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dlink-dl2k_true-unreach-call.cil.env.c
@@ -445,10 +445,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dlink-sundance_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-dlink-sundance_true-unreach-call.cil.env.c
@@ -563,10 +563,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-fealnx_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-fealnx_true-unreach-call.cil.env.c
@@ -509,10 +509,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-icplus-ipg_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-icplus-ipg_true-unreach-call.cil.env.c
@@ -496,10 +496,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e100_true-unreach-call.cil.env.c
@@ -666,10 +666,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sis-sis900_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sis-sis900_true-unreach-call.cil.env.c
@@ -575,10 +575,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-smsc-epic100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-smsc-epic100_true-unreach-call.cil.env.c
@@ -594,10 +594,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-hippi-rrunner_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-hippi-rrunner_true-unreach-call.cil.env.c
@@ -440,10 +440,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-adm8211_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-adm8211_true-unreach-call.cil.env.c
@@ -512,10 +512,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -722,10 +722,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -625,10 +625,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -845,10 +845,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -701,10 +701,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-dec-tulip-tulip_true-unreach-call.cil.env.c
@@ -700,10 +700,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -844,10 +844,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-stmicro-stmmac-stmmac_true-unreach-call.cil.env.c
@@ -841,10 +841,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-via-via-rhine_true-unreach-call.cil.env.c
@@ -718,10 +718,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -715,10 +715,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-alloc-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -827,10 +827,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -853,10 +853,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -852,10 +852,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-stmicro-stmmac-stmmac_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-stmicro-stmmac-stmmac_false-unreach-call.cil.env.c
@@ -815,10 +815,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -723,10 +723,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -829,10 +829,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -699,10 +699,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -632,10 +632,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -853,10 +853,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -708,10 +708,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -722,10 +722,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-3com-3c59x_true-unreach-call.cil.env.c
@@ -625,10 +625,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-broadcom-bnx2_true-unreach-call.cil.env.c
@@ -845,10 +845,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-cisco-enic-enic_true-unreach-call.cil.env.c
@@ -701,10 +701,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-emulex-benet-be2net_true-unreach-call.cil.env.c
@@ -844,10 +844,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2100_true-unreach-call.cil.env.c
@@ -715,10 +715,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point.cil.out.i
@@ -7680,9 +7680,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point.cil.out.i
@@ -13265,9 +13265,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-entry_point.cil.out.i
@@ -11868,9 +11868,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -15509,9 +15509,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
@@ -15150,9 +15150,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--stmicro--stmmac--stmmac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--stmicro--stmmac--stmmac.ko-entry_point.cil.out.i
@@ -23186,9 +23186,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
@@ -18256,9 +18256,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--tulip.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--tulip.ko-entry_point.cil.out.i
@@ -14792,9 +14792,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
@@ -26366,9 +26366,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
@@ -9840,9 +9840,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
@@ -35242,9 +35242,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -22846,9 +22846,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point.cil.out.i
@@ -7714,9 +7714,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msix(struct pci_dev *arg0, struct msix_entry *arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--serial--8250--8250_pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--serial--8250--8250_pci.ko-entry_point.cil.out.i
@@ -7583,9 +7583,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void *external_alloc(void);
 void *pci_ioremap_bar(struct pci_dev *arg0, int arg1) {

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--dec--tulip--xircom_cb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -326,10 +326,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -671,10 +671,9 @@ int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -443,10 +443,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -587,10 +587,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -679,10 +679,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--stmicro--stmmac--stmmac.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--stmicro--stmmac--stmmac.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -981,10 +981,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -718,10 +718,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--tulip.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--tulip.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -658,10 +658,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -886,10 +886,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -536,10 +536,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1202,10 +1202,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -683,10 +683,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--vmw_pvscsi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -340,10 +340,9 @@ int pci_enable_msix(struct pci_dev *arg0, struct msix_entry *arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--serial--8250--8250_pci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--tty--serial--8250--8250_pci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -257,10 +257,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_ioremap_bar

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4822,9 +4822,8 @@ void ldv_check_return_value(int arg0) {
 void ldv_initialize() {
   return;
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5998,9 +5998,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -15287,9 +15287,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6312,9 +6312,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6107,9 +6107,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6047,9 +6047,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3044,9 +3044,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
@@ -37960,9 +37960,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigned int arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
@@ -24512,9 +24512,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigned int arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4661,9 +4661,8 @@ void *external_alloc(void);
 struct page *ldv_some_page() {
   return (struct page *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5663,9 +5663,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -15038,9 +15038,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6231,9 +6231,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5914,9 +5914,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6186,9 +6186,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5918,9 +5918,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -2917,9 +2917,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -66,10 +66,9 @@ void ldv_initialize() {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -133,10 +133,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--mwifiex--mwifiex_pcie.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -300,10 +300,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -166,10 +166,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -166,10 +166,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -166,10 +166,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -129,10 +129,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
@@ -2465,10 +2465,9 @@ struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigne
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
@@ -1810,10 +1810,9 @@ struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigne
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -92,10 +92,9 @@ struct page *ldv_some_page() {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -159,10 +159,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -334,10 +334,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -201,10 +201,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -201,10 +201,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -227,10 +227,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -201,10 +201,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -155,10 +155,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-3.7.3/main0_drivers-net-wireless-mwl8k-ko---32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main0_drivers-net-wireless-mwl8k-ko---32_7a--linux-3.7.3.i
@@ -13656,9 +13656,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-3.7.3/model/main0_false-unreach-call_drivers-net-wireless-mwl8k-ko---32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main0_false-unreach-call_drivers-net-wireless-mwl8k-ko---32_7a--linux-3.7.3.env.c
@@ -623,10 +623,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.i
@@ -18692,9 +18692,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.i
@@ -24296,9 +24296,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.i
@@ -20860,9 +20860,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.i
@@ -28502,9 +28502,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.i
@@ -15935,9 +15935,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.i
@@ -15765,9 +15765,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.i
@@ -24112,9 +24112,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i
@@ -24406,9 +24406,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.i
@@ -13294,9 +13294,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko_false-unreach-call.cil.env.c
@@ -720,10 +720,9 @@ int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko_false-unreach-call.cil.env.c
@@ -893,10 +893,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko_true-unreach-call.cil.env.c
@@ -543,10 +543,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko_false-unreach-call.cil.env.c
@@ -744,10 +744,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko_true-unreach-call.cil.env.c
@@ -459,10 +459,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko_true-unreach-call.cil.env.c
@@ -419,10 +419,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko_true-unreach-call.cil.env.c
@@ -535,10 +535,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--scsi--pmcraid.ko_false-unreach-call.cil.env.c
@@ -680,10 +680,9 @@ int pci_find_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko_false-unreach-call.cil.env.c
@@ -322,10 +322,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point.cil.out.i
@@ -139249,9 +139249,8 @@ struct pci_dev *pci_get_class(unsigned int arg0, struct pci_dev *arg1) {
 void pci_ignore_hotplug(struct pci_dev *arg0) {
   return;
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
@@ -15076,9 +15076,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -20972,9 +20972,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
@@ -28536,9 +28536,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -42572,9 +42572,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -23868,9 +23868,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point.cil.out.i
@@ -13231,9 +13231,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point.cil.out.i
@@ -10127,9 +10127,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
@@ -16960,9 +16960,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point.cil.out.i
@@ -14405,9 +14405,8 @@ int __VERIFIER_nondet_int(void);
 int pci_bus_write_config_dword(struct pci_bus *arg0, unsigned int arg1, int arg2, u32 arg3) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -21664,9 +21664,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -43663,9 +43663,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -25150,9 +25150,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -16984,9 +16984,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -66329,9 +66329,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_pcie_error_reporting(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point.cil.out.i
@@ -23022,9 +23022,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msix(struct pci_dev *arg0, struct msix_entry *arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--vfio--pci--vfio-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--vfio--pci--vfio-pci.ko-entry_point.cil.out.i
@@ -141715,9 +141715,8 @@ bool __VERIFIER_nondet_bool(void);
 bool pci_intx_mask_supported(struct pci_dev *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point.cil.out.i
@@ -13303,9 +13303,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point.cil.out.i
@@ -14642,9 +14642,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point.cil.out.i
@@ -15021,9 +15021,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point.cil.out.i
@@ -21133,9 +21133,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
@@ -21713,9 +21713,8 @@ int __VERIFIER_nondet_int(void);
 int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_release_regions(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--dmfe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--dmfe.ko-entry_point.cil.out.i
@@ -9371,9 +9371,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--icplus--ipg.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--icplus--ipg.ko-entry_point.cil.out.i
@@ -9474,9 +9474,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -43663,9 +43663,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point.cil.out.i
@@ -10023,9 +10023,8 @@ void *external_alloc(void);
 struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_dev *arg2) {
   return (struct pci_dev *)external_alloc();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--via--via-rhine.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--via--via-rhine.ko-entry_point.cil.out.i
@@ -12038,9 +12038,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point.cil.out.i
@@ -9552,9 +9552,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point.cil.out.i
@@ -37884,9 +37884,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point.cil.out.i
@@ -23989,9 +23989,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -16463,9 +16463,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point.cil.out.i
@@ -16628,9 +16628,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -66172,9 +66172,8 @@ int __VERIFIER_nondet_int(void);
 int pci_enable_pcie_error_reporting(struct pci_dev *arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point.cil.out.i
@@ -16537,9 +16537,8 @@ struct pci_dev *pci_dev_get(struct pci_dev *arg0) {
 void pci_dev_put(struct pci_dev *arg0) {
   return;
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--vfio--pci--vfio-pci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--vfio--pci--vfio-pci.ko-entry_point.cil.out.i
@@ -140675,9 +140675,8 @@ bool __VERIFIER_nondet_bool(void);
 bool pci_intx_mask_supported(struct pci_dev *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -3583,10 +3583,9 @@ void pci_ignore_hotplug(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1116,10 +1116,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -4731,10 +4731,9 @@ struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigne
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -960,10 +960,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -939,10 +939,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1306,10 +1306,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -699,10 +699,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -782,10 +782,9 @@ int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -541,10 +541,9 @@ int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1124,10 +1124,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -4739,10 +4739,9 @@ struct pci_dev *pci_get_domain_bus_and_slot(int arg0, unsigned int arg1, unsigne
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -925,10 +925,9 @@ int pci_bus_write_config_dword(struct pci_bus *arg0, unsigned int arg1, int arg2
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -969,10 +969,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1331,10 +1331,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -708,10 +708,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -650,10 +650,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -641,10 +641,9 @@ int pci_enable_pcie_error_reporting(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -575,10 +575,9 @@ int pci_enable_msix(struct pci_dev *arg0, struct msix_entry *arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--vfio--pci--vfio-pci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--vfio--pci--vfio-pci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -590,10 +590,9 @@ bool pci_intx_mask_supported(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--atm--solos-pci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -383,10 +383,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atl1e--atl1e.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -579,10 +579,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -679,10 +679,9 @@ int pci_enable_msi_range(struct pci_dev *arg0, int arg1, int arg2) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--bnx2.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -959,10 +959,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -822,10 +822,9 @@ int pci_find_ext_capability(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_release_regions

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--dmfe.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--dmfe.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -479,10 +479,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--uli526x.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--dec--tulip--uli526x.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -405,10 +405,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--icplus--ipg.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--icplus--ipg.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -453,10 +453,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1296,10 +1296,9 @@ int pci_enable_sriov(struct pci_dev *arg0, int arg1) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--sis--sis900.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -533,10 +533,9 @@ struct pci_dev *pci_get_device(unsigned int arg0, unsigned int arg1, struct pci_
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--via--via-rhine.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--via--via-rhine.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -862,10 +862,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--hippi--rrunner.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -374,10 +374,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ath--ath5k--ath5k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1170,10 +1170,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2100.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -698,10 +698,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--mwl8k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -640,10 +640,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -729,10 +729,9 @@ int pci_enable_device(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -640,10 +640,9 @@ int pci_enable_pcie_error_reporting(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -749,10 +749,9 @@ void pci_dev_put(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--vfio--pci--vfio-pci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--vfio--pci--vfio-pci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -589,10 +589,9 @@ bool pci_intx_mask_supported(struct pci_dev *arg0) {
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *, int, unsigned long)
 // with return type: (void)*
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2) {
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(arg2);
 }
 
 // Function: pci_iounmap


### PR DESCRIPTION
Removes one of the uses of external_alloc, which is implemented using
__VERIFIER_nondet_pointer. We allocate the amount of memory specified in
the maxlen member, and don't currently handle the "0" case (where the
full BAR should be mapped) at the moment.  This is in preparation of
removing uses of __VERIFIER_nondet_pointer (see #767).

The changes were done using the following command:
```
for f in c/ldv-*/model/*.c
do
perl -i -e \
  '$p = 1; $d = 0;
   while(<>) {
     if(/^\/\/ Function: pci_iomap\s*$/) {
       $p = 2;
     }
     if($p == 2) {
       if(/^void \*external_alloc\(void\);\s*$/) { next; }
       elsif(/^  return \(void \*\)external_alloc\(\);$/) {
         print "  return ldv_malloc(arg2);\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
