### PR TITLE
verifythis/prefixsum_rec.c: incorrectly labelled after PR #1014

### DIFF
--- a/c/MemSafety-MemCleanup.set
+++ b/c/MemSafety-MemCleanup.set
@@ -4,7 +4,6 @@ forester-heap/*.yml
 list-properties/*.yml
 list-ext3-properties/*.yml
 memsafety-bftpd/*.yml
-verifythis/prefixsum_rec.yml
 verifythis/tree_max.yml
 verifythis/tree_del_iter.yml
 verifythis/tree_del_rec.yml

--- a/c/verifythis/prefixsum_rec.yml
+++ b/c/verifythis/prefixsum_rec.yml
@@ -3,7 +3,7 @@ format_version: '1.0'
 input_files: 'prefixsum_rec.c'
 
 properties:
-  - property_file: ../properties/valid-memcleanup.prp
-    expected_verdict: false
+  - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true


### PR DESCRIPTION
After PR #1014 there is no more memsafety/memcleanup violation (original error due to invalid dereference, if `n == 1` reported by esbmc in PR #923 by @mikhailramalho).

@mchalupa said:

> Fix invalid dereferences in two tasks that are not in memsafety category.

But `verifythis/prefixsum_rec.c` was/is (wrongly) in memcleanup category and pull request was incomplete. Now it should be in MemSafety-Arrays.