### PR TITLE
Implements __CPROVER_file_local_priority_queue_c_s_swap function

### DIFF
--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
@@ -8498,7 +8498,18 @@ size_t aws_priority_queue_size(const struct aws_priority_queue *queue) {
 size_t aws_priority_queue_capacity(const struct aws_priority_queue *queue) {
     return aws_array_list_capacity(&queue->container);
 }
-void __CPROVER_file_local_priority_queue_c_s_swap(struct aws_priority_queue *queue, size_t a, size_t b);
+void __CPROVER_file_local_priority_queue_c_s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
+    __VERIFIER_assert(aws_priority_queue_is_valid(queue));
+    __VERIFIER_assert(a < queue->container.length);
+    __VERIFIER_assert(b < queue->container.length);
+    __VERIFIER_assert(aws_priority_queue_backpointer_index_valid(queue, a));
+    __VERIFIER_assert(aws_priority_queue_backpointer_index_valid(queue, b));
+
+    if (queue->backpointers.data) {
+        __VERIFIER_assert(queue->backpointers.length > a);
+        __VERIFIER_assert(queue->backpointers.length > b);
+    }
+}
 
 void aws_priority_queue_s_swap_harness() {
 

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -29,3 +29,5 @@ sed 's/__builtin___mem/___mem/g' -i \
 sed '1 i int compare(const void *a, const void *b, unsigned long item_size);' -i \
     $SV/c/aws-c-common/./aws_array_list_sort_harness.i
 
+# adds missing __CPROVER_file_local_priority_queue_c_s_swap function
+cd $SV && patch -p1 < c/aws-c-common/s_swap-fix.diff

--- a/c/aws-c-common/s_swap-fix.diff
+++ b/c/aws-c-common/s_swap-fix.diff
@@ -1,0 +1,32 @@
+commit 493d99f27fe71cf078563505eede0cf2a3413729
+Author: feliperodri <rms.felipe@gmail.com>
+Date:   Tue Nov 19 19:01:36 2019 -0400
+
+    Implements __CPROVER_file_local_priority_queue_c_s_swap function
+    
+    Signed-off-by: feliperodri <rms.felipe@gmail.com>
+
+diff --git a/c/aws-c-common/aws_priority_queue_s_swap_harness.i b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+index cf1021cdd7..30269897bb 100644
+--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
++++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+@@ -8498,7 +8498,18 @@ size_t aws_priority_queue_size(const struct aws_priority_queue *queue) {
+ size_t aws_priority_queue_capacity(const struct aws_priority_queue *queue) {
+     return aws_array_list_capacity(&queue->container);
+ }
+-void __CPROVER_file_local_priority_queue_c_s_swap(struct aws_priority_queue *queue, size_t a, size_t b);
++void __CPROVER_file_local_priority_queue_c_s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
++    __VERIFIER_assert(aws_priority_queue_is_valid(queue));
++    __VERIFIER_assert(a < queue->container.length);
++    __VERIFIER_assert(b < queue->container.length);
++    __VERIFIER_assert(aws_priority_queue_backpointer_index_valid(queue, a));
++    __VERIFIER_assert(aws_priority_queue_backpointer_index_valid(queue, b));
++
++    if (queue->backpointers.data) {
++        __VERIFIER_assert(queue->backpointers.length > a);
++        __VERIFIER_assert(queue->backpointers.length > b);
++    }
++}
+ 
+ void aws_priority_queue_s_swap_harness() {
+ 

--- a/c/check.py
+++ b/c/check.py
@@ -102,6 +102,7 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("openbsd-6.2", "unexpected file prepreprocess.py"),
 
     ("aws-c-common", "unexpected file patch.diff"),
+    ("aws-c-common", "unexpected file s_swap-fix.diff"),
     ("aws-c-common", "unexpected file makeall"),
     ("aws-c-common", "unexpected file Makefile.sv-benchmarks"),
     ("aws-c-common", "unexpected file yml.sh"),


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

This PR fixes the `aws_priority_queue_s_swap_harness.i` benchmark from `SoftwareSystems-AWS-C-Common-ReachSafety`. The benchmark does not have the implementation for the `__CPROVER_file_local_priority_queue_c_s_swap` function, which might lead to spurious verification results. The original version of this function is available at [s_swap_override_no_op.c](https://github.com/awslabs/aws-c-common/blob/0459e83c0d0c96f1506bda89b0c3eab80c4f11ab/.cbmc-batch/stubs/s_swap_override_no_op.c).