### PR TITLE
Changed verdict of program that uses alloca

### DIFF
--- a/c/memsafety-ext3/getNumbers1-1.yml
+++ b/c/memsafety-ext3/getNumbers1-1.yml
@@ -5,5 +5,4 @@ input_files: 'getNumbers1-1.c'
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: false
-    subproperty: valid-deref
+    expected_verdict: true


### PR DESCRIPTION
The program returns a pointer to an array allocated using alloca.

This program only fails if the alloca overflows the stack, but that against the SV-COMP rules that malloc and alloca always return a valid memory.


Signed-off-by: Mikhail Gadelha <mikhail.ramalho@gmail.com>
