### PR TITLE
Revert "Change K&R-style declared functions to use the ANSI C syntax instead"

### DIFF
--- a/c/termination-libowfat/strlcat.c
+++ b/c/termination-libowfat/strlcat.c
@@ -22,7 +22,11 @@ size_t strlen(const char *s) {
  * Returns strlen(initial dst) + strlen(src); if retval >= siz,
  * truncation occurred.
  */
-size_t strlcat(char *dst, const char *src, size_t siz) {
+size_t strlcat(dst, src, siz)
+	char *dst;
+	const char *src;
+	size_t siz;
+{
 	register char *d = dst;
 	register const char *s = src;
 	register size_t n = siz;

--- a/c/termination-libowfat/strlcpy.c
+++ b/c/termination-libowfat/strlcpy.c
@@ -13,7 +13,11 @@ extern int __VERIFIER_nondet_int(void);
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-size_t strlcpy(char *dst, const char *src, size_t siz) {
+size_t strlcpy(dst, src, siz)
+	char *dst;
+	const char *src;
+	size_t siz;
+{
 	register char *d = dst;
 	register const char *s = src;
 	register size_t n = siz;


### PR DESCRIPTION
Reverts sosy-lab/sv-benchmarks#905

This revert is necessary because of the discussion in issue https://github.com/sosy-lab/sv-benchmarks/issues/934.

This PR fixes issue #934.