### PR TITLE
Check overflow with appropriate builtin functions

### DIFF
--- a/c/aws-c-common/aws_add_size_saturating_harness.i
+++ b/c/aws-c-common/aws_add_size_saturating_harness.i
@@ -240,16 +240,6 @@ int __CPROVER_uninterpreted_compare(const void *const a, const void *const b) { 
 
 
 
-_Bool __CPROVER_overflow_plus(unsigned long a, unsigned long b) {
-    unsigned long c;
-    return __builtin_uaddl_overflow(a, b, &c);
-}
-
-_Bool __CPROVER_overflow_mult(unsigned long a, unsigned long b) {
-    unsigned long c;
-    return __builtin_umull_overflow(a, b, &c);
-}
-
 
 
 
@@ -2496,8 +2486,9 @@ static inline int aws_round_up_to_power_of_two(size_t n, size_t *result);
 
 
 static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
-    if (__CPROVER_overflow_mult(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_umull_overflow(a, b, &c))
+        return
               (18446744073709551615UL)
                         ;
     return a * b;
@@ -2508,7 +2499,8 @@ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 
 static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    if (__CPROVER_overflow_mult(a, b))
+    unsigned long c;
+    if (__builtin_umull_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
     return (0);
@@ -2518,8 +2510,9 @@ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
 
 
 static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
-    if (__CPROVER_overflow_mult(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_umul_overflow(a, b, &c))
+        return
               (4294967295U)
                         ;
     return a * b;
@@ -2530,7 +2523,8 @@ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 
 static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    if (__CPROVER_overflow_mult(a, b))
+    unsigned long c;
+    if (__builtin_umul_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
     return (0);
@@ -2540,8 +2534,9 @@ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
 
 
 static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
-    if (__CPROVER_overflow_plus(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_uaddl_overflow(a, b, &c))
+        return
               (18446744073709551615UL)
                         ;
     return a + b;
@@ -2552,7 +2547,8 @@ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 
 static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    if (__CPROVER_overflow_plus(a, b))
+    unsigned long c;
+    if (__builtin_uaddl_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
     return (0);
@@ -2562,8 +2558,9 @@ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
 
 
 static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
-    if (__CPROVER_overflow_plus(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_uadd_overflow(a, b, &c))
+        return
               (4294967295U)
                         ;
     return a + b;
@@ -2572,9 +2569,9 @@ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
 
 
 
-
 static inline int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    if (__CPROVER_overflow_plus(a, b))
+    unsigned long c;
+    if (__builtin_uadd_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
     return (0);

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -34,6 +34,7 @@ cd $SV && patch -p1 < c/aws-c-common/s_swap-fix.diff
 
 # fix overflow functions
 cd $SV && patch -p1 < c/aws-c-common/overflow-fix-1.diff
+cd $SV && patch -p1 < c/aws-c-common/overflow-fix-2.diff
 
 # remove all unsupported benchmarks
 rm -f aws_ring_buffer_buf_belongs_to_pool_harness.*

--- a/c/aws-c-common/overflow-fix-2.diff
+++ b/c/aws-c-common/overflow-fix-2.diff
@@ -1,0 +1,119 @@
+commit 6a08847d8b8e2ffe2a0a60d1590e68d91a748a88
+Author: feliperodri <rms.felipe@gmail.com>
+Date:   Tue Nov 19 15:28:03 2019 -0400
+
+    Check overflow with appropriate builtin functions
+    
+    Signed-off-by: feliperodri <rms.felipe@gmail.com>
+
+diff --git a/c/aws-c-common/aws_add_size_saturating_harness.i b/c/aws-c-common/aws_add_size_saturating_harness.i
+index 9c0e964a60..59fcbd2b5b 100644
+--- a/c/aws-c-common/aws_add_size_saturating_harness.i
++++ b/c/aws-c-common/aws_add_size_saturating_harness.i
+@@ -240,16 +240,6 @@ int __CPROVER_uninterpreted_compare(const void *const a, const void *const b) {
+ 
+ 
+ 
+-_Bool __CPROVER_overflow_plus(unsigned long a, unsigned long b) {
+-    unsigned long c;
+-    return __builtin_uaddl_overflow(a, b, &c);
+-}
+-
+-_Bool __CPROVER_overflow_mult(unsigned long a, unsigned long b) {
+-    unsigned long c;
+-    return __builtin_umull_overflow(a, b, &c);
+-}
+-
+ 
+ 
+ 
+@@ -2496,8 +2486,9 @@ static inline int aws_round_up_to_power_of_two(size_t n, size_t *result);
+ 
+ 
+ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
+-    if (__CPROVER_overflow_mult(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_umull_overflow(a, b, &c))
++        return
+               (18446744073709551615UL)
+                         ;
+     return a * b;
+@@ -2508,7 +2499,8 @@ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
+ 
+ 
+ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+-    if (__CPROVER_overflow_mult(a, b))
++    unsigned long c;
++    if (__builtin_umull_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a * b;
+     return (0);
+@@ -2518,8 +2510,9 @@ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+ 
+ 
+ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
+-    if (__CPROVER_overflow_mult(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_umul_overflow(a, b, &c))
++        return
+               (4294967295U)
+                         ;
+     return a * b;
+@@ -2530,7 +2523,8 @@ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
+ 
+ 
+ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+-    if (__CPROVER_overflow_mult(a, b))
++    unsigned long c;
++    if (__builtin_umul_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a * b;
+     return (0);
+@@ -2540,8 +2534,9 @@ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+ 
+ 
+ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
+-    if (__CPROVER_overflow_plus(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_uaddl_overflow(a, b, &c))
++        return
+               (18446744073709551615UL)
+                         ;
+     return a + b;
+@@ -2552,7 +2547,8 @@ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
+ 
+ 
+ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+-    if (__CPROVER_overflow_plus(a, b))
++    unsigned long c;
++    if (__builtin_uaddl_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a + b;
+     return (0);
+@@ -2562,8 +2558,9 @@ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+ 
+ 
+ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
+-    if (__CPROVER_overflow_plus(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_uadd_overflow(a, b, &c))
++        return
+               (4294967295U)
+                         ;
+     return a + b;
+@@ -2572,9 +2569,9 @@ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
+ 
+ 
+ 
+-
+ static inline int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+-    if (__CPROVER_overflow_plus(a, b))
++    unsigned long c;
++    if (__builtin_uadd_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a + b;
+     return (0);

--- a/c/check.py
+++ b/c/check.py
@@ -104,6 +104,7 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("aws-c-common", "unexpected file patch.diff"),
     ("aws-c-common", "unexpected file s_swap-fix.diff"),
     ("aws-c-common", "unexpected file overflow-fix-1.diff"),
+    ("aws-c-common", "unexpected file overflow-fix-2.diff"),
     ("aws-c-common", "unexpected file makeall"),
     ("aws-c-common", "unexpected file Makefile.sv-benchmarks"),
     ("aws-c-common", "unexpected file yml.sh"),


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

Fix #922 

In AWS C Common benchmarks, every time it checks for overflow in 32-bit operations, it uses the `__CPROVER_overflow_plus` or `__CPROVER_overflow_mul` functions. For instance, take a look at the following example:

```
static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
    if (__CPROVER_overflow_plus(a, b))
        return (4294967295U);
    return a + b;
}
```

However, there is only one version of `__CPROVER_overflow_plus`:

```
_Bool __CPROVER_overflow_plus(unsigned long a, unsigned long b) {
    unsigned long c;
    return __builtin_uaddl_overflow(a, b, &c);
}
```

Therefore, when we pass a `uint32_t` to the `__CPROVER_overflow_plus` function, it cast the `uint32_t` value to `unsigned long` and only then it performs the overflow check using `__builtin_uaddl_overflow`, which is also for `unsigned long`. This PR moves the appropriate builtin functions, which actually check for overflows, within the arithmetic functions. For instance,

```
static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
    unsigned long c;
    if (__builtin_uadd_overflow(a, b, &c))
        return (4294967295U);
    return a + b;
}
```
