### PR TITLE
fix verdict for the valid-memcleanup property

### DIFF
--- a/c/list-properties/alternating_list-2.yml
+++ b/c/list-properties/alternating_list-2.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp


### PR DESCRIPTION
In lines 521-539 the main function creates a list of the form (21)*3.

1. In case the list has only one element, the second and the third while loop are not entered and `p` which points to the only node of the list is freed before termination.
2. In case the list has more than one element, the second while loop takes the if-branch in the first iteration (because the first element of the list is 2) goes to the label ERROR and calls the function `__VERIFIER_error()`. Like in all other SV-COMP benchmarks, this function is declared as `extern void __VERIFIER_error() __attribute__ ((__noreturn__));` hence the program does not terminate and the valid-memcleanup property holds.