### PR TITLE
Removes unnecessary code snippet on s_buf_belongs_to_pool function

### DIFF
--- a/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
@@ -8920,12 +8920,6 @@ static inline
 
 
 
-    if ((buf->buffer != ring_buffer->allocation) ||
-        (buf->buffer != ring_buffer->allocation_end)) {
-        return 
-              0
-                   ;
-    }
 
     return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
            buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;

--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
@@ -8920,12 +8920,6 @@ static inline
 
 
 
-    if ((buf->buffer != ring_buffer->allocation) ||
-        (buf->buffer != ring_buffer->allocation_end)) {
-        return 
-              0
-                   ;
-    }
 
     return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
            buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -29,6 +29,9 @@ sed 's/__builtin___mem/___mem/g' -i \
 sed '1 i int compare(const void *a, const void *b, unsigned long item_size);' -i \
     $SV/c/aws-c-common/./aws_array_list_sort_harness.i
 
+# remove unnecessary code snippet on s_buf_belongs_to_pool function
+cd $SV && patch -p1 < c/aws-c-common/s_buf_belongs_to_pool-fix.diff
+    
 # add missing __CPROVER_file_local_priority_queue_c_s_swap function
 cd $SV && patch -p1 < c/aws-c-common/s_swap-fix.diff
 

--- a/c/aws-c-common/s_buf_belongs_to_pool-fix.diff
+++ b/c/aws-c-common/s_buf_belongs_to_pool-fix.diff
@@ -1,0 +1,42 @@
+commit 734ae514218a68b66336f8acffce17d0377c5199
+Author: feliperodri <rms.felipe@gmail.com>
+Date:   Mon Nov 25 14:58:56 2019 -0400
+
+    Removes unnecessary code snippet on s_buf_belongs_to_pool function
+    
+    Signed-off-by: feliperodri <rms.felipe@gmail.com>
+
+diff --git a/c/aws-c-common/aws_ring_buffer_acquire_harness.i b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+index bd08d0f63b..c314a671bd 100644
+--- a/c/aws-c-common/aws_ring_buffer_acquire_harness.i
++++ b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+@@ -8920,12 +8920,6 @@ static inline
+ 
+ 
+ 
+-    if ((buf->buffer != ring_buffer->allocation) ||
+-        (buf->buffer != ring_buffer->allocation_end)) {
+-        return 
+-              0
+-                   ;
+-    }
+ 
+     return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
+            buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;
+diff --git a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+index 2dd6a635ab..6d1b1e12d7 100644
+--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
++++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+@@ -8920,12 +8920,6 @@ static inline
+ 
+ 
+ 
+-    if ((buf->buffer != ring_buffer->allocation) ||
+-        (buf->buffer != ring_buffer->allocation_end)) {
+-        return 
+-              0
+-                   ;
+-    }
+ 
+     return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
+            buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;

--- a/c/check.py
+++ b/c/check.py
@@ -102,6 +102,7 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("openbsd-6.2", "unexpected file prepreprocess.py"),
 
     ("aws-c-common", "unexpected file patch.diff"),
+    ("aws-c-common", "unexpected file s_buf_belongs_to_pool-fix.diff"),
     ("aws-c-common", "unexpected file s_swap-fix.diff"),
     ("aws-c-common", "unexpected file overflow-fix-1.diff"),
     ("aws-c-common", "unexpected file overflow-fix-2.diff"),


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

This PR fixes the `aws_ring_buffer_acquire_harness.i` and `aws_ring_buffer_acquire_up_to_harness.i` benchmarks from `SoftwareSystems-AWS-C-Common-ReachSafety`. The original implementation of the `s_buf_belongs_to_pool` function contains a code snippet for CBMC only:
```
static inline bool s_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buffer, const struct aws_byte_buf *buf) {
#ifdef CBMC
    /* only continue if buf points-into ring_buffer because comparison of pointers to different objects is undefined
     * (C11 6.5.8) */
    if ((__CPROVER_POINTER_OBJECT(buf->buffer) != __CPROVER_POINTER_OBJECT(ring_buffer->allocation)) ||
        (__CPROVER_POINTER_OBJECT(buf->buffer) != __CPROVER_POINTER_OBJECT(ring_buffer->allocation_end))) {
        return false;
    }
#endif
    return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
           buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;
}
```
(see [s_buf_belongs_to_pool](https://github.com/awslabs/aws-c-common/blob/852014d35fdb543649fe10384f5360be0466cfe0/source/ring_buffer.c#L241)).

This code snippet should be removed from the SV-COMP benchmarks, since it may lead to spurious results.