### PR TITLE
Split tasks in order to make task names unique

### DIFF
--- a/c/memsafety-bftpd/bftpd_1a.yml
+++ b/c/memsafety-bftpd/bftpd_1a.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'bftpd_1.i'
+
+properties:
+  - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true

--- a/c/memsafety-bftpd/bftpd_1b.yml
+++ b/c/memsafety-bftpd/bftpd_1b.yml
@@ -1,0 +1,7 @@
+format_version: '1.0'
+
+input_files: 'bftpd_1.i'
+
+properties:
+  - property_file: ../properties/valid-memcleanup.prp
+    expected_verdict: true

--- a/c/memsafety-bftpd/bftpd_2a.yml
+++ b/c/memsafety-bftpd/bftpd_2a.yml
@@ -1,9 +1,7 @@
 format_version: '1.0'
 
-input_files: 'bftpd_1.i'
+input_files: 'bftpd_2.i'
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
-  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: true

--- a/c/memsafety-bftpd/bftpd_2b.yml
+++ b/c/memsafety-bftpd/bftpd_2b.yml
@@ -3,7 +3,5 @@ format_version: '1.0'
 input_files: 'bftpd_2.i'
 
 properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false


### PR DESCRIPTION
BenchExec uses the file name as id, and SV-COMP's benchmark definitions
put the tasks for memsafety and memcleanup in one run set.

May be this should be changed. But for now, I split the four tasks into four separate task-definition files.