### PR TITLE
Implement vm_get_page_prot, pgprot_writecombine using ldv_xmalloc

### DIFF
--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
@@ -15698,12 +15698,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 void prepare_to_wait(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {
   return;
@@ -15795,12 +15791,8 @@ void unregister_shrinker(struct shrinker *arg0) {
 void vfree(const void *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 int __VERIFIER_nondet_int(void);
 int vm_insert_mixed(struct vm_area_struct *arg0, unsigned long arg1, unsigned long arg2) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--infiniband--hw--mlx4--mlx4_ib.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--infiniband--hw--mlx4--mlx4_ib.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.i
@@ -27469,12 +27469,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
@@ -764,15 +764,11 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: prepare_to_wait
@@ -1001,15 +997,11 @@ void vfree(const void *arg0) {
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_insert_mixed

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--infiniband--hw--mlx4--mlx4_ib.ko-ldv_main4_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--infiniband--hw--mlx4--mlx4_ib.ko-ldv_main4_sequence_infinite_withcheck_stateful.env.c
@@ -1402,15 +1402,11 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.i
@@ -21348,12 +21348,8 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int simple_strtoul(const char *arg0, char **arg1, unsigned int arg2) {
   return __VERIFIER_nondet_ulong();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 int __VERIFIER_nondet_int(void);
 int vm_iomap_memory(struct vm_area_struct *arg0, phys_addr_t arg1, unsigned long arg2) {

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko_false-unreach-call.cil.env.c
@@ -416,15 +416,11 @@ unsigned long int simple_strtoul(const char *arg0, char **arg1, unsigned int arg
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_iomap_memory

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
@@ -55515,12 +55515,8 @@ int __VERIFIER_nondet_int(void);
 int pcie_capability_read_dword(struct pci_dev *arg0, int arg1, u32 *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 void *external_alloc(void);
 struct task_struct *pid_task(struct pid *arg0, enum pid_type arg1) {
@@ -55701,12 +55697,8 @@ int __VERIFIER_nondet_int(void);
 int vga_client_register(struct pci_dev *arg0, void *arg1, void (*arg2)(void *, bool ), unsigned int (*arg3)(void *, bool )) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int vm_mmap(struct file *arg0, unsigned long arg1, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
@@ -29358,12 +29358,8 @@ void mutex_unlock(struct mutex *arg0) {
 void neigh_destroy(struct neighbour *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 unsigned int __VERIFIER_nondet_uint(void);
 u32 prandom_u32() {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point.cil.out.i
@@ -22259,12 +22259,8 @@ void mutex_lock_nested(struct mutex *arg0, unsigned int arg1) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--video--fbdev--core--fb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--video--fbdev--core--fb.ko-entry_point.cil.out.i
@@ -14103,12 +14103,8 @@ unsigned long int simple_strtoul(const char *arg0, char **arg1, unsigned int arg
 void unlock_page(struct page *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 int __VERIFIER_nondet_int(void);
 int vm_iomap_memory(struct vm_area_struct *arg0, phys_addr_t arg1, unsigned long arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point.cil.out.i
@@ -24587,12 +24587,8 @@ int mutex_trylock(struct mutex *arg0) {
 void mutex_unlock(struct mutex *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1627,15 +1627,11 @@ int pcie_capability_read_dword(struct pci_dev *arg0, int arg1, u32 *arg2) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: pid_task
@@ -2104,15 +2100,11 @@ int vga_client_register(struct pci_dev *arg0, void *arg1, void (*arg2)(void *, b
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_mmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -4790,15 +4790,11 @@ void pci_unmap_rom(struct pci_dev *arg0, void *arg1) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: pid_task
@@ -5609,15 +5605,11 @@ bool vgacon_text_force() {
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_insert_pfn

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1132,15 +1132,11 @@ void neigh_destroy(struct neighbour *arg0) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: prandom_u32

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1130,15 +1130,11 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: printk

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--video--fbdev--core--fb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--video--fbdev--core--fb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -583,15 +583,11 @@ void unlock_page(struct page *arg0) {
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_iomap_memory

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -4798,15 +4798,11 @@ void pci_unmap_rom(struct pci_dev *arg0, void *arg1) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: pid_task
@@ -5617,15 +5613,11 @@ bool vgacon_text_force() {
 // Function: vm_get_page_prot
 // with type: pgprot_t vm_get_page_prot(unsigned long)
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t vm_get_page_prot(unsigned long arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: vm_insert_pfn

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--infiniband--hw--mlx5--mlx5_ib.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1139,15 +1139,11 @@ void mutex_unlock(struct mutex *arg0) {
 // Function: pgprot_writecombine
 // with type: pgprot_t pgprot_writecombine(pgprot_t )
 // with return type: pgprot_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 pgprot_t pgprot_writecombine(pgprot_t arg0) {
   // Typedef type
   // Real type: struct pgprot
   // Composite type
-  struct pgprot *tmp = (struct pgprot*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct pgprot *)ldv_xmalloc(sizeof(struct pgprot));
 }
 
 // Function: printk


### PR DESCRIPTION
Removes one of the uses of external_alloc, which is implemented using
__VERIFIER_nondet_pointer. The type and size are known, so just allocate
memory using ldv_xmalloc, which also simplifies the implementation.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).

The changes were done using the following command:
```
for f in c/ldv-*/model/*.c
do
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^\/\/ Function: (vm_get_page_prot|pgprot_writecombine)\s*$/) {
       $p = 2;
     }
     elsif($p == 2) {
       if(/^void \*external_alloc\(void\);\s*$/) { next; }
       elsif(/^void __VERIFIER_assume\(int\);\s*$/) { next; }
       elsif(/^  struct pgprot \*tmp = \(struct pgprot\*\)external_alloc\(\);\s*$/) { next; }
       elsif(/^  __VERIFIER_assume\(tmp != 0\);\s*$/) { next; }
       elsif(/^  return \*tmp;\s*$/) {
         print "  return *ldv_xmalloc(sizeof(struct pgprot));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
followed by re-preprocessing of all LDV benchmarks.
