### PR TITLE
Implement cfs_block_{allsigs,sigsinv} using ldv_xmalloc

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -34318,12 +34318,8 @@ void *cfs_array_alloc(int arg0, unsigned int arg1) {
 void cfs_array_free(void *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_current(struct cfs_cpt_table *arg0, int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -31235,12 +31235,8 @@ void *external_alloc(void);
 struct page *alloc_pages_current(gfp_t arg0, unsigned int arg1) {
   return (struct page *)external_alloc();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_number(struct cfs_cpt_table *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -36459,12 +36459,8 @@ void *cfs_array_alloc(int arg0, unsigned int arg1) {
 void cfs_array_free(void *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_current(struct cfs_cpt_table *arg0, int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -32592,12 +32592,8 @@ void *external_alloc(void);
 struct page *alloc_pages_current(gfp_t arg0, unsigned int arg1) {
   return (struct page *)external_alloc();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_number(struct cfs_cpt_table *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point.cil.out.i
@@ -24417,12 +24417,8 @@ void add_wait_queue(wait_queue_head_t *arg0, wait_queue_t *arg1) {
 void capa_cpy(void *arg0, struct obd_capa *arg1) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 void cfs_clear_sigpending() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -36239,12 +36239,8 @@ void *cfs_array_alloc(int arg0, unsigned int arg1) {
 void cfs_array_free(void *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_current(struct cfs_cpt_table *arg0, int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -32430,12 +32430,8 @@ void _raw_spin_lock(raw_spinlock_t *arg0) {
 void _raw_spin_unlock(raw_spinlock_t *arg0) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 int __VERIFIER_nondet_int(void);
 int cfs_cpt_number(struct cfs_cpt_table *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point.cil.out.i
@@ -68837,12 +68837,8 @@ bool capable(int arg0) {
 void ccc_inode_lsm_put(struct inode *arg0, struct lov_stripe_md *arg1) {
   return;
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 void cfs_clear_sigpending() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point.cil.out.i
@@ -40850,12 +40850,8 @@ bool __VERIFIER_nondet_bool(void);
 bool capable(int arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 void cfs_clear_sigpending() {
   return;

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -168,15 +168,11 @@ void cfs_array_free(void *arg0) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_cpt_current

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -286,15 +286,11 @@ struct page *alloc_pages_current(gfp_t arg0, unsigned int arg1) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_cpt_number

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -168,15 +168,11 @@ void cfs_array_free(void *arg0) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_163
   // Composite type
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 
 // Function: cfs_cpt_current

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -286,15 +286,11 @@ struct page *alloc_pages_current(gfp_t arg0, unsigned int arg1) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_163
   // Composite type
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 
 // Function: cfs_cpt_number

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -193,15 +193,11 @@ void capa_cpy(void *arg0, struct obd_capa *arg1) {
 // Function: cfs_block_sigsinv
 // with type: sigset_t cfs_block_sigsinv(unsigned long)
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_163
   // Composite type
-  struct __anonstruct_sigset_t_163 *tmp = (struct __anonstruct_sigset_t_163*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_163 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_163));
 }
 
 // Function: cfs_clear_sigpending

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -159,15 +159,11 @@ void cfs_array_free(void *arg0) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_cpt_current

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -268,15 +268,11 @@ void _raw_spin_unlock(raw_spinlock_t *arg0) {
 // Function: cfs_block_allsigs
 // with type: sigset_t cfs_block_allsigs()
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_allsigs() {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_cpt_number

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--llite--lustre.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -341,15 +341,11 @@ void ccc_inode_lsm_put(struct inode *arg0, struct lov_stripe_md *arg1) {
 // Function: cfs_block_sigsinv
 // with type: sigset_t cfs_block_sigsinv(unsigned long)
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_clear_sigpending

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lustre--osc--osc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -237,15 +237,11 @@ bool capable(int arg0) {
 // Function: cfs_block_sigsinv
 // with type: sigset_t cfs_block_sigsinv(unsigned long)
 // with return type: sigset_t 
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 sigset_t cfs_block_sigsinv(unsigned long arg0) {
   // Typedef type
   // Real type: struct __anonstruct_sigset_t_180
   // Composite type
-  struct __anonstruct_sigset_t_180 *tmp = (struct __anonstruct_sigset_t_180*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct __anonstruct_sigset_t_180 *)ldv_xmalloc(sizeof(struct __anonstruct_sigset_t_180));
 }
 
 // Function: cfs_clear_sigpending


### PR DESCRIPTION
Implement cfs_block_{allsigs,sigsinv} using ldv_xmalloc.

Removes one of the uses of external_alloc, which is implemented using
__VERIFIER_nondet_pointer. The type and size are known, so just allocate
memory using ldv_xmalloc, which also simplifies the implementation.
This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).

The changes were done using the following command:
```
for f in c/ldv-*/model/*.c
do
perl -i -e \
  '$p = 1; $t = "";
   while(<>) {
     if(/^\/\/ Function: cfs_block_(allsigs|sigsinv)\s*$/) {
       $p = 2;
     }
     elsif($p == 2) {
       if(/^void \*external_alloc\(void\);\s*$/) { next; }
       elsif(/^void __VERIFIER_assume\(int\);\s*$/) { next; }
       elsif(/^  struct (__anonstruct_sigset_t_\d+) \*tmp = \(struct .*\*\)external_alloc\(\);\s*$/) { $t = $1; next; }
       elsif(/^  __VERIFIER_assume\(tmp != 0\);\s*$/) { next; }
       elsif(/^  return \*tmp;\s*$/) {
         print "  return *ldv_xmalloc(sizeof(struct $t));\n";
         $p = 1;
         next;
       }
       elsif(/^\}$/) { $p = 1; }
     }
     print;
   }' \
  $f
done
```
followed by re-preprocessing of all LDV benchmarks.
