### PR TITLE
Invalid deref fixes

### DIFF
--- a/c/recursive-with-pointer/system-with-recursion.c
+++ b/c/recursive-with-pointer/system-with-recursion.c
@@ -308,7 +308,7 @@ int event_precess(event_t *e) {
 }
 
 void user_initialize() {
-  user->info = calloc(0, sizeof(info_t));
+  user->info = calloc(1, sizeof(info_t));
   user->message.id = 11;
   user->info->is_valid = 0;
   user->status = AS_NULL;

--- a/c/recursive-with-pointer/system-with-recursion.i
+++ b/c/recursive-with-pointer/system-with-recursion.i
@@ -952,7 +952,7 @@ int event_precess(event_t *e) {
   return rc;
 }
 void user_initialize() {
-  user->info = calloc(0, sizeof(info_t));
+  user->info = calloc(1, sizeof(info_t));
   user->message.id = 11;
   user->info->is_valid = 0;
   user->status = AS_NULL;

--- a/c/verifythis/prefixsum_rec.c
+++ b/c/verifythis/prefixsum_rec.c
@@ -46,7 +46,7 @@ void check(int *a0, int *a, int n) {
 int main() {
     int n = __VERIFIER_nondet_int();
     /* 1 << 30 will make sure n * sizeof(int) does not overflow */
-    __VERIFIER_assume(n >= 0 && n < (1 << 30));
+    __VERIFIER_assume(n > 1 && n < (1 << 30));
     __VERIFIER_assume(is_pow2(n));
     int *a = calloc(n, sizeof(int));
 


### PR DESCRIPTION
Fix invalid dereferences in two tasks that are not in memsafety category. See commit messages for more info.