### PR TITLE
Fix incompatible types in assignment

### DIFF
--- a/c/busybox-1.22.0/uudecode-2.c
+++ b/c/busybox-1.22.0/uudecode-2.c
@@ -1557,7 +1557,7 @@ signed int __main(signed int argc, char **argv)
         }
         if(!(tmp_if_expr$3 == (_Bool)0))
         {
-          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const char *)line;
+          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const unsigned char *)line;
           signed int uudecode_main$$1$$1$$3$$2$$__result;
 
           uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)0] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)0];

--- a/c/busybox-1.22.0/uudecode-2.i
+++ b/c/busybox-1.22.0/uudecode-2.i
@@ -3457,7 +3457,7 @@ signed int __main(signed int argc, char **argv)
         }
         if(!(tmp_if_expr$3 == (_Bool)0))
         {
-          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const char *)line;
+          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const unsigned char *)line;
           signed int uudecode_main$$1$$1$$3$$2$$__result;
           uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)0] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)0];
           if(uudecode_main$$1$$1$$3$$__s2_len > 0ul)


### PR DESCRIPTION
According to 6.5.16.1 of the C standard, types for assignment must be compatible.
According to that, for the affected line, the types are only compatible, if "both operands are pointers to qualified or unqualified versions of compatible types [...]".
Regarding the compatible types, 6.2.7 describes that "two types have compatible type if their types are the same", and  6.7.2 describes that `char`, `unsigned char` and `signed char` are not the same, but three distinct types.

I didn't find anything about that for GNU C, but gcc prints a warning for that line when compiling with `-Wall`.