### PR TITLE
Fix verdict of a ldv-commit-tester task after changes from #942

### DIFF
--- a/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.yml
+++ b/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.yml
@@ -5,4 +5,4 @@ input_files: 'm0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true


### PR DESCRIPTION
Commit 17420e1f5089f422137226aff27657be5880ccb4 from #942 changed the verdict of at least one verification task ([ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.yml](https://github.com/sosy-lab/sv-benchmarks/blob/master/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.yml)) from `false` to `true`.

Previously, there was this [counterexample trace](https://github.com/sosy-lab/sv-benchmarks/files/3878567/Counterexample.1.txt) ([shortened version](https://github.com/sosy-lab/sv-benchmarks/files/3878574/Counterexample.1.core.txt)):
- `main()` calls `init()`.
- `init()` [calls](https://github.com/sosy-lab/sv-benchmarks/blob/8b98491f2d70e9eeb94f6fb1b0882ad70d85f9f3/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i#L5319) `ldv_create_class()`, which returns a `ldv_undef_ptr()`. The latter calls `__VERIFIER_nondet_pointer()` through `external_alloc()`. The result is an arbitrary pointer.
- `init()` passes the pointer to `IS_ERR()`, which checks whether the pointer is larger than 2012 (which it can be).
- `init()` passes the pointer to `PTR_ERR`, which does some calculation with it and returns it.
- `init()` casts the result from `PTR_ERR` from `long` to `int`, which can result in 0 if the nondet pointer is chosen appropriately (value 4294969308 works).
- This means that `init()` returns 0 (which means "no error") although the nondet pointer (which was stored in the global variable `usb_gadget_class`) was an "error" pointer.
- When `main()` reaches the call to `cleanup()` at some point `ldv_unregister_usb_gadget()` will be called, which triggers the error.

What now happens is that `ldv_create_class()` calls `ldv_malloc()`, which returns either 0 or a ["non-error" pointer](https://github.com/sosy-lab/sv-benchmarks/blob/8b98491f2d70e9eeb94f6fb1b0882ad70d85f9f3/c/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i#L3130). Because of the assumption that this is not an "error" pointer, the above counterexample is not valid anymore.

So replacing calls to `ldv_undef_ptr()` with `ldv_malloc()` has a bigger effect than just allocating memory, it also restricts a whole class of errors. **It is likely that this affects other verification tasks as well**.

Maybe @mutilin or @tautschnig can suggest a more general solution?

This was found by the regression tests of CPAchecker (using a different configuration than the SV-COMP config, which runs out of resources). The command line of CPAchecker that finds the counterexample in the old version and now a proof is:
```
scripts/cpa.sh -heap 10000M -setprop cpa.predicate.memoryAllocationsAlwaysSucceed=true -setprop cpa.arg.proofWitness=witness.graphml -predicateAnalysis -64 -timelimit 900s -spec test/programs/benchmarks/properties/unreach-call.prp test/programs/benchmarks/ldv-commit-tester/m0_drivers-usb-gadget-g_printer-ko--106_1a--2b9ec6c-2.i
```

Here is the (compressed) [witness](https://github.com/sosy-lab/sv-benchmarks/files/3878557/witness.graphml.gz) (produced with revision 8b98491f2d70e9eeb94f6fb1b0882ad70d85f9f3 of the repository and CPAchecker 1.8-svn-32298).
Ultimate successfully confirmed this correctness witness in 20 minutes ([Ultimate.log](https://github.com/sosy-lab/sv-benchmarks/files/3878554/Ultimate.log)).