### PR TITLE
fix undefined behaviour from pointer comparison after a pointer was freed

### DIFF
--- a/c/memsafety/cmp-freed-ptr.c
+++ b/c/memsafety/cmp-freed-ptr.c
@@ -10,12 +10,14 @@ int main() {
     struct T* y = NULL;
 
     y = malloc(sizeof(*y));
+    long int adressY = (long int) y;
 
     free(y);
 
     x = malloc(sizeof(*x));
+    long int adressX = (long int) x;
 
-    if (x == y)
+    if (adressX == adressY)
     { // if the second malloc returns the same value as the first, I should get here
         free(x);
     }

--- a/c/memsafety/cmp-freed-ptr.c
+++ b/c/memsafety/cmp-freed-ptr.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdint.h>
 
 int main() {
 
@@ -10,12 +11,12 @@ int main() {
     struct T* y = NULL;
 
     y = malloc(sizeof(*y));
-    long int adressY = (long int) y;
+    intptr_t adressY = (intptr_t) y;
 
     free(y);
 
     x = malloc(sizeof(*x));
-    long int adressX = (long int) x;
+    intptr_t adressX = (intptr_t) x;
 
     if (adressX == adressY)
     { // if the second malloc returns the same value as the first, I should get here

--- a/c/memsafety/cmp-freed-ptr.i
+++ b/c/memsafety/cmp-freed-ptr.i
@@ -515,9 +515,11 @@ int main() {
     struct T* x = ((void *)0);
     struct T* y = ((void *)0);
     y = malloc(sizeof(*y));
+    long int adressY = (long int) y;
     free(y);
     x = malloc(sizeof(*x));
-    if (x == y)
+    long int adressX = (long int) x;
+    if (adressX == adressY)
     {
         free(x);
     }

--- a/c/memsafety/cmp-freed-ptr.i
+++ b/c/memsafety/cmp-freed-ptr.i
@@ -508,6 +508,34 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+typedef __uint8_t uint8_t;
+typedef __uint16_t uint16_t;
+typedef __uint32_t uint32_t;
+typedef __uint64_t uint64_t;
+typedef signed char int_least8_t;
+typedef short int int_least16_t;
+typedef int int_least32_t;
+__extension__
+typedef long long int int_least64_t;
+typedef unsigned char uint_least8_t;
+typedef unsigned short int uint_least16_t;
+typedef unsigned int uint_least32_t;
+__extension__
+typedef unsigned long long int uint_least64_t;
+typedef signed char int_fast8_t;
+typedef int int_fast16_t;
+typedef int int_fast32_t;
+__extension__
+typedef long long int int_fast64_t;
+typedef unsigned char uint_fast8_t;
+typedef unsigned int uint_fast16_t;
+typedef unsigned int uint_fast32_t;
+__extension__
+typedef unsigned long long int uint_fast64_t;
+typedef int intptr_t;
+typedef unsigned int uintptr_t;
+typedef __intmax_t intmax_t;
+typedef __uintmax_t uintmax_t;
 int main() {
     struct T {
         struct T* next;
@@ -515,10 +543,10 @@ int main() {
     struct T* x = ((void *)0);
     struct T* y = ((void *)0);
     y = malloc(sizeof(*y));
-    long int adressY = (long int) y;
+    intptr_t adressY = (intptr_t) y;
     free(y);
     x = malloc(sizeof(*x));
-    long int adressX = (long int) x;
+    intptr_t adressX = (intptr_t) x;
     if (adressX == adressY)
     {
         free(x);


### PR DESCRIPTION
According to ISO-C99 6.2.4(2),
the value of a pointer becomes indeterminate when
the object it points to reaches the end of its lifetime.

The undefined behavior comes from computing "x==y" in this task,
because "y" was freed before, so its value is indeterminate.
The fix uses a temporary variable for storing the corresponding value.