### PR TITLE
Fixes misconverted assumptions in aws_byte_cursor_read_* benchmarks

### DIFF
--- a/c/aws-c-common/aws_byte_cursor_read-fix.diff
+++ b/c/aws-c-common/aws_byte_cursor_read-fix.diff
@@ -1,0 +1,62 @@
+commit 7436f150ebeb101b07b41770fcb9ec18cc79fb54
+Author: feliperodri <rms.felipe@gmail.com>
+Date:   Mon Nov 25 15:21:05 2019 -0400
+
+    Fixes misconverted assumptions
+    
+    Signed-off-by: feliperodri <rms.felipe@gmail.com>
+
+diff --git a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+index 5d3dcfa16b..00d6b57ec2 100644
+--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
++++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
+ 
+     ensure_byte_cursor_has_allocated_buffer_member(&cur);
+     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
+-    __VERIFIER_assume(((((2)) == 0) || ((cur.ptr))));
++    __VERIFIER_assume(cur.ptr);
+     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
+ 
+ 
+diff --git a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+index c23e42f5ef..ceca1d6e9f 100644
+--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
++++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
+ 
+     ensure_byte_cursor_has_allocated_buffer_member(&cur);
+     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
+-    __VERIFIER_assume(((((4)) == 0) || ((cur.ptr))));
++    __VERIFIER_assume(cur.ptr);
+     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
+ 
+ 
+diff --git a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+index 0b7b581b11..1970b78baa 100644
+--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
++++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
+ 
+     ensure_byte_cursor_has_allocated_buffer_member(&cur);
+     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
+-    __VERIFIER_assume(((((8)) == 0) || ((cur.ptr))));
++    __VERIFIER_assume(cur.ptr);
+     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
+ 
+ 
+diff --git a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+index 6d180569c6..5fb5b57f8a 100644
+--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
++++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+@@ -9111,8 +9111,8 @@ void aws_byte_cursor_read_u8_harness() {
+     ensure_byte_cursor_has_allocated_buffer_member(&cur);
+     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
+ 
+-
+-    __VERIFIER_assume(((((1)) == 0) || ((dest))));
++    
++    __VERIFIER_assume(dest);
+ 
+ 
+     struct aws_byte_cursor old_cur = cur;

--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
-    __VERIFIER_assume(((((2)) == 0) || ((cur.ptr))));
+    __VERIFIER_assume(cur.ptr);
     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
 
 

--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
-    __VERIFIER_assume(((((4)) == 0) || ((cur.ptr))));
+    __VERIFIER_assume(cur.ptr);
     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
 
 

--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
@@ -9110,7 +9110,7 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
-    __VERIFIER_assume(((((8)) == 0) || ((cur.ptr))));
+    __VERIFIER_assume(cur.ptr);
     __VERIFIER_assume(((((sizeof(*(dest)))) == 0) || (((dest)))));
 
 

--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
@@ -9111,8 +9111,8 @@ void aws_byte_cursor_read_u8_harness() {
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __VERIFIER_assume(aws_byte_cursor_is_valid(&cur));
 
-
-    __VERIFIER_assume(((((1)) == 0) || ((dest))));
+    
+    __VERIFIER_assume(dest);
 
 
     struct aws_byte_cursor old_cur = cur;

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -38,6 +38,9 @@ cd $SV && patch -p1 < c/aws-c-common/s_swap-fix.diff
 # add missing __CPROVER_file_local_priority_queue_c_s_remove_node function
 cd $SV && patch -p1 < c/aws-c-common/s_remove_node-fix.diff
 
+# fix misconverted assumptions
+cd $SV && patch -p1 < c/aws-c-common/aws_byte_cursor_read-fix.diff
+
 # fix overflow functions
 cd $SV && patch -p1 < c/aws-c-common/overflow-fix-1.diff
 cd $SV && patch -p1 < c/aws-c-common/overflow-fix-2.diff

--- a/c/check.py
+++ b/c/check.py
@@ -105,6 +105,7 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("aws-c-common", "unexpected file s_buf_belongs_to_pool-fix.diff"),
     ("aws-c-common", "unexpected file s_swap-fix.diff"),
     ("aws-c-common", "unexpected file s_remove_node-fix.diff"),
+    ("aws-c-common", "unexpected file aws_byte_cursor_read-fix.diff"),
     ("aws-c-common", "unexpected file overflow-fix-1.diff"),
     ("aws-c-common", "unexpected file overflow-fix-2.diff"),
     ("aws-c-common", "unexpected file makeall"),


### PR DESCRIPTION
Signed-off-by: feliperodri <rms.felipe@gmail.com>

The original benchmarks contain the following assumptions:
```
__CPROVER_assume(AWS_MEM_IS_WRITABLE(dest, 1));
```
see [aws_byte_cursor_read_u8_harness.c](https://github.com/awslabs/aws-c-common/blob/17e2a5a462da952795f2f564acfe83029c4f9375/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c#L31).

The line was converted to:
```
__VERIFIER_assume(((((1)) == 0) || ((dest))));
```

This PR removes the unnecessary parts of the assumptions.