### PR TITLE
Make null-ness test explicit in AWS C Common benchmarks

### DIFF
--- a/c/aws-c-common/aws_array_list_front_harness.i
+++ b/c/aws-c-common/aws_array_list_front_harness.i
@@ -8047,8 +8047,8 @@ void aws_array_list_front_harness() {
     if (!aws_array_list_front(&list, val)) {
 
         __VERIFIER_assert((memcmp(val, list.data, list.item_size) == 0));
-        __VERIFIER_assert(list.data);
-        __VERIFIER_assert(list.length);
+        __VERIFIER_assert(list.data != ((void *)0));
+        __VERIFIER_assert(list.length != 0);
     }
 
 

--- a/c/aws-c-common/aws_array_list_front_harness.i
+++ b/c/aws-c-common/aws_array_list_front_harness.i
@@ -8048,7 +8048,7 @@ void aws_array_list_front_harness() {
 
         __VERIFIER_assert((memcmp(val, list.data, list.item_size) == 0));
         __VERIFIER_assert(list.data != ((void *)0));
-        __VERIFIER_assert(list.length != 0);
+        __VERIFIER_assert(list.length);
     }
 
 

--- a/c/aws-c-common/aws_array_list_get_at_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_harness.i
@@ -8051,7 +8051,7 @@ void aws_array_list_get_at_harness() {
 
 
 
-        __VERIFIER_assert(list.data);
+        __VERIFIER_assert(list.data != ((void *)0));
         __VERIFIER_assert(list.length > index);
     }
 

--- a/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
@@ -8049,7 +8049,7 @@ void aws_array_list_get_at_ptr_harness() {
 
 
 
-        __VERIFIER_assert(list.data);
+        __VERIFIER_assert(list.data != ((void *)0));
         __VERIFIER_assert(list.length > index);
     }
 

--- a/c/aws-c-common/aws_array_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_harness.i
@@ -8037,7 +8037,7 @@ void aws_array_list_pop_front_harness() {
 
     if (!aws_array_list_pop_front(&list)) {
         __VERIFIER_assert(list.length == old.length - 1);
-        __VERIFIER_assert(list.data);
+        __VERIFIER_assert(list.data != ((void *)0));
         __VERIFIER_assert(list.alloc == old.alloc);
         __VERIFIER_assert(list.current_size == old.current_size);
         __VERIFIER_assert(list.item_size == old.item_size);

--- a/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
@@ -8040,8 +8040,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
     if (from->len > 0) {
 
-        __VERIFIER_assert(from->ptr);
-        __VERIFIER_assert(to->buffer);
+        __VERIFIER_assert(from->ptr != ((void *)0));
+        __VERIFIER_assert(to->buffer != ((void *)0));
         memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
@@ -8154,8 +8154,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
     } else {
         if (from->len > 0) {
 
-            __VERIFIER_assert(from->ptr);
-            __VERIFIER_assert(to->buffer);
+            __VERIFIER_assert(from->ptr != ((void *)0));
+            __VERIFIER_assert(to->buffer != ((void *)0));
             memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }

--- a/c/aws-c-common/aws_byte_buf_append_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_harness.i
@@ -8034,8 +8034,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
     if (from->len > 0) {
 
-        __VERIFIER_assert(from->ptr);
-        __VERIFIER_assert(to->buffer);
+        __VERIFIER_assert(from->ptr != ((void *)0));
+        __VERIFIER_assert(to->buffer != ((void *)0));
         memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }

--- a/c/aws-c-common/aws_hash_iter_delete_harness.i
+++ b/c/aws-c-common/aws_hash_iter_delete_harness.i
@@ -10112,17 +10112,17 @@ _Bool
 
 _Bool 
     aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
-    if (!iter) {
+    if (iter != ((void *)0)) {
         return 
               0
                    ;
     }
-    if (!iter->map) {
+    if (iter->map != ((void *)0)) {
         return 
               0
                    ;
     }
-    if (!aws_hash_table_is_valid(iter->map)) {
+    if (aws_hash_table_is_valid(iter->map) != 0) {
         return 
               0
                    ;

--- a/c/aws-c-common/aws_hash_iter_delete_harness.i
+++ b/c/aws-c-common/aws_hash_iter_delete_harness.i
@@ -10122,7 +10122,7 @@ _Bool
               0
                    ;
     }
-    if (aws_hash_table_is_valid(iter->map) != 0) {
+    if (aws_hash_table_is_valid(iter->map)) {
         return 
               0
                    ;

--- a/c/aws-c-common/aws_linked_list_push_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_front_harness.i
@@ -4704,7 +4704,7 @@ static inline
 static inline 
                _Bool 
                     aws_linked_list_is_valid(const struct aws_linked_list *list) {
-    if (list && list->head.next && list->head.prev == 
+    if (list != ((void *)0) && list->head.next != ((void *)0) && list->head.prev == 
                                                      ((void *)0) 
                                                           && list->tail.prev && list->tail.next == 
                                                                                                    ((void *)0)
@@ -4728,7 +4728,7 @@ static inline
 static inline 
                _Bool 
                     aws_linked_list_node_next_is_valid(const struct aws_linked_list_node *node) {
-    return node && node->next && node->next->prev == node;
+    return node != ((void *)0) && node->next != ((void *)0) && node->next->prev == node;
 }
 
 
@@ -4739,12 +4739,12 @@ static inline
 static inline 
                _Bool 
                     aws_linked_list_node_prev_is_valid(const struct aws_linked_list_node *node) {
-    return node && node->prev && node->prev->next == node;
+    return node != ((void *)0) && node->prev != ((void *)0) && node->prev->next == node;
 }
 static inline 
                _Bool 
                     aws_linked_list_is_valid_deep(const struct aws_linked_list *list) {
-    if (!list) {
+    if (list != ((void *)0)) {
         return 
               0
                    ;
@@ -4760,7 +4760,7 @@ static inline
 
 
 
-    while (temp) {
+    while (temp != ((void *)0)) {
         if (temp == &list->tail) {
             head_reaches_tail = 
                                1


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

The following benchmarks have non-explicit null-ness tests in assertions, which may lead to spurious results:
```
aws_array_list_front_harness.i
aws_array_list_get_at_harness.i
aws_array_list_get_at_ptr_harness.i
aws_array_list_pop_front_harness.i
aws_byte_buf_append_dynamic_harness.i
aws_byte_buf_append_harness.i
aws_hash_iter_delete_harness.i
aws_linked_list_push_front_harness.i
```


Therefore, this PR does `s/__VERIFIER_assert(ptr)/__VERIFIER_assert(ptr != ((void *)0))/g`