### PR TITLE
ldv-*: Replace all remaining uses of ldv_undef_ptr

### DIFF
--- a/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i
+++ b/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i
@@ -5902,10 +5902,6 @@ void ldv_handler_precall() {
 void ldv_initialize() {
   return;
 }
-void *external_alloc(void);
-void *ldv_undef_ptr() {
-  return (void *)external_alloc();
-}
 void list_del(struct list_head *arg0) {
   return;
 }

--- a/c/ldv-commit-tester/model/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-1.env.c
+++ b/c/ldv-commit-tester/model/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-1.env.c
@@ -239,15 +239,6 @@ void ldv_initialize() {
   return;
 }
 
-// Function: ldv_undef_ptr
-// with type: void *ldv_undef_ptr()
-// with return type: (void)*
-void *external_alloc(void);
-void *ldv_undef_ptr() {
-  // Pointer type
-  return (void *)external_alloc();
-}
-
 // Function: list_del
 // with type: void list_del(struct list_head *)
 // with return type: void

--- a/c/ldv-commit-tester/model/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.env.c
+++ b/c/ldv-commit-tester/model/m0_false-unreach-call_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c.env.c
@@ -239,15 +239,6 @@ void ldv_initialize() {
   return;
 }
 
-// Function: ldv_undef_ptr
-// with type: void *ldv_undef_ptr()
-// with return type: (void)*
-void *external_alloc(void);
-void *ldv_undef_ptr() {
-  // Pointer type
-  return (void *)external_alloc();
-}
-
 // Function: list_del
 // with type: void list_del(struct list_head *)
 // with return type: void

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c
@@ -10573,7 +10573,7 @@ __inline static void *ldv_idr_find_114(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_resource_idr_of_client();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct client_resource));
   }
   return (tmp);
 }
@@ -13359,7 +13359,7 @@ __inline static void *ldv_idr_find_96(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_fw_device_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct fw_device));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.i
@@ -10005,7 +10005,7 @@ __inline static void *ldv_idr_find_114(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_resource_idr_of_client();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct client_resource));
   }
   return (tmp);
 }
@@ -12543,7 +12543,7 @@ __inline static void *ldv_idr_find_96(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_fw_device_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct fw_device));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c
@@ -21251,7 +21251,7 @@ __inline static void *ldv_idr_find_150(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_surf_id_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_bo));
   }
   return (tmp);
 }
@@ -25371,7 +25371,7 @@ __inline static void *ldv_idr_find_123(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_release_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_release));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.i
@@ -19883,7 +19883,7 @@ __inline static void *ldv_idr_find_150(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_surf_id_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_bo));
   }
   return (tmp);
 }
@@ -23636,7 +23636,7 @@ __inline static void *ldv_idr_find_123(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_release_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_release));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.c
@@ -22378,8 +22378,6 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
   int first ;
   int last ;
   int tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   int tmp___2 ;
 
   {
@@ -22432,8 +22430,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     }
     {
     ldv_check_for_read_section();
-    tmp___0 = ldv_undef_ptr();
-    p->rdev = (struct md_rdev *)tmp___0;
+    p->rdev = ldv_malloc(sizeof(struct md_rdev));
     }
     goto out;
   } else {
@@ -22461,8 +22458,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     err = 0;
     conf->fullsync = 1;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    p->replacement = (struct md_rdev *)tmp___1;
+    p->replacement = ldv_malloc(sizeof(struct md_rdev));
     }
     goto ldv_41839;
   } else {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--md--raid456.ko.cil.i
@@ -20934,8 +20934,6 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
   int first ;
   int last ;
   int tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   int tmp___2 ;
   {
   conf = (struct r5conf *)mddev->private;
@@ -20981,8 +20979,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     }
     {
     ldv_check_for_read_section();
-    tmp___0 = ldv_undef_ptr();
-    p->rdev = (struct md_rdev *)tmp___0;
+    p->rdev = ldv_malloc(sizeof(struct md_rdev));
     }
     goto out;
   } else {
@@ -21008,8 +21005,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     err = 0;
     conf->fullsync = 1;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    p->replacement = (struct md_rdev *)tmp___1;
+    p->replacement = ldv_malloc(sizeof(struct md_rdev));
     }
     goto ldv_41839;
   } else {

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c
@@ -14566,7 +14566,7 @@ __inline static void *ldv_idr_find_235(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_p();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct ppp));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.i
@@ -13847,7 +13847,7 @@ __inline static void *ldv_idr_find_235(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_p();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct ppp));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.c
@@ -18017,7 +18017,7 @@ __inline static void *ldv_idr_find_128(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_sg_index_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(Sg_device));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--sg.ko.cil.i
@@ -16925,7 +16925,7 @@ __inline static void *ldv_idr_find_128(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_sg_index_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(Sg_device));
   }
   return (tmp);
 }

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c
@@ -11078,8 +11078,6 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
   bool __warned ;
   int tmp ;
   int tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
 
   {
   if ((unsigned long )newstats == (unsigned long )((struct nft_stats *)0)) {
@@ -11109,16 +11107,14 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
     {
     oldstats = chain->stats;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___1;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     synchronize_rcu();
     free_percpu((void *)oldstats);
     }
   } else {
     {
     ldv_check_for_read_section();
-    tmp___2 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___2;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     }
   }
   return;
@@ -11225,7 +11221,6 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
   void const   *__vpp_verify ;
   unsigned long __ptr ;
   unsigned int tmp___31 ;
-  void *tmp___32 ;
   void *tmp___33 ;
   struct nft_base_chain *tmp___34 ;
 
@@ -11565,8 +11560,7 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
       }
       {
       ldv_check_for_read_section();
-      tmp___32 = ldv_undef_ptr();
-      basechain->stats = (struct nft_stats *)tmp___32;
+      basechain->stats = ldv_malloc(sizeof(struct nft_stats));
       }
     }
     basechain->type = type;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.i
@@ -10680,8 +10680,6 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
   bool __warned ;
   int tmp ;
   int tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
   {
   if ((unsigned long )newstats == (unsigned long )((struct nft_stats *)0)) {
     return;
@@ -10707,16 +10705,14 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
     {
     oldstats = chain->stats;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___1;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     synchronize_rcu();
     free_percpu((void *)oldstats);
     }
   } else {
     {
     ldv_check_for_read_section();
-    tmp___2 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___2;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     }
   }
   return;
@@ -10821,7 +10817,6 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
   void const *__vpp_verify ;
   unsigned long __ptr ;
   unsigned int tmp___31 ;
-  void *tmp___32 ;
   void *tmp___33 ;
   struct nft_base_chain *tmp___34 ;
   {
@@ -11126,8 +11121,7 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
       }
       {
       ldv_check_for_read_section();
-      tmp___32 = ldv_undef_ptr();
-      basechain->stats = (struct nft_stats *)tmp___32;
+      basechain->stats = ldv_malloc(sizeof(struct nft_stats));
       }
     }
     basechain->type = type;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.c
@@ -16571,7 +16571,7 @@ void *ldv_dma_pool_alloc_24(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(264UL);
   return (tmp);
 }
 }
@@ -16581,7 +16581,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(14UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--DAC960.ko-entry_point.cil.out.i
@@ -15730,7 +15730,7 @@ void *ldv_dma_pool_alloc_24(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(264UL);
   return (tmp);
 }
 }
@@ -15739,7 +15739,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(14UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.c
@@ -16381,7 +16381,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(240UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--block--rbd.ko-entry_point.cil.out.i
@@ -15353,7 +15353,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(240UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-cache.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-cache.ko-entry_point.cil.out.c
@@ -11677,7 +11677,7 @@ void *ldv_mempool_alloc_29(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(72UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-cache.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-cache.ko-entry_point.cil.out.i
@@ -10919,7 +10919,7 @@ void *ldv_mempool_alloc_29(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(72UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.c
@@ -10250,7 +10250,7 @@ void *ldv_mempool_alloc_41(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct ablkcipher_request));
   return (tmp);
 }
 }
@@ -10260,7 +10260,7 @@ void *ldv_mempool_alloc_42(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct page));
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-crypt.ko-entry_point.cil.out.i
@@ -9629,7 +9629,7 @@ void *ldv_mempool_alloc_41(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct ablkcipher_request));
   return (tmp);
 }
 }
@@ -9638,7 +9638,7 @@ void *ldv_mempool_alloc_42(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct page));
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.c
@@ -8618,7 +8618,7 @@ void *ldv_mempool_alloc_25(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(128UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-snapshot.ko-entry_point.cil.out.i
@@ -8115,7 +8115,7 @@ void *ldv_mempool_alloc_25(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(128UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.c
@@ -12400,7 +12400,7 @@ void *ldv_mempool_alloc_28(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(88UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--dm-thin-pool.ko-entry_point.cil.out.i
@@ -11570,7 +11570,7 @@ void *ldv_mempool_alloc_28(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(88UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point.cil.out.c
@@ -23096,17 +23096,17 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags ) 
 { 
   void *tmp ;
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(1040UL);
   return (tmp);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) 
 { 
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--md--raid456.ko-entry_point.cil.out.i
@@ -21313,16 +21313,16 @@ __inline static struct page *alloc_pages(gfp_t flags , unsigned int order )
   return ((struct page *)tmp);
 }
 }
+void *ldv_zalloc(size_t size ) ;
 __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 {
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(1040UL);
   return (tmp);
 }
 }
-void *ldv_zalloc(size_t size ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags )
 {
   void *tmp ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.c
@@ -65350,7 +65350,7 @@ void *ldv_dma_pool_alloc_942(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(2048UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -59797,7 +59797,7 @@ void *ldv_dma_pool_alloc_942(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(2048UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.c
@@ -11680,7 +11680,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -14818,7 +14818,7 @@ void *ldv_vmalloc_node_141(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
@@ -11325,7 +11325,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -14163,7 +14163,7 @@ void *ldv_vmalloc_node_141(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.c
@@ -13649,7 +13649,7 @@ void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(576);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -13118,7 +13118,7 @@ void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(576);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point.cil.out.c
@@ -20304,7 +20304,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--realtek--r8169.ko-entry_point.cil.out.i
@@ -19175,7 +19175,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.c
@@ -14246,7 +14246,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
@@ -13492,7 +13492,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.c
@@ -34740,7 +34740,7 @@ void *ldv_dma_pool_alloc_56(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(8191UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -32041,7 +32041,7 @@ void *ldv_dma_pool_alloc_56(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(8191UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
@@ -7194,7 +7194,7 @@ struct sk_buff *ldv_skb_copy_expand_42(struct sk_buff  const  *ldv_func_arg1 , i
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
@@ -7074,7 +7074,7 @@ struct sk_buff *ldv_skb_copy_expand_42(struct sk_buff const *ldv_func_arg1 , int
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.c
@@ -14993,13 +14993,14 @@ struct sk_buff *ldv_skb_clone_41(struct sk_buff *ldv_func_arg1 , gfp_t flags )
   return ((struct sk_buff *)tmp);
 }
 }
+extern void *realloc(void * , size_t  ) ;
 void *ldv_krealloc_42(void const   *ldv_func_arg1 , size_t ldv_func_arg2 , gfp_t flags ) 
 { 
   void *tmp ;
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--rndis_wlan.ko-entry_point.cil.out.i
@@ -14221,12 +14221,13 @@ struct sk_buff *ldv_skb_clone_41(struct sk_buff *ldv_func_arg1 , gfp_t flags )
   return ((struct sk_buff *)tmp);
 }
 }
+extern void *realloc(void * , size_t ) ;
 void *ldv_krealloc_42(void const *ldv_func_arg1 , size_t ldv_func_arg2 , gfp_t flags )
 {
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = realloc(ldv_func_arg1, ldv_func_arg2);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--advansys.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--advansys.ko-entry_point.cil.out.c
@@ -15055,7 +15055,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(36432UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--advansys.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--advansys.ko-entry_point.cil.out.i
@@ -14185,7 +14185,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(36432UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.c
@@ -21816,7 +21816,7 @@ void *ldv_dma_pool_alloc_92(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(324UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--be2iscsi--be2iscsi.ko-entry_point.cil.out.i
@@ -20569,7 +20569,7 @@ void *ldv_dma_pool_alloc_92(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(324UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.c
@@ -22528,7 +22528,7 @@ void *ldv_dma_pool_alloc_42(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(1872UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--ipr.ko-entry_point.cil.out.i
@@ -21019,7 +21019,7 @@ void *ldv_dma_pool_alloc_42(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(1872UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--libfc--libfc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--libfc--libfc.ko-entry_point.cil.out.c
@@ -12781,7 +12781,7 @@ void *ldv_mempool_alloc_137(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(576UL);
   return (tmp);
 }
 }
@@ -13995,7 +13995,7 @@ __inline static struct sk_buff *alloc_skb_fclone(unsigned int size , gfp_t flags
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }
@@ -24862,7 +24862,7 @@ void *ldv_mempool_alloc_386(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(448UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--libfc--libfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--libfc--libfc.ko-entry_point.cil.out.i
@@ -12147,7 +12147,7 @@ void *ldv_mempool_alloc_137(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(576UL);
   return (tmp);
 }
 }
@@ -13289,7 +13289,7 @@ __inline static struct sk_buff *alloc_skb_fclone(unsigned int size , gfp_t flags
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct sk_buff));
   return ((struct sk_buff *)tmp);
 }
 }
@@ -23154,7 +23154,7 @@ void *ldv_mempool_alloc_386(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(448UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.c
@@ -5282,7 +5282,7 @@ void *ldv_dma_pool_alloc_24(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }
@@ -5304,7 +5304,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(60UL);
   return (tmp);
 }
 }
@@ -5314,7 +5314,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.i
@@ -5088,7 +5088,7 @@ void *ldv_dma_pool_alloc_24(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }
@@ -5108,7 +5108,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(60UL);
   return (tmp);
 }
 }
@@ -5117,7 +5117,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.c
@@ -13782,7 +13782,7 @@ void *ldv_dma_pool_alloc_35(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }
@@ -13813,7 +13813,7 @@ void *ldv_dma_pool_alloc_38(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }
@@ -13823,7 +13823,7 @@ void *ldv_dma_pool_alloc_39(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }
@@ -13833,7 +13833,7 @@ void *ldv_dma_pool_alloc_40(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }
@@ -13843,7 +13843,7 @@ void *ldv_dma_pool_alloc_41(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--mpt3sas--mpt3sas.ko-entry_point.cil.out.i
@@ -13062,7 +13062,7 @@ void *ldv_dma_pool_alloc_35(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }
@@ -13090,7 +13090,7 @@ void *ldv_dma_pool_alloc_38(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }
@@ -13099,7 +13099,7 @@ void *ldv_dma_pool_alloc_39(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }
@@ -13108,7 +13108,7 @@ void *ldv_dma_pool_alloc_40(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }
@@ -13117,7 +13117,7 @@ void *ldv_dma_pool_alloc_41(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.c
@@ -26053,7 +26053,7 @@ void *ldv_dma_pool_alloc_45(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26075,7 +26075,7 @@ void *ldv_mempool_alloc_47(mempool_t *ldv_func_arg1 , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL); // pool element size is not constant
   return (tmp);
 }
 }
@@ -26180,7 +26180,7 @@ void *ldv_dma_pool_alloc_57(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26190,7 +26190,7 @@ void *ldv_dma_pool_alloc_58(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26210,7 +26210,7 @@ void *ldv_dma_pool_alloc_60(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26230,7 +26230,7 @@ void *ldv_dma_pool_alloc_62(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26250,7 +26250,7 @@ void *ldv_dma_pool_alloc_64(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -28270,7 +28270,7 @@ void *ldv_dma_pool_alloc_130(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -31268,7 +31268,7 @@ void *ldv_dma_pool_alloc_180(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -31278,7 +31278,7 @@ void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.i
@@ -24566,7 +24566,7 @@ void *ldv_dma_pool_alloc_45(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -24586,7 +24586,7 @@ void *ldv_mempool_alloc_47(mempool_t *ldv_func_arg1 , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(0UL);
   return (tmp);
 }
 }
@@ -24679,7 +24679,7 @@ void *ldv_dma_pool_alloc_57(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -24688,7 +24688,7 @@ void *ldv_dma_pool_alloc_58(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -24706,7 +24706,7 @@ void *ldv_dma_pool_alloc_60(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -24724,7 +24724,7 @@ void *ldv_dma_pool_alloc_62(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -24742,7 +24742,7 @@ void *ldv_dma_pool_alloc_64(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -26540,7 +26540,7 @@ void *ldv_dma_pool_alloc_130(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -29242,7 +29242,7 @@ void *ldv_dma_pool_alloc_180(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }
@@ -29251,7 +29251,7 @@ void *ldv_dma_pool_alloc_181(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.c
@@ -12602,7 +12602,7 @@ void *ldv_vmalloc_node_39(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }
@@ -18060,7 +18060,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -18170,7 +18170,7 @@ void *ldv_vmalloc_node_157(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }
@@ -36109,7 +36109,7 @@ void *ldv_vmalloc_node_457(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -12184,7 +12184,7 @@ void *ldv_vmalloc_node_39(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }
@@ -17204,7 +17204,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -17303,7 +17303,7 @@ void *ldv_vmalloc_node_157(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }
@@ -33834,7 +33834,7 @@ void *ldv_vmalloc_node_457(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.c
@@ -31850,7 +31850,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -31960,7 +31960,7 @@ void *ldv_vmalloc_node_242(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
 
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -29994,7 +29994,7 @@ __inline static void *kmalloc_node(size_t size , gfp_t flags , int node )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(size);
   return (tmp);
 }
 }
@@ -30093,7 +30093,7 @@ void *ldv_vmalloc_node_242(unsigned long ldv_func_arg1 , int ldv_func_arg2 )
   void *tmp ;
   {
   ldv_check_alloc_nonatomic();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(ldv_func_arg1);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.c
@@ -35545,7 +35545,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(48UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--target--target_core_mod.ko-entry_point.cil.out.i
@@ -33400,7 +33400,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(48UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.c
@@ -6889,7 +6889,7 @@ void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(256UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--thunderbolt--thunderbolt.ko-entry_point.cil.out.i
@@ -6490,7 +6490,7 @@ void *ldv_dma_pool_alloc_72(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(256UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.c
@@ -9387,7 +9387,7 @@ void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--bdc--bdc.ko-entry_point.cil.out.i
@@ -8871,7 +8871,7 @@ void *ldv_dma_pool_alloc_99(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(512UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--gr_udc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--gr_udc.ko-entry_point.cil.out.c
@@ -7502,7 +7502,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(24UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--gr_udc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--gadget--udc--gr_udc.ko-entry_point.cil.out.i
@@ -7090,7 +7090,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(24UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.c
@@ -16480,7 +16480,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -16490,7 +16490,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -16500,7 +16500,7 @@ void *ldv_dma_pool_alloc_28(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }
@@ -16510,7 +16510,7 @@ void *ldv_dma_pool_alloc_29(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ehci-hcd.ko-entry_point.cil.out.i
@@ -15350,7 +15350,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -15359,7 +15359,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -15368,7 +15368,7 @@ void *ldv_dma_pool_alloc_28(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }
@@ -15377,7 +15377,7 @@ void *ldv_dma_pool_alloc_29(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.c
@@ -12673,7 +12673,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -12683,7 +12683,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -12693,7 +12693,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
@@ -11846,7 +11846,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -11855,7 +11855,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -11864,7 +11864,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.c
@@ -12703,7 +12703,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -12713,7 +12713,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -12723,7 +12723,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--fusbh200-hcd.ko-entry_point.cil.out.i
@@ -11874,7 +11874,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -11883,7 +11883,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -11892,7 +11892,7 @@ void *ldv_dma_pool_alloc_27(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(192UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.c
@@ -10973,7 +10973,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -10983,7 +10983,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(112UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--ohci-hcd.ko-entry_point.cil.out.i
@@ -10313,7 +10313,7 @@ void *ldv_dma_pool_alloc_25(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(96UL);
   return (tmp);
 }
 }
@@ -10322,7 +10322,7 @@ void *ldv_dma_pool_alloc_26(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(112UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.c
@@ -18837,7 +18837,7 @@ void *ldv_dma_pool_alloc_73(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }
@@ -18847,7 +18847,7 @@ void *ldv_dma_pool_alloc_74(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(2112UL);
   return (tmp);
 }
 }
@@ -18857,7 +18857,7 @@ void *ldv_dma_pool_alloc_75(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(256UL);
   return (tmp);
 }
 }
@@ -18867,7 +18867,7 @@ void *ldv_dma_pool_alloc_76(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(1024UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
@@ -17471,7 +17471,7 @@ void *ldv_dma_pool_alloc_73(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(4096UL);
   return (tmp);
 }
 }
@@ -17480,7 +17480,7 @@ void *ldv_dma_pool_alloc_74(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(2112UL);
   return (tmp);
 }
 }
@@ -17489,7 +17489,7 @@ void *ldv_dma_pool_alloc_75(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(256UL);
   return (tmp);
 }
 }
@@ -17498,7 +17498,7 @@ void *ldv_dma_pool_alloc_76(struct dma_pool *ldv_func_arg1 , gfp_t flags , dma_a
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(1024UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.c
@@ -9018,7 +9018,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
 
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(48UL);
   return (tmp);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--isp1760--isp1760.ko-entry_point.cil.out.i
@@ -8483,7 +8483,7 @@ __inline static void *kmem_cache_zalloc(struct kmem_cache *k , gfp_t flags )
   void *tmp ;
   {
   ldv_check_alloc_flags(flags);
-  tmp = ldv_undef_ptr();
+  tmp = ldv_zalloc(48UL);
   return (tmp);
 }
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko_false-unreach-call.cil.c
@@ -10573,7 +10573,7 @@ __inline static void *ldv_idr_find_114(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_resource_idr_of_client();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct client_resource));
   }
   return (tmp);
 }
@@ -13359,7 +13359,7 @@ __inline static void *ldv_idr_find_96(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_fw_device_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct fw_device));
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko_false-unreach-call.cil.c
@@ -21251,7 +21251,7 @@ __inline static void *ldv_idr_find_150(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_surf_id_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_bo));
   }
   return (tmp);
 }
@@ -25371,7 +25371,7 @@ __inline static void *ldv_idr_find_123(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_release_idr_of_qxl_device();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct qxl_release));
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko_false-unreach-call.cil.c
@@ -22378,8 +22378,6 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
   int first ;
   int last ;
   int tmp ;
-  void *tmp___0 ;
-  void *tmp___1 ;
   int tmp___2 ;
 
   {
@@ -22432,8 +22430,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     }
     {
     ldv_check_for_read_section();
-    tmp___0 = ldv_undef_ptr();
-    p->rdev = (struct md_rdev *)tmp___0;
+    p->rdev = ldv_malloc(sizeof(struct md_rdev));
     }
     goto out;
   } else {
@@ -22461,8 +22458,7 @@ static int raid5_add_disk(struct mddev *mddev , struct md_rdev *rdev )
     err = 0;
     conf->fullsync = 1;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    p->replacement = (struct md_rdev *)tmp___1;
+    p->replacement = ldv_malloc(sizeof(struct md_rdev));
     }
     goto ldv_41839;
   } else {

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko_false-unreach-call.cil.c
@@ -14566,7 +14566,7 @@ __inline static void *ldv_idr_find_235(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_p();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(struct ppp));
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko_false-unreach-call.cil.c
@@ -18017,7 +18017,7 @@ __inline static void *ldv_idr_find_128(struct idr *idr , int id )
   {
   {
   ldv_linux_lib_idr_idr_find_sg_index_idr();
-  tmp = ldv_undef_ptr();
+  tmp = ldv_malloc(sizeof(Sg_device));
   }
   return (tmp);
 }

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko_false-unreach-call.cil.c
@@ -11078,8 +11078,6 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
   bool __warned ;
   int tmp ;
   int tmp___0 ;
-  void *tmp___1 ;
-  void *tmp___2 ;
 
   {
   if ((unsigned long )newstats == (unsigned long )((struct nft_stats *)0)) {
@@ -11109,16 +11107,14 @@ static void nft_chain_stats_replace(struct nft_base_chain *chain , struct nft_st
     {
     oldstats = chain->stats;
     ldv_check_for_read_section();
-    tmp___1 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___1;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     synchronize_rcu();
     free_percpu((void *)oldstats);
     }
   } else {
     {
     ldv_check_for_read_section();
-    tmp___2 = ldv_undef_ptr();
-    chain->stats = (struct nft_stats *)tmp___2;
+    chain->stats = ldv_malloc(sizeof(struct nft_stats));
     }
   }
   return;
@@ -11225,7 +11221,6 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
   void const   *__vpp_verify ;
   unsigned long __ptr ;
   unsigned int tmp___31 ;
-  void *tmp___32 ;
   void *tmp___33 ;
   struct nft_base_chain *tmp___34 ;
 
@@ -11565,8 +11560,7 @@ static int nf_tables_newchain(struct sock *nlsk , struct sk_buff *skb , struct n
       }
       {
       ldv_check_for_read_section();
-      tmp___32 = ldv_undef_ptr();
-      basechain->stats = (struct nft_stats *)tmp___32;
+      basechain->stats = ldv_malloc(sizeof(struct nft_stats));
       }
     }
     basechain->type = type;

--- a/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.c
@@ -5980,11 +5980,9 @@ __inline static void ldv_stop___0(void)
 struct tty_struct___0 *ldv_latest_tty  ;
 void ldv_initialize(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
 
   } else {
@@ -5995,11 +5993,9 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
 
   } else {

--- a/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point.cil.out.i
@@ -5745,10 +5745,8 @@ __inline static void ldv_stop___0(void)
 struct tty_struct___0 *ldv_latest_tty ;
 void ldv_initialize(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
   } else {
     ldv_stop___0();
@@ -5758,10 +5756,8 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
   } else {
     ldv_stop___0();

--- a/c/ldv-validator-v0.6/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point.cil.out.c
@@ -4697,7 +4697,6 @@ int ldv_blk_rq  =    0;
 struct request *ldv_blk_get_request(gfp_t mask ) 
 { 
   struct request *res ;
-  void *tmp ;
 
   {
   if (ldv_blk_rq == 0) {
@@ -4705,8 +4704,7 @@ struct request *ldv_blk_get_request(gfp_t mask )
   } else {
     ldv_error();
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((mask == 16U || mask == 208U) || mask == 16U) {
     if ((unsigned long )res != (unsigned long )((void *)0)) {
 
@@ -4727,7 +4725,6 @@ struct request *ldv_blk_get_request(gfp_t mask )
 struct request *ldv_blk_make_request(gfp_t mask ) 
 { 
   struct request *res ;
-  void *tmp ;
   long tmp___0 ;
 
   {
@@ -4736,8 +4733,7 @@ struct request *ldv_blk_make_request(gfp_t mask )
   } else {
     ldv_error();
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((unsigned long )res != (unsigned long )((void *)0)) {
 
   } else {

--- a/c/ldv-validator-v0.6/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point.cil.out.i
@@ -4515,14 +4515,12 @@ int ldv_blk_rq = 0;
 struct request *ldv_blk_get_request(gfp_t mask )
 {
   struct request *res ;
-  void *tmp ;
   {
   if (ldv_blk_rq == 0) {
   } else {
     ldv_error();
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((mask == 16U || mask == 208U) || mask == 16U) {
     if ((unsigned long )res != (unsigned long )((void *)0)) {
     } else {
@@ -4540,15 +4538,13 @@ struct request *ldv_blk_get_request(gfp_t mask )
 struct request *ldv_blk_make_request(gfp_t mask )
 {
   struct request *res ;
-  void *tmp ;
   long tmp___0 ;
   {
   if (ldv_blk_rq == 0) {
   } else {
     ldv_error();
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((unsigned long )res != (unsigned long )((void *)0)) {
   } else {
     ldv_stop___0();

--- a/c/ldv-validator-v0.6/linux-stable-4ed3cba-1-100_1a-drivers--usb--serial--qcserial.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-4ed3cba-1-100_1a-drivers--usb--serial--qcserial.ko-entry_point.cil.out.c
@@ -5457,11 +5457,9 @@ __inline static void ldv_stop___0(void)
 struct tty_struct___0 *ldv_latest_tty  ;
 void ldv_initialize(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
 
   } else {
@@ -5472,11 +5470,9 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
 
   } else {

--- a/c/ldv-validator-v0.6/linux-stable-4ed3cba-1-100_1a-drivers--usb--serial--qcserial.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-4ed3cba-1-100_1a-drivers--usb--serial--qcserial.ko-entry_point.cil.out.i
@@ -5292,10 +5292,8 @@ __inline static void ldv_stop___0(void)
 struct tty_struct___0 *ldv_latest_tty ;
 void ldv_initialize(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
   } else {
     ldv_stop___0();
@@ -5305,10 +5303,8 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct___0 *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct___0));
   if ((unsigned long )ldv_latest_tty != (unsigned long )((void *)0)) {
   } else {
     ldv_stop___0();

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_1a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_1a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.c
@@ -8608,12 +8608,10 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8636,12 +8634,10 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8699,7 +8695,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_2025;
   ldv_2024: ;
   ldv_2025: 
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_2024;
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_1a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-063f96c-1-144_1a-drivers--mmc--host--vub300.ko.unsigned-entry_point_ldv-val-v0.8.cil.out.i
@@ -8201,11 +8201,9 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8225,11 +8223,9 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8278,7 +8274,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_2025;
   ldv_2024: ;
   ldv_2025:
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_2024;
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -4897,11 +4897,9 @@ __inline static void ldv_error(void)
 struct tty_struct *ldv_latest_tty  ;
 void ldv_initialize(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct));
   if ((unsigned long )ldv_latest_tty == (unsigned long )((struct tty_struct *)0)) {
     ldv_stop();
   } else {
@@ -4912,11 +4910,9 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void) 
 { 
-  void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct));
   if ((unsigned long )ldv_latest_tty == (unsigned long )((struct tty_struct *)0)) {
     ldv_stop();
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-1dfa93a-1-100_1a-drivers--usb--serial--kobil_sct.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -4715,10 +4715,8 @@ __inline static void ldv_error(void)
 struct tty_struct *ldv_latest_tty ;
 void ldv_initialize(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct));
   if ((unsigned long )ldv_latest_tty == (unsigned long )((struct tty_struct *)0)) {
     ldv_stop();
   } else {
@@ -4728,10 +4726,8 @@ void ldv_initialize(void)
 }
 void ldv_handler_precall(void)
 {
-  void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  ldv_latest_tty = (struct tty_struct *)tmp;
+  ldv_latest_tty = ldv_malloc(sizeof(struct tty_struct));
   if ((unsigned long )ldv_latest_tty == (unsigned long )((struct tty_struct *)0)) {
     ldv_stop();
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -4408,7 +4408,6 @@ int ldv_blk_rq  =    0;
 struct request *ldv_blk_get_request(gfp_t mask ) 
 { 
   struct request *res ;
-  void *tmp ;
 
   {
   if (ldv_blk_rq != 0) {
@@ -4416,8 +4415,7 @@ struct request *ldv_blk_get_request(gfp_t mask )
   } else {
 
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((mask == 16U || mask == 208U) || mask == 16U) {
     if ((unsigned long )res == (unsigned long )((struct request *)0)) {
       ldv_stop();
@@ -4438,7 +4436,6 @@ struct request *ldv_blk_get_request(gfp_t mask )
 struct request *ldv_blk_make_request(gfp_t mask ) 
 { 
   struct request *res ;
-  void *tmp ;
   long tmp___0 ;
 
   {
@@ -4447,8 +4444,7 @@ struct request *ldv_blk_make_request(gfp_t mask )
   } else {
 
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((unsigned long )res == (unsigned long )((struct request *)0)) {
     ldv_stop();
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-39a1d13-1-101_1a-drivers--block--virtio_blk.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -4276,14 +4276,12 @@ int ldv_blk_rq = 0;
 struct request *ldv_blk_get_request(gfp_t mask )
 {
   struct request *res ;
-  void *tmp ;
   {
   if (ldv_blk_rq != 0) {
     ldv_error();
   } else {
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((mask == 16U || mask == 208U) || mask == 16U) {
     if ((unsigned long )res == (unsigned long )((struct request *)0)) {
       ldv_stop();
@@ -4301,15 +4299,13 @@ struct request *ldv_blk_get_request(gfp_t mask )
 struct request *ldv_blk_make_request(gfp_t mask )
 {
   struct request *res ;
-  void *tmp ;
   long tmp___0 ;
   {
   if (ldv_blk_rq != 0) {
     ldv_error();
   } else {
   }
-  tmp = ldv_undef_ptr();
-  res = (struct request *)tmp;
+  res = ldv_malloc(sizeof(struct request));
   if ((unsigned long )res == (unsigned long )((struct request *)0)) {
     ldv_stop();
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-468e4e3-1-204_8a-drivers--net--jme.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-468e4e3-1-204_8a-drivers--net--jme.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -11444,19 +11444,17 @@ Set LDV_PCI_DMA_PAGE_BUFS  ;
 dma_addr_t ldv_pci_dma_map_page(struct pci_dev *hwdev , struct page *page , unsigned long offset ,
                                 size_t size , int direction ) 
 { 
-  int nonedetermined ;
   void *tmp ;
 
   {
-  tmp = ldv_undef_ptr();
-  nonedetermined = (int )((long )tmp);
-  if (nonedetermined == 0) {
+  tmp = ldv_malloc(size);
+  if (tmp == 0) {
     return (0ULL);
   } else {
 
   }
   LDV_PCI_DMA_PAGE_BUFS = LDV_PCI_DMA_PAGE_BUFS + 1;
-  return ((dma_addr_t )nonedetermined);
+  return tmp;
 }
 }
 void ldv_pci_dma_unmap_page(struct pci_dev *hwdev , dma_addr_t dma_address , size_t size ,
@@ -11477,20 +11475,18 @@ void ldv_pci_dma_unmap_page(struct pci_dev *hwdev , dma_addr_t dma_address , siz
 dma_addr_t ldv_pci_dma_map(struct pci_dev *hwdev , void *ptr , size_t size , int direction ) 
 { 
   dma_addr_t dma_buf ;
-  int nonedetermined ;
   void *tmp ;
 
   {
   dma_buf = (dma_addr_t )ptr;
-  tmp = ldv_undef_ptr();
-  nonedetermined = (int )((long )tmp);
-  if (nonedetermined == 0) {
+  tmp = ldv_malloc(size);
+  if (tmp == 0) {
     return (0ULL);
   } else {
 
   }
   LDV_PCI_DMA_BUFS = LDV_PCI_DMA_BUFS + 1;
-  return ((dma_addr_t )nonedetermined);
+  return tmp;
 }
 }
 void ldv_pci_dma_unmap(struct pci_dev *hwdev , dma_addr_t dma_addr , size_t size ,

--- a/c/ldv-validator-v0.8/linux-stable-468e4e3-1-204_8a-drivers--net--jme.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-468e4e3-1-204_8a-drivers--net--jme.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -10752,17 +10752,15 @@ Set LDV_PCI_DMA_PAGE_BUFS ;
 dma_addr_t ldv_pci_dma_map_page(struct pci_dev *hwdev , struct page *page , unsigned long offset ,
                                 size_t size , int direction )
 {
-  int nonedetermined ;
   void *tmp ;
   {
-  tmp = ldv_undef_ptr();
-  nonedetermined = (int )((long )tmp);
-  if (nonedetermined == 0) {
+  tmp = ldv_malloc(size);
+  if (tmp == 0) {
     return (0ULL);
   } else {
   }
   LDV_PCI_DMA_PAGE_BUFS = LDV_PCI_DMA_PAGE_BUFS + 1;
-  return ((dma_addr_t )nonedetermined);
+  return tmp;
 }
 }
 void ldv_pci_dma_unmap_page(struct pci_dev *hwdev , dma_addr_t dma_address , size_t size ,
@@ -10780,18 +10778,16 @@ void ldv_pci_dma_unmap_page(struct pci_dev *hwdev , dma_addr_t dma_address , siz
 dma_addr_t ldv_pci_dma_map(struct pci_dev *hwdev , void *ptr , size_t size , int direction )
 {
   dma_addr_t dma_buf ;
-  int nonedetermined ;
   void *tmp ;
   {
   dma_buf = (dma_addr_t )ptr;
-  tmp = ldv_undef_ptr();
-  nonedetermined = (int )((long )tmp);
-  if (nonedetermined == 0) {
+  tmp = ldv_malloc(size);
+  if (tmp == 0) {
     return (0ULL);
   } else {
   }
   LDV_PCI_DMA_BUFS = LDV_PCI_DMA_BUFS + 1;
-  return ((dma_addr_t )nonedetermined);
+  return tmp;
 }
 }
 void ldv_pci_dma_unmap(struct pci_dev *hwdev , dma_addr_t dma_addr , size_t size ,

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_1a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_1a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -8644,12 +8644,10 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8672,12 +8670,10 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8735,7 +8731,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_2019;
   ldv_2018: ;
   ldv_2019: 
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_2018;
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_1a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5fdb450-1-144_1a-drivers--mmc--host--vub300.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -8226,11 +8226,9 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8250,11 +8248,9 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -8303,7 +8299,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_2019;
   ldv_2018: ;
   ldv_2019:
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_2018;
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -4218,12 +4218,10 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -4246,12 +4244,10 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) ) 
 { 
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
 
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -4309,7 +4305,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_1805;
   ldv_1804: ;
   ldv_1805: 
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_1804;
   } else {

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -4113,11 +4113,9 @@ void ldv_free_urb(struct urb *arg )
 void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -4137,11 +4135,9 @@ void ldv_fill_int_urb(void (*complete_fn)(struct urb * ) )
 void ldv_fill_bulk_urb(void (*complete_fn)(struct urb * ) )
 {
   struct urb *value ;
-  void *tmp ;
   int tmp___0 ;
   {
-  tmp = ldv_undef_ptr();
-  value = (struct urb *)tmp;
+  value = ldv_malloc(sizeof(struct urb));
   if ((unsigned long )value == (unsigned long )((struct urb *)0)) {
     ldv_stop();
   } else {
@@ -4190,7 +4186,7 @@ struct usb_device *ldv_interface_to_usbdev(void)
   goto ldv_1805;
   ldv_1804: ;
   ldv_1805:
-  result = ldv_undef_ptr();
+  result = ldv_malloc(sizeof(struct usb_device));
   if ((unsigned long )result == (unsigned long )((void *)0)) {
     goto ldv_1804;
   } else {


### PR DESCRIPTION
Replace any call to ldv_undef_ptr by ldv_malloc or ldv_zalloc, as
appropriate. Arguments were inferred from the call sites. This is in
preparation of removing uses of __VERIFIER_nondet_pointer (see #767).