### PR TITLE
change verdict of memory safety (mem-track).

### DIFF
--- a/c/ntdrivers/floppy.i.cil-3.yml
+++ b/c/ntdrivers/floppy.i.cil-3.yml
@@ -7,4 +7,5 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack


### PR DESCRIPTION
There is at least one struct 'devobj' in the main function,
whose members are allocated on the heap, but never freed.

This violates the memory property for mem-track,
because when returning from the main function,
the struct itself is cleaned up with the stack frame,
but the heap object is no longer reachable.

Some of the allocation was introduced with d21602b024af034628dd81cf82e77d7eee2177c9.