### PR TITLE
Update instructions to reproduce (include Dockerfile and updated patch)

### DIFF
--- a/c/aws-c-common/Dockerfile
+++ b/c/aws-c-common/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+
+RUN apt-get -y update
+RUN apt-get -y upgrade
+
+RUN apt-get -y install git
+RUN apt-get -y install gcc-multilib
+
+RUN git clone https://github.com/gernst/sv-benchmarks.git
+RUN git clone https://github.com/gernst/aws-c-common.git
+
+WORKDIR /sv-benchmarks
+RUN git checkout aws-c-common
+WORKDIR /sv-benchmarks/c/aws-c-common
+
+RUN apt-get -y install make
+RUN ./makeall /aws-c-common /sv-benchmarks
+
+# RUN git config --global user.email "gidonernst@gmail.com"
+# RUN git config --global user.name "Gidon Ernst"
+
+RUN apt-get -y install vim

--- a/c/aws-c-common/README.txt
+++ b/c/aws-c-common/README.txt
@@ -4,8 +4,10 @@ Benchmarks from Amazon AWS C commons library
 You can find the original sources here:
 https://github.com/awslabs/aws-c-common
 
-Prepared by Gidon Ernst <gidonernst@gmail.com> (LMU Munich)
-with help from Daniel Schwartz-Narbonne (AWS).
+Prepared by
+- Gidon Ernst <gidonernst@gmail.com> (LMU Munich)
+- Daniel Schwartz-Narbonne
+- Michael Tautschnig
 
 The benchmark files are under the same license as AWS C commons (Apache 2.0).
 
@@ -20,8 +22,15 @@ If necessary, make modifications there.
 Steps to re-create these files
 ------------------------------
 
-Based on commit `816ec134472c4d0d5ad0d949bae3417617f1e63d` from 
-`https://github.com/awslabs/aws-c-common`.
+Platform:
+- Ubuntu 18:04
+- gcc-multilib
+
+The provided Dockerfile initializes a container with freshly generated benchmark files.
+Note that in order to push the repository, additional steps to authenticate from within the container may be necessary
+(e.g. by creating a temporary ssh key in the container and registering it on github).
+
+Based on commit `816ec134472c4d0d5ad0d949bae3417617f1e63d` from `https://github.com/awslabs/aws-c-common`.
 
 - Check out the sv-benchmarks into some directory $SV
 - Check out AWS C commons into some directory $AWS and apply `patch.diff`.
@@ -30,3 +39,4 @@ Based on commit `816ec134472c4d0d5ad0d949bae3417617f1e63d` from
 - Finally, create all the files with:
 
     $SV/c/aws-c-common/makeall $AWS $SV
+

--- a/c/aws-c-common/patch.diff
+++ b/c/aws-c-common/patch.diff
@@ -155,10 +155,97 @@ index 2148eb2..6f96936 100644
 +    save_byte_from_array(buf.buffer, buf.len, &rhs_byte);
 +    assert_byte_buf_equivalence(&buf_old, &buf, &rhs_byte);
  }
+diff --git a/.cbmc-batch/source/make_common_data_structures.c b/.cbmc-batch/source/make_common_data_structures.c
+index e7473b7..bc382b5 100644
+--- a/.cbmc-batch/source/make_common_data_structures.c
++++ b/.cbmc-batch/source/make_common_data_structures.c
+@@ -36,8 +36,8 @@ void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf)
+ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, const size_t size) {
+     ring_buf->allocator = can_fail_allocator();
+     ring_buf->allocation = bounded_malloc(sizeof(*(ring_buf->allocation)) * size);
+-    size_t position_head;
+-    size_t position_tail;
++    size_t position_head = nondet_uint64_t();
++    size_t position_tail = nondet_uint64_t();
+     __CPROVER_assume(position_head <= size);
+     __CPROVER_assume(position_tail <= size);
+     aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
+@@ -51,7 +51,7 @@ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf,
+ void ensure_byte_buf_has_allocated_buffer_member_in_range(struct aws_byte_buf *buf, uint8_t *lo, uint8_t *hi) {
+     assert(lo < hi);
+     size_t space = hi - lo;
+-    size_t pos;
++    size_t pos = nondet_uint64_t();
+     __CPROVER_assume(pos < space);
+     buf->buffer = lo + pos;
+     size_t max_capacity = hi - buf->buffer;
+@@ -109,7 +109,7 @@ void ensure_array_list_has_allocated_data_member(struct aws_array_list *const li
+ }
+ 
+ void ensure_linked_list_is_allocated(struct aws_linked_list *const list, size_t max_length) {
+-    size_t length;
++    size_t length = nondet_uint64_t();
+     __CPROVER_assume(length <= max_length);
+ 
+     list->head.prev = NULL;
+@@ -152,7 +152,7 @@ void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *cons
+ }
+ 
+ void ensure_allocated_hash_table(struct aws_hash_table *map, size_t max_table_entries) {
+-    size_t num_entries;
++    size_t num_entries = nondet_uint64_t();
+     __CPROVER_assume(num_entries <= max_table_entries);
+     __CPROVER_assume(aws_is_power_of_two(num_entries));
+ 
+@@ -174,7 +174,7 @@ bool aws_hash_table_has_an_empty_slot(const struct aws_hash_table *const map, si
+ 
+ bool hash_table_state_has_an_empty_slot(const struct hash_table_state *const state, size_t *const rval) {
+     __CPROVER_assume(state->entry_count > 0);
+-    size_t empty_slot_idx;
++    size_t empty_slot_idx = nondet_uint64_t();
+     __CPROVER_assume(empty_slot_idx < state->size);
+     *rval = empty_slot_idx;
+     return state->slots[empty_slot_idx].hash_code == 0;
+@@ -194,7 +194,7 @@ struct aws_string *ensure_string_is_allocated_nondet_length() {
+ }
+ 
+ struct aws_string *ensure_string_is_allocated_bounded_length(size_t max_size) {
+-    size_t len;
++    size_t len = nondet_uint64_t();
+     __CPROVER_assume(len < max_size);
+     return ensure_string_is_allocated(len);
+ }
+@@ -210,7 +210,7 @@ struct aws_string *ensure_string_is_allocated(size_t len) {
+ }
+ 
+ const char *ensure_c_str_is_allocated(size_t max_size) {
+-    size_t cap;
++    size_t cap = nondet_uint64_t();
+     __CPROVER_assume(cap > 0 && cap <= max_size);
+     const char *str = bounded_malloc(cap);
+     /* Ensure that its a valid c string. Since all bytes are nondeterminstic, the actual
 diff --git a/.cbmc-batch/source/utils.c b/.cbmc-batch/source/utils.c
-index ff0c3c8..6487ff6 100644
+index ff0c3c8..7e2d7d2 100644
 --- a/.cbmc-batch/source/utils.c
 +++ b/.cbmc-batch/source/utils.c
+@@ -19,7 +19,7 @@
+ void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
+     assert(!a == !b);
+     if (len > 0 && a != NULL && b != NULL) {
+-        size_t i;
++        size_t i = nondet_uint64_t();
+         __CPROVER_assume(i < len && len < MAX_MALLOC); /* prevent spurious pointer overflows */
+         assert(a[i] == b[i]);
+     }
+@@ -27,7 +27,7 @@ void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const si
+ 
+ void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len) {
+     if (len > 0 && a != NULL) {
+-        size_t i;
++        size_t i = nondet_uint64_t();
+         __CPROVER_assume(i < len);
+         assert(a[i] == c);
+     }
 @@ -101,6 +101,20 @@ void assert_byte_cursor_equivalence(
      }
  }


### PR DESCRIPTION
See #885 (note that the precise version of aws-c-commons  + patch is stated explicitly)