### PR TITLE
Make null-ness test explicit in AWS C Common benchmarks

### DIFF
--- a/c/aws-c-common/aws_array_list_erase_harness.i
+++ b/c/aws-c-common/aws_array_list_erase_harness.i
@@ -3273,7 +3273,7 @@ static inline
 
 _Bool 
     aws_array_list_is_valid(const struct aws_array_list *restrict list) {
-    if (!list) {
+    if (list != ((void *)0)) {
         return 
               0
                    ;

--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
@@ -8329,7 +8329,7 @@ _Bool
 _Bool 
     aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {
 
-    if (!queue) {
+    if (queue != ((void *)0)) {
         return 
               0
                    ;

--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
@@ -8857,7 +8857,7 @@ int aws_ring_buffer_acquire_up_to(
     if (tail_cpy > head_cpy) {
         size_t space = tail_cpy - head_cpy;
 
-        __VERIFIER_assert(space);
+        __VERIFIER_assert(space != 0);
         space -= 1;
 
         size_t returnable_size = space > requested_size ? requested_size : space;


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

Similar to #1000. 

The following benchmarks have non-explicit null-ness tests in assertions, which may lead to spurious results:
```
aws_array_list_erase_harness.i
aws_priority_queue_s_swap_harness.i
aws_ring_buffer_acquire_up_to_harness.i
```

Therefore, this PR does `s/__VERIFIER_assert(ptr)/__VERIFIER_assert(ptr != ((void *)0))/g`