### PR TITLE
Replace remaining uses of external_alloc by ldv_{x,}malloc

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -20560,9 +20560,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -33411,9 +33411,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful.cil.out.i
@@ -33411,9 +33411,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -33411,9 +33411,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
@@ -858,10 +858,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: printk

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -353,12 +353,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main11_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
@@ -353,12 +353,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -353,12 +353,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-commit-tester/m0_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389-1.i
+++ b/c/ldv-commit-tester/m0_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389-1.i
@@ -7707,9 +7707,8 @@ void ldv_check_final_state(void)
 void __const_udelay(unsigned long arg0) {
   return;
 }
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 int __VERIFIER_nondet_int(void);
 int cx2341x_ctrl_query(const struct cx2341x_mpeg_params *arg0, struct v4l2_queryctrl *arg1) {

--- a/c/ldv-commit-tester/m0_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389.i
+++ b/c/ldv-commit-tester/m0_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389.i
@@ -7707,9 +7707,8 @@ void ldv_check_final_state(void)
 void __const_udelay(unsigned long arg0) {
   return;
 }
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 int __VERIFIER_nondet_int(void);
 int cx2341x_ctrl_query(const struct cx2341x_mpeg_params *arg0, struct v4l2_queryctrl *arg1) {

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389-1.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389-1.env.c
@@ -13,10 +13,9 @@ void __const_udelay(unsigned long arg0) {
 // Function: cx2341x_ctrl_get_menu
 // with type: const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *, u32 )
 // with return type: (const (const char)*)*
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
   // Pointer type
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 
 // Function: cx2341x_ctrl_query

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-blackbird-ko--32_7a--d47b389.env.c
@@ -13,10 +13,9 @@ void __const_udelay(unsigned long arg0) {
 // Function: cx2341x_ctrl_get_menu
 // with type: const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *, u32 )
 // with return type: (const (const char)*)*
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
   // Pointer type
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 
 // Function: cx2341x_ctrl_query

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--ata--libata.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--ata--libata.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.i
@@ -29929,9 +29929,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_install_notify_handler(acpi_handle arg0, u32 arg1, void (*arg2)(acpi_handle , u32 , void *), void *arg3) {
@@ -30209,9 +30208,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_pin_device(struct pci_dev *arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -33440,9 +33440,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main11_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main11_sequence_infinite_withcheck_stateful.cil.out.i
@@ -38834,9 +38834,8 @@ bool __VERIFIER_nondet_bool(void);
 bool cancel_delayed_work_sync(struct delayed_work *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 void *external_alloc(void);
 struct ceph_buffer *ceph_buffer_new(size_t arg0, gfp_t arg1) {
@@ -38907,9 +38906,8 @@ int __VERIFIER_nondet_int(void);
 int ceph_flags_to_mode(int arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 struct page **ceph_get_direct_page_vector(const char *arg0, int arg1, bool arg2) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 int __VERIFIER_nondet_int(void);
 int ceph_monc_do_statfs(struct ceph_mon_client *arg0, struct ceph_statfs *arg1) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main7_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main7_sequence_infinite_withcheck_stateful.cil.out.i
@@ -38834,9 +38834,8 @@ bool __VERIFIER_nondet_bool(void);
 bool cancel_delayed_work_sync(struct delayed_work *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 void *external_alloc(void);
 struct ceph_buffer *ceph_buffer_new(size_t arg0, gfp_t arg1) {
@@ -38907,9 +38906,8 @@ int __VERIFIER_nondet_int(void);
 int ceph_flags_to_mode(int arg0) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 struct page **ceph_get_direct_page_vector(const char *arg0, int arg1, bool arg2) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 int __VERIFIER_nondet_int(void);
 int ceph_monc_do_statfs(struct ceph_mon_client *arg0, struct ceph_statfs *arg1) {

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main13.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main13.cil.out.i
@@ -33411,9 +33411,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--ata--libata.ko-ldv_main4_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--ata--libata.ko-ldv_main4_sequence_infinite_withcheck_stateful.env.c
@@ -214,12 +214,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_install_notify_handler
@@ -917,10 +916,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_pin_device

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
@@ -362,12 +362,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main11_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main11_sequence_infinite_withcheck_stateful.env.c
@@ -273,10 +273,9 @@ bool cancel_delayed_work_sync(struct delayed_work *arg0) {
 // Function: ceph_alloc_page_vector
 // with type: struct page **ceph_alloc_page_vector(int, gfp_t )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_buffer_new
@@ -446,10 +445,9 @@ int ceph_flags_to_mode(int arg0) {
 // Function: ceph_get_direct_page_vector
 // with type: struct page **ceph_get_direct_page_vector(const char *, int, bool )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_get_direct_page_vector(const char *arg0, int arg1, bool arg2) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_monc_do_statfs

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main7_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-fs--ceph--ceph.ko-ldv_main7_sequence_infinite_withcheck_stateful.env.c
@@ -273,10 +273,9 @@ bool cancel_delayed_work_sync(struct delayed_work *arg0) {
 // Function: ceph_alloc_page_vector
 // with type: struct page **ceph_alloc_page_vector(int, gfp_t )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_buffer_new
@@ -446,10 +445,9 @@ int ceph_flags_to_mode(int arg0) {
 // Function: ceph_get_direct_page_vector
 // with type: struct page **ceph_get_direct_page_vector(const char *, int, bool )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_get_direct_page_vector(const char *arg0, int arg1, bool arg2) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_monc_do_statfs

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main13_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--usb--core--usbcore.ko-ldv_main13_true-unreach-call.env.c
@@ -353,12 +353,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko.cil-1.i
@@ -12048,16 +12048,14 @@ void __const_udelay(unsigned long arg0){
 void msleep(unsigned int arg0){
   return;
 }
-void *external_alloc(void);
 char *strcpy(char *arg0, const char *arg1){
-  return (char *)external_alloc();
+  return ldv_malloc(sizeof(char));
 }
 void pci_restore_state(struct pci_dev *arg0){
   return;
 }
-void *external_alloc(void);
 struct v4l2_subdev *v4l2_i2c_new_subdev_board(struct v4l2_device *arg0, struct i2c_adapter *arg1, struct i2c_board_info *arg2, const unsigned short *arg3){
-  return (struct v4l2_subdev *)external_alloc();
+  return ldv_malloc(sizeof(struct v4l2_subdev));
 }
 int __VERIFIER_nondet_int(void);
 int vb2_streamon(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
@@ -12107,16 +12105,14 @@ void ldv_switch_to_interrupt_context(){
 void _raw_spin_unlock(raw_spinlock_t *arg0){
   return;
 }
-void *external_alloc(void);
 struct video_device *video_devdata(struct file *arg0){
-  return (struct video_device *)external_alloc();
+  return ldv_malloc(sizeof(struct video_device));
 }
 void ldv_check_alloc_flags(gfp_t arg0){
   return;
 }
-void *external_alloc(void);
 void *vb2_dma_contig_init_ctx(struct device *arg0){
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2){
@@ -12140,9 +12136,8 @@ int __VERIFIER_nondet_int(void);
 int vb2_dqbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1, bool arg2){
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2){
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 void pci_iounmap(struct pci_dev *arg0, void *arg1){
   return;
@@ -12184,17 +12179,11 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 void v4l2_device_unregister(struct v4l2_device *arg0){
   return;
 }
-void *external_alloc(void);
 struct scatterlist *sg_next(struct scatterlist *arg0){
-  return (struct scatterlist *)external_alloc();
+  return ldv_malloc(sizeof(struct scatterlist));
 }
-void *external_alloc(void);
-void *external_allocated_data(){
-  return (void *)external_alloc();
-}
-void *external_alloc(void);
 void *vb2_plane_cookie(struct vb2_buffer *arg0, unsigned int arg1){
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
@@ -12227,9 +12216,8 @@ long int schedule_timeout(long arg0){
 void _raw_spin_lock(raw_spinlock_t *arg0){
   return;
 }
-void *external_alloc(void);
 void *vb2_plane_vaddr(struct vb2_buffer *arg0, unsigned int arg1){
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 void debug_dma_free_coherent(struct device *arg0, size_t arg1, void *arg2, dma_addr_t arg3){
   return;
@@ -12246,9 +12234,8 @@ int __VERIFIER_nondet_int(void);
 int vb2_streamoff(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void *memcpy(void *arg0, const void *arg1, size_t arg2){
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 unsigned int vb2_poll(struct vb2_queue *arg0, struct file *arg1, poll_table *arg2){

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -20507,9 +20507,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe.cil.i
@@ -18852,9 +18852,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
@@ -833,10 +833,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: printk

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-oki-semi-pch_gbe-pch_gbe_true-unreach-call.cil.env.c
@@ -851,10 +851,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: printk

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point.cil.out.i
@@ -15316,9 +15316,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point.cil.out.i
@@ -7033,9 +7033,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_pin_device(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
@@ -36262,9 +36262,8 @@ int drm_gem_dumb_destroy(struct drm_file *arg0, struct drm_device *arg1, uint32_
 void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
   return;
 }
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0, gfp_t arg1) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 int __VERIFIER_nondet_int(void);
 int drm_gem_handle_create(struct drm_file *arg0, struct drm_gem_object *arg1, u32 *arg2) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point.cil.out.i
@@ -29096,9 +29096,8 @@ void class_unregister(struct class *arg0) {
 void complete(struct completion *arg0) {
   return;
 }
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 int __VERIFIER_nondet_int(void);
 int cx2341x_ctrl_query(const struct cx2341x_mpeg_params *arg0, struct v4l2_queryctrl *arg1) {

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--oki-semi--pch_gbe--pch_gbe.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -924,10 +924,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: printk

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--ata--sata_sx4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -315,10 +315,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_pin_device

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -568,10 +568,9 @@ void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
 // Function: drm_gem_get_pages
 // with type: struct page **drm_gem_get_pages(struct drm_gem_object *, gfp_t )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0, gfp_t arg1) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: drm_gem_handle_create

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -201,10 +201,9 @@ void complete(struct completion *arg0) {
 // Function: cx2341x_ctrl_get_menu
 // with type: const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *, u32 )
 // with return type: (const (const char)*)*
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
   // Pointer type
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 
 // Function: cx2341x_ctrl_query

--- a/c/ldv-linux-3.7.3/main11_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main11_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34138,9 +34138,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-linux-3.7.3/main15_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main15_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34138,9 +34138,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-linux-3.7.3/main1_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
+++ b/c/ldv-linux-3.7.3/main1_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.i
@@ -34138,9 +34138,8 @@ unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi_object_list *arg2, struct acpi_buffer *arg3) {
   return __VERIFIER_nondet_uint();
 }
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 unsigned int __VERIFIER_nondet_uint(void);
 acpi_status acpi_get_physical_device_location(acpi_handle arg0, struct acpi_pld_info **arg1) {

--- a/c/ldv-linux-3.7.3/model/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main11_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -362,12 +362,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-linux-3.7.3/model/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main15_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -362,12 +362,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-linux-3.7.3/model/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
+++ b/c/ldv-linux-3.7.3/model/main1_false-unreach-call_drivers-usb-core-usbcore-ko--32_7a--linux-3.7.3.env.c
@@ -362,12 +362,11 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 // Function: acpi_get_child
 // with type: acpi_handle acpi_get_child(acpi_handle , u64 )
 // with return type: acpi_handle 
-void *external_alloc(void);
 acpi_handle acpi_get_child(acpi_handle arg0, u64 arg1) {
   // Typedef type
   // Real type: (void)*
   // Pointer type
-  return (void *)external_alloc();
+  return ldv_malloc(0UL);
 }
 
 // Function: acpi_get_physical_device_location

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.i
@@ -20044,9 +20044,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_iounmap_regions(struct pci_dev *arg0, int arg1) {
   return;

--- a/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.env.c
+++ b/c/ldv-linux-4.0-rc1-mav/model/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko_false-unreach-call.cil.env.c
@@ -918,10 +918,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_iounmap_regions

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--ata--libata.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--ata--libata.ko-entry_point.cil.out.i
@@ -38454,9 +38454,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_pin_device(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
@@ -38838,9 +38838,8 @@ int drm_gem_dumb_destroy(struct drm_file *arg0, struct drm_device *arg1, uint32_
 void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
   return;
 }
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 int __VERIFIER_nondet_int(void);
 int drm_gem_handle_create(struct drm_file *arg0, struct drm_gem_object *arg1, u32 *arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
@@ -15702,9 +15702,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -39793,9 +39793,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void platform_driver_unregister(struct platform_driver *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
@@ -68491,12 +68491,8 @@ bool __VERIFIER_nondet_bool(void);
 bool cancel_work_sync(struct work_struct *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct cordic_iq cordic_calc_iq(s32 arg0) {
-  struct cordic_iq *tmp = (struct cordic_iq*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct cordic_iq *)ldv_xmalloc(sizeof(struct cordic_iq));
 }
 void debug_dma_map_page(struct device *arg0, struct page *arg1, size_t arg2, size_t arg3, int arg4, dma_addr_t arg5, bool arg6) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--ata--libata.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--ata--libata.ko-entry_point.cil.out.i
@@ -40234,9 +40234,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_pin_device(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rbd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rbd.ko-entry_point.cil.out.i
@@ -16195,9 +16195,8 @@ int bus_register(struct bus_type *arg0) {
 void bus_unregister(struct bus_type *arg0) {
   return;
 }
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 u64 ceph_client_id(struct ceph_client *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point.cil.out.i
@@ -45501,9 +45501,8 @@ int drm_gem_dumb_destroy(struct drm_file *arg0, struct drm_device *arg1, uint32_
 void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
   return;
 }
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 int __VERIFIER_nondet_int(void);
 int drm_gem_handle_create(struct drm_file *arg0, struct drm_gem_object *arg1, u32 *arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point.cil.out.i
@@ -34165,9 +34165,8 @@ void class_unregister(struct class *arg0) {
 void complete(struct completion *arg0) {
   return;
 }
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 int __VERIFIER_nondet_int(void);
 int cx2341x_ctrl_query(const struct cx2341x_mpeg_params *arg0, struct v4l2_queryctrl *arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
@@ -17585,9 +17585,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -42357,9 +42357,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void platform_driver_unregister(struct platform_driver *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
@@ -69971,12 +69971,8 @@ bool __VERIFIER_nondet_bool(void);
 bool cancel_work_sync(struct work_struct *arg0) {
   return __VERIFIER_nondet_bool();
 }
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct cordic_iq cordic_calc_iq(s32 arg0) {
-  struct cordic_iq *tmp = (struct cordic_iq*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct cordic_iq *)ldv_xmalloc(sizeof(struct cordic_iq));
 }
 void debug_dma_map_page(struct device *arg0, struct page *arg1, size_t arg2, size_t arg3, int arg4, dma_addr_t arg5, bool arg6) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
@@ -11656,9 +11656,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 bool __VERIFIER_nondet_bool(void);
 bool queue_delayed_work_on(int arg0, struct workqueue_struct *arg1, struct delayed_work *arg2, unsigned long arg3) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--ata--libata.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--ata--libata.ko-entry_point.cil.out.i
@@ -38328,9 +38328,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_pin_device(struct pci_dev *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--mtip32xx--mtip32xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--mtip32xx--mtip32xx.ko-entry_point.cil.out.i
@@ -13376,9 +13376,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 void pcim_iounmap_regions(struct pci_dev *arg0, int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
@@ -15618,9 +15618,8 @@ int bus_register(struct bus_type *arg0) {
 void bus_unregister(struct bus_type *arg0) {
   return;
 }
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 u64 ceph_client_id(struct ceph_client *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
@@ -10359,9 +10359,8 @@ int __VERIFIER_nondet_int(void);
 int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
   return __VERIFIER_nondet_int();
 }
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 bool __VERIFIER_nondet_bool(void);
 bool queue_delayed_work_on(int arg0, struct workqueue_struct *arg1, struct delayed_work *arg2, unsigned long arg3) {

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--ata--libata.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--ata--libata.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1144,10 +1144,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_pin_device

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -606,10 +606,9 @@ void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
 // Function: drm_gem_get_pages
 // with type: struct page **drm_gem_get_pages(struct drm_gem_object *)
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: drm_gem_handle_create

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -599,10 +599,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: prepare_to_wait_event

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2668,10 +2668,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: platform_driver_unregister

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -394,13 +394,9 @@ bool cancel_work_sync(struct work_struct *arg0) {
 // Function: cordic_calc_iq
 // with type: struct cordic_iq cordic_calc_iq(s32 )
 // with return type: struct cordic_iq
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct cordic_iq cordic_calc_iq(s32 arg0) {
   // Composite type
-  struct cordic_iq *tmp = (struct cordic_iq*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct cordic_iq *)ldv_xmalloc(sizeof(struct cordic_iq));
 }
 
 // Function: debug_dma_map_page

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--ata--libata.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--ata--libata.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1153,10 +1153,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_pin_device

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rbd.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rbd.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -303,10 +303,9 @@ void bus_unregister(struct bus_type *arg0) {
 // Function: ceph_alloc_page_vector
 // with type: struct page **ceph_alloc_page_vector(int, gfp_t )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_client_id

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--gma500--gma500_gfx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -606,10 +606,9 @@ void drm_gem_free_mmap_offset(struct drm_gem_object *arg0) {
 // Function: drm_gem_get_pages
 // with type: struct page **drm_gem_get_pages(struct drm_gem_object *)
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **drm_gem_get_pages(struct drm_gem_object *arg0) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: drm_gem_handle_create

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--pvrusb2--pvrusb2.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -222,10 +222,9 @@ void complete(struct completion *arg0) {
 // Function: cx2341x_ctrl_get_menu
 // with type: const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *, u32 )
 // with return type: (const (const char)*)*
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
   // Pointer type
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 
 // Function: cx2341x_ctrl_query

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -608,10 +608,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: prepare_to_wait_event

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2677,10 +2677,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: platform_driver_unregister

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -394,13 +394,9 @@ bool cancel_work_sync(struct work_struct *arg0) {
 // Function: cordic_calc_iq
 // with type: struct cordic_iq cordic_calc_iq(s32 )
 // with return type: struct cordic_iq
-void *external_alloc(void);
-void __VERIFIER_assume(int);
 struct cordic_iq cordic_calc_iq(s32 arg0) {
   // Composite type
-  struct cordic_iq *tmp = (struct cordic_iq*)external_alloc();
-  __VERIFIER_assume(tmp != 0);
-  return *tmp;
+  return *(struct cordic_iq *)ldv_xmalloc(sizeof(struct cordic_iq));
 }
 
 // Function: debug_dma_map_page

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--thunderbolt--thunderbolt.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--thunderbolt--thunderbolt.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -549,10 +549,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: queue_delayed_work_on

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--ata--libata.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--ata--libata.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1152,10 +1152,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_pin_device

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--block--mtip32xx--mtip32xx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--block--mtip32xx--mtip32xx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -962,10 +962,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: pcim_iounmap_regions

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -303,10 +303,9 @@ void bus_unregister(struct bus_type *arg0) {
 // Function: ceph_alloc_page_vector
 // with type: struct page **ceph_alloc_page_vector(int, gfp_t )
 // with return type: ((struct page)*)*
-void *external_alloc(void);
 struct page **ceph_alloc_page_vector(int arg0, gfp_t arg1) {
   // Pointer type
-  return (struct page **)external_alloc();
+  return ldv_malloc(sizeof(struct page *));
 }
 
 // Function: ceph_client_id

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -548,10 +548,9 @@ int pcim_iomap_regions(struct pci_dev *arg0, int arg1, const char *arg2) {
 // Function: pcim_iomap_table
 // with type: void * const *pcim_iomap_table(struct pci_dev *)
 // with return type: (const (void)*)*
-void *external_alloc(void);
 void * const *pcim_iomap_table(struct pci_dev *arg0) {
   // Pointer type
-  return (void * const *)external_alloc();
+  return ldv_malloc(sizeof(void *));
 }
 
 // Function: queue_delayed_work_on

--- a/c/ldv-validator-v0.6/linux-stable-d47b389-1-32_7a-drivers--media--video--cx88--cx88-blackbird.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-d47b389-1-32_7a-drivers--media--video--cx88--cx88-blackbird.ko-entry_point.cil.out.i
@@ -8242,9 +8242,8 @@ void ldv_check_final_state(void)
 void __const_udelay(unsigned long arg0) {
   return;
 }
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 int __VERIFIER_nondet_int(void);
 int cx2341x_ctrl_query(const struct cx2341x_mpeg_params *arg0, struct v4l2_queryctrl *arg1) {

--- a/c/ldv-validator-v0.6/model/linux-stable-d47b389-1-32_7a-drivers--media--video--cx88--cx88-blackbird.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-d47b389-1-32_7a-drivers--media--video--cx88--cx88-blackbird.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -25,10 +25,9 @@ void __const_udelay(unsigned long arg0) {
 // Function: cx2341x_ctrl_get_menu
 // with type: const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *, u32 )
 // with return type: (const (const char)*)*
-void *external_alloc(void);
 const char * const *cx2341x_ctrl_get_menu(const struct cx2341x_mpeg_params *arg0, u32 arg1) {
   // Pointer type
-  return (const char * const *)external_alloc();
+  return ldv_malloc(sizeof(char *));
 }
 
 // Function: cx2341x_ctrl_query


### PR DESCRIPTION
Replace remaining uses of external_alloc by ldv_{x,}malloc.

This is in preparation of removing uses of __VERIFIER_nondet_pointer
(see #767).
