### PR TITLE
Implement ns_to_timeval using ldv_xmalloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -49291,12 +49291,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -49141,12 +49141,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -763,13 +763,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -780,13 +780,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--pci--cx18--cx18.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--media--pci--cx18--cx18.ko-main.cil.out.i
@@ -27768,12 +27768,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_read_config_byte(struct pci_bus *arg0, unsigned int arg1, int arg2, u8 *arg3) {

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--pci--cx18--cx18.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--pci--cx18--cx18.ko-main.env.c
@@ -595,13 +595,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_read_config_byte

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -1753,13 +1753,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_alloc_resource

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
@@ -524,13 +524,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prepare_to_wait

--- a/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
@@ -72209,12 +72209,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_alloc_resource(struct pci_bus *arg0, struct resource *arg1, resource_size_t arg2, resource_size_t arg3, resource_size_t arg4, unsigned int arg5, resource_size_t (*arg6)(void *, const struct resource *, resource_size_t , resource_size_t ), void *arg7) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
@@ -17973,12 +17973,8 @@ void mutex_lock_nested(struct mutex *arg0, unsigned int arg1) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 void prepare_to_wait(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {
   return;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point.cil.out.i
@@ -9407,12 +9407,8 @@ void mutex_lock_nested(struct mutex *arg0, unsigned int arg1) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 void prepare_to_wait(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {
   return;

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -205,13 +205,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prepare_to_wait

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -44978,12 +44978,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -45257,12 +45257,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -45100,12 +45100,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -43783,12 +43783,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -44062,12 +44062,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -47946,12 +47946,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-mwifiex-mwifiex.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-mwifiex-mwifiex.cil.i
@@ -43905,12 +43905,8 @@ int __VERIFIER_nondet_int(void);
 int netpoll_trap() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -781,13 +781,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -773,13 +773,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -773,13 +773,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -781,13 +781,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -773,13 +773,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -780,13 +780,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-mwifiex-mwifiex_true-unreach-call.cil.env.c
@@ -773,13 +773,9 @@ int netpoll_trap() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--usb--peak_usb--peak_usb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--usb--peak_usb--peak_usb.ko-entry_point.cil.out.i
@@ -10159,12 +10159,8 @@ int netdev_warn(const struct net_device *arg0, const char *arg1, ...) {
 void netif_device_detach(struct net_device *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int open_candev(struct net_device *arg0) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
@@ -27445,12 +27445,8 @@ void mutex_lock_nested(struct mutex *arg0, unsigned int arg1) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_read_config_byte(struct pci_bus *arg0, unsigned int arg1, int arg2, u8 *arg3) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point.cil.out.i
@@ -18089,12 +18089,8 @@ int __VERIFIER_nondet_int(void);
 int nla_put(struct sk_buff *arg0, int arg1, int arg2, const void *arg3) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_read_config_word(struct pci_bus *arg0, unsigned int arg1, int arg2, u16 *arg3) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
@@ -32212,12 +32212,8 @@ long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2) {
   return __VERIFIER_nondet_long();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int posix_lock_file(struct file *arg0, struct file_lock *arg1, struct file_lock *arg2) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point.cil.out.i
@@ -15433,12 +15433,8 @@ int __VERIFIER_nondet_int(void);
 int net_ratelimit() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-dummy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-dummy.ko-entry_point.cil.out.i
@@ -6718,12 +6718,8 @@ int __VERIFIER_nondet_int(void);
 int ldv_thaw_noirq_3() {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 void *external_alloc(void);
 struct platform_device *platform_device_register_full(const struct platform_device_info *arg0) {

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--usb--peak_usb--peak_usb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--can--usb--peak_usb--peak_usb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -284,13 +284,9 @@ void netif_device_detach(struct net_device *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: open_candev

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -628,13 +628,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_read_config_byte

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--cisco--enic--enic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -619,13 +619,9 @@ int nla_put(struct sk_buff *arg0, int arg1, int arg2, const void *arg3) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_read_config_word

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -976,13 +976,9 @@ loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: posix_lock_file

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -613,13 +613,9 @@ int net_ratelimit() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-dummy.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--drivers--snd-dummy.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -341,13 +341,9 @@ int ldv_thaw_noirq_3() {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: platform_device_register_full

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.i
@@ -18911,12 +18911,8 @@ void *external_alloc(void);
 struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, nodemask_t *arg2, struct zone **arg3) {
   return (struct zoneref *)external_alloc();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
@@ -30896,12 +30896,8 @@ struct timespec ns_to_timespec(const s64 arg0) {
   __VERIFIER_assume(tmp != 0);
   return *tmp;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
@@ -37910,12 +37910,8 @@ struct timespec ns_to_timespec(const s64 arg0) {
   __VERIFIER_assume(tmp != 0);
   return *tmp;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
@@ -36181,12 +36181,8 @@ struct timespec ns_to_timespec(const s64 arg0) {
   __VERIFIER_assume(tmp != 0);
   return *tmp;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
@@ -24462,12 +24462,8 @@ void *external_alloc(void);
 struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, nodemask_t *arg2, struct zone **arg3) {
   return (struct zoneref *)external_alloc();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-usb-image-microtek.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-usb-image-microtek.cil.out.i
@@ -26037,12 +26037,8 @@ void *external_alloc(void);
 struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, nodemask_t *arg2, struct zone **arg3) {
   return (struct zoneref *)external_alloc();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int out_of_line_wait_on_bit(void *arg0, int arg1, int (*arg2)(void *), unsigned arg3) {

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-media-video-vivi.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-media-video-vivi.cil.out.env.c
@@ -1379,13 +1379,9 @@ struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, n
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.env.c
@@ -1353,13 +1353,9 @@ struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, n
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
@@ -1885,13 +1885,9 @@ struct timespec ns_to_timespec(const s64 arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
@@ -2355,13 +2355,9 @@ struct timespec ns_to_timespec(const s64 arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
@@ -2152,13 +2152,9 @@ struct timespec ns_to_timespec(const s64 arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
@@ -1700,13 +1700,9 @@ struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, n
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-usb-image-microtek.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-usb-image-microtek.cil.out.env.c
@@ -1868,13 +1868,9 @@ struct zoneref *next_zones_zonelist(struct zoneref *arg0, enum zone_type arg1, n
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 nsec)
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: out_of_line_wait_on_bit

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.i
@@ -16392,12 +16392,8 @@ unsigned long int msecs_to_jiffies(const unsigned int arg0) {
 void msleep(unsigned int arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.i
@@ -15671,12 +15671,8 @@ int __VERIFIER_nondet_int(void);
 int nla_put(struct sk_buff *arg0, int arg1, int arg2, const void *arg3) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.env.c
@@ -185,13 +185,9 @@ void msleep(unsigned int arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: prepare_to_wait_event

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko_false-unreach-call.cil.env.c
@@ -291,13 +291,9 @@ int nla_put(struct sk_buff *arg0, int arg1, int arg2, const void *arg3) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: printk

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
@@ -55467,12 +55467,8 @@ long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2) {
   return __VERIFIER_nondet_long();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int of_get_videomode(struct device_node *arg0, struct videomode *arg1, int arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
@@ -31547,12 +31547,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_read_config_byte(struct pci_bus *arg0, unsigned int arg1, int arg2, u8 *arg3) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point.cil.out.i
@@ -29715,12 +29715,8 @@ void mutex_lock_nested(struct mutex *arg0, unsigned int arg1) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 int __VERIFIER_nondet_int(void);
 int pci_bus_read_config_byte(struct pci_bus *arg0, unsigned int arg1, int arg2, u8 *arg3) {

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1519,13 +1519,9 @@ loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: of_get_videomode

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -639,13 +639,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_read_config_byte

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--cx18--cx18.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -638,13 +638,9 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: ns_to_timeval
 // with type: struct timeval ns_to_timeval(const s64 )
 // with return type: struct timeval
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct timeval ns_to_timeval(const s64 arg0) {
   // Composite type
-  struct timeval *tmp = (struct timeval*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct timeval *)ldv_xmalloc(sizeof(struct timeval));
 }
 
 // Function: pci_bus_read_config_byte


### PR DESCRIPTION
Removes one of the uses of external_alloc, which is implemented using
__VERIFIER_nondet_pointer. The type and size are known, so just allocate
memory using ldv_xmalloc, which also simplifies the implementation.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).

The changes were done using the following command:
```
for f in c/ldv-*/model/*.c
do
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^\/\/ Function: ns_to_timeval\s*$/) {
       $p = 2;
     }
     elsif($p == 2) {
       if(/^void \*external_alloc\(void\);\s*$/) { next; }
       elsif(/^void __VERIFIER_assume\(int\);\s*$/) { next; }
       elsif(/^  struct timeval \*tmp = \(struct timeval\*\)external_alloc\(\);\s*$/) { next; }
       elsif(/^  __VERIFIER_assume\(tmp != 0\);\s*$/) { next; }
       elsif(/^  return \*tmp;\s*$/) {
         print "  return *ldv_xmalloc(sizeof(struct timeval));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
followed by re-preprocessing of all LDV benchmarks.
