### PR TITLE
bitvector/s3_{clnt_1,srvr_1a_alt}: Update overflow verdict

### DIFF
--- a/c/bitvector/s3_clnt_1.BV.c.cil-1a.yml
+++ b/c/bitvector/s3_clnt_1.BV.c.cil-1a.yml
@@ -6,8 +6,6 @@ input_files: 's3_clnt_1.BV.c.cil-1a.c'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
-  - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp

--- a/c/bitvector/s3_clnt_1.BV.c.cil-1a.yml
+++ b/c/bitvector/s3_clnt_1.BV.c.cil-1a.yml
@@ -5,7 +5,7 @@ input_files: 's3_clnt_1.BV.c.cil-1a.c'
 
 properties:
   - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
   - property_file: ../properties/coverage-branches.prp

--- a/c/bitvector/s3_clnt_1.BV.c.cil-2a.yml
+++ b/c/bitvector/s3_clnt_1.BV.c.cil-2a.yml
@@ -6,8 +6,6 @@ input_files: 's3_clnt_1.BV.c.cil-2a.c'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
-  - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp

--- a/c/bitvector/s3_clnt_1.BV.c.cil-2a.yml
+++ b/c/bitvector/s3_clnt_1.BV.c.cil-2a.yml
@@ -5,7 +5,7 @@ input_files: 's3_clnt_1.BV.c.cil-2a.c'
 
 properties:
   - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/coverage-error-call.prp

--- a/c/bitvector/s3_srvr_1a_alt.BV.c.cil.yml
+++ b/c/bitvector/s3_srvr_1a_alt.BV.c.cil.yml
@@ -5,7 +5,7 @@ input_files: 's3_srvr_1a_alt.BV.c.cil.c'
 
 properties:
   - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
   - property_file: ../properties/coverage-branches.prp

--- a/c/bitvector/s3_srvr_1a_alt.BV.c.cil.yml
+++ b/c/bitvector/s3_srvr_1a_alt.BV.c.cil.yml
@@ -6,8 +6,6 @@ input_files: 's3_srvr_1a_alt.BV.c.cil.c'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
-  - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
The two s3_clnt_1 tasks can result in an arithmetic overflow when
computing
```
s__s3__flags = (long )s__s3__flags - -5L;
```
as `s__s3__flags` has a non-deterministic value.

The s3_srvr_1a_alt task yields an overflow when computing
```
s__state = (ag_X * ag_Y) / ag_Z;
```
as both `ag_X` and `ag_y` have non-deterministic values.
