### PR TITLE
change expected verdict of rule57_ebda_blast.

### DIFF
--- a/c/ldv-regression/rule57_ebda_blast.yml
+++ b/c/ldv-regression/rule57_ebda_blast.yml
@@ -7,7 +7,8 @@ properties:
   - property_file: ../properties/termination.prp
     expected_verdict: true
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
+    # __VERIFIER_error would be reachable if memory allocation with kzalloc fails.
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp

--- a/c/ldv-regression/rule57_ebda_blast_2.i
+++ b/c/ldv-regression/rule57_ebda_blast_2.i
@@ -1,0 +1,139 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+
+void __blast_assert()
+{
+ ERROR: __VERIFIER_error();
+}
+
+
+
+
+
+
+
+
+
+struct hotplug_slot;
+
+struct bus_info {
+};
+
+struct slot {
+ int a;
+ int b;
+ struct hotplug_slot * hotplug_slot;
+ struct bus_info *bus_on;
+};
+
+struct hotplug_slot {
+ struct slot *private;
+ int b;
+};
+
+
+
+
+
+
+struct slot *tmp_slot;
+int used_tmp_slot = 0;
+int freed_tmp_slot = 1;
+
+typedef long unsigned int size_t;
+extern void * calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+void * kzalloc(int size, int flags) { (void)flags; return calloc(1, size); }
+
+void kfree(void *p) {
+ if(p!=0 && p==tmp_slot)
+  freed_tmp_slot = 1;
+}
+
+
+struct bus_info *ibmphp_find_same_bus_num() {
+ if (__VERIFIER_nondet_int()) {
+   return 0;
+ }
+ return kzalloc(sizeof(struct bus_info), 0);
+}
+
+int fillslotinfo(struct hotplug_slot *p) {
+ (void) p;
+ return __VERIFIER_nondet_int();
+}
+
+int ibmphp_init_devno(struct slot **pp) {
+ (void) pp;
+ return __VERIFIER_nondet_int();
+}
+
+int ebda_rsrc_controller() {
+ struct hotplug_slot *hp_slot_ptr;
+
+ struct bus_info *bus_info_ptr1;
+ int rc;
+
+ hp_slot_ptr = kzalloc(sizeof(*hp_slot_ptr), 1);
+ if(!hp_slot_ptr) {
+  rc = -2;
+  goto error_no_hp_slot;
+ }
+ hp_slot_ptr->b = 5;
+
+ tmp_slot = kzalloc(sizeof(*tmp_slot), 1);
+
+ if(!tmp_slot) {
+  rc = -2;
+  goto error_no_slot;
+ }
+
+ used_tmp_slot = 0;
+ freed_tmp_slot = 0;
+
+ tmp_slot->a = 2;
+ tmp_slot->b = 3;
+
+ bus_info_ptr1 = ibmphp_find_same_bus_num();
+ if(!bus_info_ptr1) {
+  rc = -3;
+
+
+
+
+
+  goto error;
+ }
+ tmp_slot->bus_on = bus_info_ptr1;
+ bus_info_ptr1 = 0;
+
+ tmp_slot->hotplug_slot = hp_slot_ptr;
+
+ hp_slot_ptr->private = tmp_slot;
+ used_tmp_slot = 1;
+
+ rc = fillslotinfo(hp_slot_ptr);
+ if(rc)
+  goto error;
+
+ rc = ibmphp_init_devno((struct slot **) &hp_slot_ptr->private);
+ if(rc)
+  goto error;
+
+ return 0;
+
+error:
+ kfree(hp_slot_ptr->private);
+error_no_slot:
+
+error_no_hp_slot:
+
+ return rc;
+}
+
+int main() {
+ ebda_rsrc_controller();
+ if(!used_tmp_slot)
+  ((freed_tmp_slot) ? (0) : __blast_assert ());
+}

--- a/c/ldv-regression/rule57_ebda_blast_2.yml
+++ b/c/ldv-regression/rule57_ebda_blast_2.yml
@@ -1,0 +1,13 @@
+format_version: '1.0'
+
+input_files: 'rule57_ebda_blast_2.i'
+
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: false
+  - property_file: ../properties/coverage-branches.prp
+  - property_file: ../properties/coverage-conditions.prp
+  - property_file: ../properties/coverage-statements.prp
+  - property_file: ../properties/coverage-error-call.prp


### PR DESCRIPTION
Due to the changes in 43eed055 and 05e736a7 the call of VERIFIER_nondet_pointer was removed.
According to SV-COMP rules all memory allocations suceed and do not return a null pointer.
This resulted in a pointer that is always valid, i.e. the underlying task was fixed by that change.
Now we need to fix the expected verdict.
