### PR TITLE
VerifyThis benchmarks: avoid overflow in calloc

### DIFF
--- a/c/verifythis/duplets.c
+++ b/c/verifythis/duplets.c
@@ -42,7 +42,8 @@ int finddup(int *a, int n, int *_i, int *_j) {
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     int *a = calloc(n, sizeof(int));
 
     mkdup(a, n);

--- a/c/verifythis/elimination_max.c
+++ b/c/verifythis/elimination_max.c
@@ -10,7 +10,8 @@ extern int __VERIFIER_nondet_int(void);
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     int *a = calloc(n, sizeof(int));
 
     int x = 0;

--- a/c/verifythis/elimination_max_rec.c
+++ b/c/verifythis/elimination_max_rec.c
@@ -35,7 +35,8 @@ int check(int x, int y, int *a, int n) {
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     int *a = calloc(n, sizeof(int));
     int x = check(0, n-1, a, n);
 

--- a/c/verifythis/elimination_max_rec_onepoint.c
+++ b/c/verifythis/elimination_max_rec_onepoint.c
@@ -36,7 +36,8 @@ int main() {
     int n = __VERIFIER_nondet_int();
     __VERIFIER_assume(n >= 0);
     int i = __VERIFIER_nondet_int();
-    __VERIFIER_assume(0 <= i && i < n);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(0 <= i && i < n && n < (1 << 30));
     int *a = calloc(n, sizeof(int));
     int x = check(0, n-1, a, i, n);
     int ai = a[i];

--- a/c/verifythis/lcp.c
+++ b/c/verifythis/lcp.c
@@ -29,7 +29,8 @@ void check(int *a, int n, int x, int y, int l) {
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     int *a = calloc(n, sizeof(int));
 
     int x = __VERIFIER_nondet_int();

--- a/c/verifythis/prefixsum_iter.c
+++ b/c/verifythis/prefixsum_iter.c
@@ -54,7 +54,8 @@ void check(int *a0, int *a, int n) {
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     __VERIFIER_assume(is_pow2(n));
     int *a = calloc(n, sizeof(int));
 

--- a/c/verifythis/prefixsum_rec.c
+++ b/c/verifythis/prefixsum_rec.c
@@ -45,7 +45,8 @@ void check(int *a0, int *a, int n) {
 
 int main() {
     int n = __VERIFIER_nondet_int();
-    __VERIFIER_assume(n >= 0);
+    /* 1 << 30 will make sure n * sizeof(int) does not overflow */
+    __VERIFIER_assume(n >= 0 && n < (1 << 30));
     __VERIFIER_assume(is_pow2(n));
     int *a = calloc(n, sizeof(int));
 


### PR DESCRIPTION
The man page for calloc says: "The  calloc()  function  allocates memory
for  an array of nmemb elements of size bytes each and returns a pointer
to the allocated memory." It is not further specified what the behaviour
is when nmemb * size exceeds the maximum addressable storage. Thus guard
the call to calloc by an assumption that ensures that nmemb is strictly
less than 2^30 (this is a 32-bit category).
