### PR TITLE
Fix invalid Java main methods

### DIFF
--- a/java/jayhorn-recursive/SatFibonacci01/Main.java
+++ b/java/jayhorn-recursive/SatFibonacci01/Main.java
@@ -20,7 +20,7 @@ public class Main {
     }
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     int x = Verifier.nondetInt();
     if (x > 46 || x == -2147483648) {
       return;

--- a/java/jayhorn-recursive/SatFibonacci02/Main.java
+++ b/java/jayhorn-recursive/SatFibonacci02/Main.java
@@ -18,7 +18,7 @@ public class Main {
     }
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     int x = 9;
     int result = fibonacci(x);
     if (result == 34) {

--- a/java/jayhorn-recursive/SatFibonacci03/Main.java
+++ b/java/jayhorn-recursive/SatFibonacci03/Main.java
@@ -20,7 +20,7 @@ public class Main {
     }
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     int x = Verifier.nondetInt();
     if (x > 46) {
       return;

--- a/java/jbmc-regression/classtest1/Main.java
+++ b/java/jbmc-regression/classtest1/Main.java
@@ -7,6 +7,6 @@
  * The benchmark was taken from the repo: 24 January 2018
  */
 public class Main {
-  static void main(String[] args) { g(Main.class); }
+  public static void main(String[] args) { g(Main.class); }
   static void g(Object c) { assert true; }
 }


### PR DESCRIPTION
Non-public main methods don't comply with the rules and cannot be executed with `java`.
