### PR TITLE
Change termination verdict for pals_floodmax.3.2.ufo.UNBOUNDED.p…

### DIFF
--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
@@ -63,7 +63,6 @@ char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
-void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
 typedef int port_t;
 extern void read(port_t p , msg_t m ) ;

--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void abort(void);
 
 /**********************************************************************
 
@@ -562,7 +563,9 @@ int main(void)
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   i2 = init();
-  __VERIFIER_assume(i2);
+  if(!i2){
+    abort();
+  }
   p12_old = nomsg;
   p12_new = nomsg;
   p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.yml
@@ -7,5 +7,5 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp


### PR DESCRIPTION
The termination verdict of the program [pals_floodmax.3.2.ufo.UNBOUNDED.pals.c](https://github.com/sosy-lab/sv-benchmarks/blob/master/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c) must be true and therefore is wrong.
@animeshbchowdhury could you please review this PR or show me the mistake in my thinking since You introduced the termination verdict for this program.

A lot of the nondeterminism vanishes by the assume statement in
 ` i2 = init();
  __VERIFIER_assume(i2); `

Explicitly the variables which are responsible to produce a __VERIFIER_error() are highly restricted by this assume as follows: 
`  r1 = 0;  st1 = 0;   nl1 = 0;  mode1 = 0; r2 = 0; st2 = 0; nl2 = 0; mode2 = 0; r3 = 0; st3 =0; nl3 = 0;
  mode3 = 0;`
And: 
 `1 = (ep12 || (ep13 && ep32) ) && (ep13 || (ep12 && ep23)) && (ep21 || (ep23 && ep31) ) && (ep23 || (ep21 && ep13)) && (ep32 || (ep31 && ep12))`

The nondet initialization of m1, m2 and m3 doesn't matter as well because they are assigned with -1 before first use.

This leads to only 18 possible initial states left which all terminates via __VERIFIER_error() when compiled with gcc. 
