### PR TITLE
Revert label due to changes in 24e7400

### DIFF
--- a/java/algorithms/BellmanFord-FunSat01.yml
+++ b/java/algorithms/BellmanFord-FunSat01.yml
@@ -4,5 +4,5 @@ input_files:
   - BellmanFord-FunSat01/
 properties:
   - property_file: ../properties/assert.prp
-    expected_verdict: false
+    expected_verdict: true
 


### PR DESCRIPTION
As discussed in [PR-916](https://github.com/sosy-lab/sv-benchmarks/pull/916) this change had a race condition with changes done by @peterschrammel in 24e7400.
Hence, I want to revert this flag change
