### PR TITLE
fix comparison of freed pointer.

### DIFF
--- a/c/list-ext3-properties/sll_circular_traversal-1.c
+++ b/c/list-ext3-properties/sll_circular_traversal-1.c
@@ -6,7 +6,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
  * Directly continue the traversal, check data and deallocate.
  */
 #include <stdlib.h>
-#include <stdint.h>
 
 typedef struct node {
   struct node* next;
@@ -56,16 +55,18 @@ int main() {
   } while(ptr != head);
   /* second traversal */
   data_new = data_new - len;
-  intptr_t headptr = (intptr_t)head;
   do {
     if(data_new != ptr->data) {
       goto ERROR;
     }
     SLL temp = ptr->next;
-    free(ptr);
+    if (ptr != head) {
+        free(ptr);
+    }
     ptr = temp;
     data_new++;
-  } while((intptr_t)ptr != headptr);
+  } while(ptr != head);
+  free(head);
   return 0;
  ERROR: __VERIFIER_error();
   return 1;

--- a/c/list-ext3-properties/sll_circular_traversal-1.c
+++ b/c/list-ext3-properties/sll_circular_traversal-1.c
@@ -6,6 +6,7 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
  * Directly continue the traversal, check data and deallocate.
  */
 #include <stdlib.h>
+#include <stdint.h>
 
 typedef struct node {
   struct node* next;
@@ -55,6 +56,7 @@ int main() {
   } while(ptr != head);
   /* second traversal */
   data_new = data_new - len;
+  intptr_t headptr = (intptr_t)head;
   do {
     if(data_new != ptr->data) {
       goto ERROR;
@@ -63,7 +65,7 @@ int main() {
     free(ptr);
     ptr = temp;
     data_new++;
-  } while(ptr != head);
+  } while((intptr_t)ptr != headptr);
   return 0;
  ERROR: __VERIFIER_error();
   return 1;

--- a/c/list-ext3-properties/sll_circular_traversal-1.i
+++ b/c/list-ext3-properties/sll_circular_traversal-1.i
@@ -553,6 +553,37 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+typedef unsigned char uint8_t;
+typedef unsigned short int uint16_t;
+typedef unsigned int uint32_t;
+__extension__
+typedef unsigned long long int uint64_t;
+typedef signed char int_least8_t;
+typedef short int int_least16_t;
+typedef int int_least32_t;
+__extension__
+typedef long long int int_least64_t;
+typedef unsigned char uint_least8_t;
+typedef unsigned short int uint_least16_t;
+typedef unsigned int uint_least32_t;
+__extension__
+typedef unsigned long long int uint_least64_t;
+typedef signed char int_fast8_t;
+typedef int int_fast16_t;
+typedef int int_fast32_t;
+__extension__
+typedef long long int int_fast64_t;
+typedef unsigned char uint_fast8_t;
+typedef unsigned int uint_fast16_t;
+typedef unsigned int uint_fast32_t;
+__extension__
+typedef unsigned long long int uint_fast64_t;
+typedef int intptr_t;
+typedef unsigned int uintptr_t;
+__extension__
+typedef long long int intmax_t;
+__extension__
+typedef unsigned long long int uintmax_t;
 typedef struct node {
   struct node* next;
   int data;
@@ -596,6 +627,7 @@ int main() {
     data_new++;
   } while(ptr != head);
   data_new = data_new - len;
+  intptr_t headptr = (intptr_t)head;
   do {
     if(data_new != ptr->data) {
       goto ERROR;
@@ -604,7 +636,7 @@ int main() {
     free(ptr);
     ptr = temp;
     data_new++;
-  } while(ptr != head);
+  } while((intptr_t)ptr != headptr);
   return 0;
  ERROR: __VERIFIER_error();
   return 1;

--- a/c/list-ext3-properties/sll_circular_traversal-1.i
+++ b/c/list-ext3-properties/sll_circular_traversal-1.i
@@ -553,37 +553,6 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-typedef unsigned char uint8_t;
-typedef unsigned short int uint16_t;
-typedef unsigned int uint32_t;
-__extension__
-typedef unsigned long long int uint64_t;
-typedef signed char int_least8_t;
-typedef short int int_least16_t;
-typedef int int_least32_t;
-__extension__
-typedef long long int int_least64_t;
-typedef unsigned char uint_least8_t;
-typedef unsigned short int uint_least16_t;
-typedef unsigned int uint_least32_t;
-__extension__
-typedef unsigned long long int uint_least64_t;
-typedef signed char int_fast8_t;
-typedef int int_fast16_t;
-typedef int int_fast32_t;
-__extension__
-typedef long long int int_fast64_t;
-typedef unsigned char uint_fast8_t;
-typedef unsigned int uint_fast16_t;
-typedef unsigned int uint_fast32_t;
-__extension__
-typedef unsigned long long int uint_fast64_t;
-typedef int intptr_t;
-typedef unsigned int uintptr_t;
-__extension__
-typedef long long int intmax_t;
-__extension__
-typedef unsigned long long int uintmax_t;
 typedef struct node {
   struct node* next;
   int data;
@@ -627,16 +596,18 @@ int main() {
     data_new++;
   } while(ptr != head);
   data_new = data_new - len;
-  intptr_t headptr = (intptr_t)head;
   do {
     if(data_new != ptr->data) {
       goto ERROR;
     }
     SLL temp = ptr->next;
-    free(ptr);
+    if (ptr != head) {
+        free(ptr);
+    }
     ptr = temp;
     data_new++;
-  } while((intptr_t)ptr != headptr);
+  } while(ptr != head);
+  free(head);
   return 0;
  ERROR: __VERIFIER_error();
   return 1;


### PR DESCRIPTION
This problem is a follow-up of #979.

According to ISO-C99 6.2.4(2),
the value of a pointer becomes indeterminate when
the object it points to reaches the end of its lifetime.

There is also a nice blog post about that:
https://kristerw.blogspot.com/2016/03/c-pointers-are-not-hardware-pointers.html

For the task changed in 59606cd, the pointer itself is not even used in the `free` operation,
but only another pointer to the same object.
This makes it hard to understand the consequences of strict application of the C standard here.

We need to check for further tasks containing such a kind of undefined behaviour,
because it is quite common to write code like this in C and GCC/Clang happily compile the code,
even if the standard does not specify the behaviour for such cases.

I do not know whether it is worth to exclude such tasks from SV-COMP20 now.

Also, I am not yet a C expert for all kind of weird behaviour,
so the reviewers need to really take a deep look into the C standard.