### PR TITLE
memsafety-ext3/freeAlloca.c: change long to int

### DIFF
--- a/c/memsafety-ext3/freeAlloca.c
+++ b/c/memsafety-ext3/freeAlloca.c
@@ -1,4 +1,5 @@
-extern void *alloca(unsigned long size);
+typedef unsigned int size_t;
+extern void *alloca(size_t size);
 extern void free(void*);
 extern char __VERIFIER_nondet_char(void);
 


### PR DESCRIPTION
This file is part of MemSafety-Other category, which is 32-bit, so int should be used instead of long.

`clang -m32 freeAlloca.c` yields -Wincompatible-library-redeclaration in case unsigned long is used.