### PR TITLE
Check overflow with appropriate builtin functions

### DIFF
--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
+++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
@@ -240,15 +240,6 @@ int __CPROVER_uninterpreted_compare(const void *const a, const void *const b) { 
 
 
 
-_Bool __CPROVER_overflow_plus(unsigned long a, unsigned long b) {
-    unsigned long c;
-    return __builtin_uaddl_overflow(a, b, &c);
-}
-
-_Bool __CPROVER_overflow_mult(unsigned long a, unsigned long b) {
-    unsigned long c;
-    return __builtin_umull_overflow(a, b, &c);
-}
 
 
 
@@ -2496,8 +2487,9 @@ static inline int aws_round_up_to_power_of_two(size_t n, size_t *result);
 
 
 static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
-    if (__CPROVER_overflow_mult(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_umull_overflow(a, b, &c))
+        return
               (18446744073709551615UL)
                         ;
     return a * b;
@@ -2508,7 +2500,8 @@ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 
 static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    if (__CPROVER_overflow_mult(a, b))
+    unsigned long c;
+    if (__builtin_umull_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
     return (0);
@@ -2518,8 +2511,9 @@ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
 
 
 static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
-    if (__CPROVER_overflow_mult(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_umul_overflow(a, b, &c))
+        return
               (4294967295U)
                         ;
     return a * b;
@@ -2530,7 +2524,8 @@ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 
 static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    if (__CPROVER_overflow_mult(a, b))
+    unsigned long c;
+    if (__builtin_umul_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
     return (0);
@@ -2540,8 +2535,9 @@ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
 
 
 static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
-    if (__CPROVER_overflow_plus(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_uaddl_overflow(a, b, &c))
+        return
               (18446744073709551615UL)
                         ;
     return a + b;
@@ -2552,7 +2548,8 @@ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 
 static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    if (__CPROVER_overflow_plus(a, b))
+    unsigned long c;
+    if (__builtin_uaddl_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
     return (0);
@@ -2562,8 +2559,9 @@ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
 
 
 static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
-    if (__CPROVER_overflow_plus(a, b))
-        return 
+    unsigned long c;
+    if (__builtin_uadd_overflow(a, b, &c))
+        return
               (4294967295U)
                         ;
     return a + b;
@@ -2571,10 +2569,9 @@ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
 
 
 
-
-
 static inline int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    if (__CPROVER_overflow_plus(a, b))
+    unsigned long c;
+    if (__builtin_uadd_overflow(a, b, &c))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
     return (0);

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -29,5 +29,8 @@ sed 's/__builtin___mem/___mem/g' -i \
 sed '1 i int compare(const void *a, const void *b, unsigned long item_size);' -i \
     $SV/c/aws-c-common/./aws_array_list_sort_harness.i
 
-# adds missing __CPROVER_file_local_priority_queue_c_s_swap function
+# add missing __CPROVER_file_local_priority_queue_c_s_swap function
 cd $SV && patch -p1 < c/aws-c-common/s_swap-fix.diff
+
+# fix overflow functions
+cd $SV && patch -p1 < c/aws-c-common/overflow-fix-1.diff

--- a/c/aws-c-common/overflow-fix-1.diff
+++ b/c/aws-c-common/overflow-fix-1.diff
@@ -1,0 +1,119 @@
+commit acf192572d53ce6ea6c17836e359702abd9f89d9
+Author: feliperodri <rms.felipe@gmail.com>
+Date:   Tue Nov 19 15:52:55 2019 -0400
+
+    Check overflow with appropriate builtin functions
+    
+    Signed-off-by: feliperodri <rms.felipe@gmail.com>
+
+diff --git a/c/aws-c-common/aws_mul_size_saturating_harness.i b/c/aws-c-common/aws_mul_size_saturating_harness.i
+index 1f244d4ec0..eae109f9e5 100644
+--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
++++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
+@@ -240,15 +240,6 @@ int __CPROVER_uninterpreted_compare(const void *const a, const void *const b) {
+ 
+ 
+ 
+-_Bool __CPROVER_overflow_plus(unsigned long a, unsigned long b) {
+-    unsigned long c;
+-    return __builtin_uaddl_overflow(a, b, &c);
+-}
+-
+-_Bool __CPROVER_overflow_mult(unsigned long a, unsigned long b) {
+-    unsigned long c;
+-    return __builtin_umull_overflow(a, b, &c);
+-}
+ 
+ 
+ 
+@@ -2496,8 +2487,9 @@ static inline int aws_round_up_to_power_of_two(size_t n, size_t *result);
+ 
+ 
+ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
+-    if (__CPROVER_overflow_mult(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_umull_overflow(a, b, &c))
++        return
+               (18446744073709551615UL)
+                         ;
+     return a * b;
+@@ -2508,7 +2500,8 @@ static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
+ 
+ 
+ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+-    if (__CPROVER_overflow_mult(a, b))
++    unsigned long c;
++    if (__builtin_umull_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a * b;
+     return (0);
+@@ -2518,8 +2511,9 @@ static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+ 
+ 
+ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
+-    if (__CPROVER_overflow_mult(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_umul_overflow(a, b, &c))
++        return
+               (4294967295U)
+                         ;
+     return a * b;
+@@ -2530,7 +2524,8 @@ static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
+ 
+ 
+ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+-    if (__CPROVER_overflow_mult(a, b))
++    unsigned long c;
++    if (__builtin_umul_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a * b;
+     return (0);
+@@ -2540,8 +2535,9 @@ static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+ 
+ 
+ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
+-    if (__CPROVER_overflow_plus(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_uaddl_overflow(a, b, &c))
++        return
+               (18446744073709551615UL)
+                         ;
+     return a + b;
+@@ -2552,7 +2548,8 @@ static inline uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
+ 
+ 
+ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+-    if (__CPROVER_overflow_plus(a, b))
++    unsigned long c;
++    if (__builtin_uaddl_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a + b;
+     return (0);
+@@ -2562,8 +2559,9 @@ static inline int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+ 
+ 
+ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
+-    if (__CPROVER_overflow_plus(a, b))
+-        return 
++    unsigned long c;
++    if (__builtin_uadd_overflow(a, b, &c))
++        return
+               (4294967295U)
+                         ;
+     return a + b;
+@@ -2571,10 +2569,9 @@ static inline uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
+ 
+ 
+ 
+-
+-
+ static inline int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+-    if (__CPROVER_overflow_plus(a, b))
++    unsigned long c;
++    if (__builtin_uadd_overflow(a, b, &c))
+         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+     *r = a + b;
+     return (0);

--- a/c/check.py
+++ b/c/check.py
@@ -103,6 +103,7 @@ KNOWN_DIRECTORY_PROBLEMS = [
 
     ("aws-c-common", "unexpected file patch.diff"),
     ("aws-c-common", "unexpected file s_swap-fix.diff"),
+    ("aws-c-common", "unexpected file overflow-fix-1.diff"),
     ("aws-c-common", "unexpected file makeall"),
     ("aws-c-common", "unexpected file Makefile.sv-benchmarks"),
     ("aws-c-common", "unexpected file yml.sh"),


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

Fix #922 

In AWS C Common benchmarks, every time it checks for overflow in 32-bit operations, it uses the `__CPROVER_overflow_plus` or `__CPROVER_overflow_mul` functions. For instance, take a look at the following example:

```
static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
    if (__CPROVER_overflow_mul(a, b))
        return
              (4294967295U)
                        ;
    return a * b;
}
```

However, there is only one version of `__CPROVER_overflow_mul`:

```
_Bool __CPROVER_overflow_mul(unsigned long a, unsigned long b) {
    unsigned long c;
    return __builtin_umull_overflow(a, b, &c);
}
```

Therefore, when we pass a `uint32_t` to the `__CPROVER_overflow_mul` function, it cast the `uint32_t` value to `unsigned long` and only then it performs the overflow check using `__builtin_umull_overflow`, which is also for `unsigned long`. This PR moves the appropriate builtin functions, which actually check for overflows, within the arithmetic functions. For instance,

```
static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
    unsigned long c;
    if (__builtin_umul_overflow(a, b, &c))
        return
              (4294967295U)
                        ;
    return a * b;
}
```
