### PR TITLE
Rename functions that collide with the C standard in AWS-C-Common

### DIFF
--- a/c/aws-c-common/aws_add_size_checked_harness.i
+++ b/c/aws-c-common/aws_add_size_checked_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_add_size_saturating_harness.i
+++ b/c/aws-c-common/aws_add_size_saturating_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1614,7 +1614,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5814,7 +5814,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_eq_harness.i
+++ b/c/aws-c-common/aws_array_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_back_harness.i
+++ b/c/aws-c-common/aws_array_list_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7475,7 +7475,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7504,7 +7504,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7523,7 +7523,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7574,7 +7574,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7602,17 +7602,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_capacity_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_clean_up_harness.i
+++ b/c/aws-c-common/aws_array_list_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_clear_harness.i
+++ b/c/aws-c-common/aws_array_list_clear_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_comparator_string_harness.i
+++ b/c/aws-c-common/aws_array_list_comparator_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_copy_harness.i
+++ b/c/aws-c-common/aws_array_list_copy_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7481,7 +7481,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7510,7 +7510,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7529,7 +7529,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7580,7 +7580,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7608,17 +7608,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7481,7 +7481,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7510,7 +7510,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7529,7 +7529,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7580,7 +7580,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7608,17 +7608,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_erase_harness.i
+++ b/c/aws-c-common/aws_array_list_erase_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,11 +2059,11 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
-extern void *memmove (void *__dest, const void *__src, size_t __n)
+extern void *my_memmove (void *__dest, const void *__src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3381,7 +3381,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *restrict list, size_t n) 
         size_t popping_bytes = list->item_size * n;
         size_t remaining_items = aws_array_list_length(list) - n;
         size_t remaining_bytes = remaining_items * list->item_size;
-        memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
+        my_memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
         list->length = remaining_items;
 
 
@@ -3412,7 +3412,7 @@ int aws_array_list_erase(struct aws_array_list *restrict list, size_t index) {
         uint8_t *next_item_ptr = item_ptr + list->item_size;
         size_t trailing_items = (length - index) - 1;
         size_t trailing_bytes = trailing_items * list->item_size;
-        memmove(item_ptr, next_item_ptr, trailing_bytes);
+        my_memmove(item_ptr, next_item_ptr, trailing_bytes);
 
         aws_array_list_pop_back(list);
     }
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7421,7 +7421,7 @@ void *memmove_impl(void *dest, const void *src, size_t n) {
     return dest;
 }
 
-void *memmove(void *dest, const void *src, size_t n) {
+void *my_memmove(void *dest, const void *src, size_t n) {
     return memmove_impl(dest, src, n);
 }
 
@@ -7449,7 +7449,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7474,7 +7474,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7531,7 +7531,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7560,7 +7560,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7579,7 +7579,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7630,7 +7630,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7658,17 +7658,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -7850,7 +7850,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_array_list_front_harness.i
+++ b/c/aws-c-common/aws_array_list_front_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((memcmp(val, list->data, list->item_size) == 0)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6139,7 +6139,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7416,7 +7416,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7473,7 +7473,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7502,7 +7502,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7521,7 +7521,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7572,7 +7572,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7600,17 +7600,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_get_at_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7475,7 +7475,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7504,7 +7504,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7523,7 +7523,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7574,7 +7574,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7602,17 +7602,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7475,7 +7475,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7504,7 +7504,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7523,7 +7523,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7574,7 +7574,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7602,17 +7602,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_array_list_init_dynamic_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_init_static_harness.i
+++ b/c/aws-c-common/aws_array_list_init_static_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_length_harness.i
+++ b/c/aws-c-common/aws_array_list_length_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7794,7 +7794,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_array_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2063,7 +2063,7 @@ extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
-extern void *memmove (void *__dest, const void *__src, size_t __n)
+extern void *my_memmove (void *__dest, const void *__src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3381,7 +3381,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *restrict list, size_t n) 
         size_t popping_bytes = list->item_size * n;
         size_t remaining_items = aws_array_list_length(list) - n;
         size_t remaining_bytes = remaining_items * list->item_size;
-        memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
+        my_memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
         list->length = remaining_items;
 
 
@@ -3412,7 +3412,7 @@ int aws_array_list_erase(struct aws_array_list *restrict list, size_t index) {
         uint8_t *next_item_ptr = item_ptr + list->item_size;
         size_t trailing_items = (length - index) - 1;
         size_t trailing_bytes = trailing_items * list->item_size;
-        memmove(item_ptr, next_item_ptr, trailing_bytes);
+        my_memmove(item_ptr, next_item_ptr, trailing_bytes);
 
         aws_array_list_pop_back(list);
     }
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7414,7 +7414,7 @@ void *memmove_impl(void *dest, const void *src, size_t n) {
     return dest;
 }
 
-void *memmove(void *dest, const void *src, size_t n) {
+void *my_memmove(void *dest, const void *src, size_t n) {
     return memmove_impl(dest, src, n);
 }
 

--- a/c/aws-c-common/aws_array_list_pop_front_n_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_n_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2063,7 +2063,7 @@ extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
-extern void *memmove (void *__dest, const void *__src, size_t __n)
+extern void *my_memmove (void *__dest, const void *__src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3381,7 +3381,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *restrict list, size_t n) 
         size_t popping_bytes = list->item_size * n;
         size_t remaining_items = aws_array_list_length(list) - n;
         size_t remaining_bytes = remaining_items * list->item_size;
-        memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
+        my_memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
         list->length = remaining_items;
 
 
@@ -3412,7 +3412,7 @@ int aws_array_list_erase(struct aws_array_list *restrict list, size_t index) {
         uint8_t *next_item_ptr = item_ptr + list->item_size;
         size_t trailing_items = (length - index) - 1;
         size_t trailing_bytes = trailing_items * list->item_size;
-        memmove(item_ptr, next_item_ptr, trailing_bytes);
+        my_memmove(item_ptr, next_item_ptr, trailing_bytes);
 
         aws_array_list_pop_back(list);
     }
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7414,7 +7414,7 @@ void *memmove_impl(void *dest, const void *src, size_t n) {
     return dest;
 }
 
-void *memmove(void *dest, const void *src, size_t n) {
+void *my_memmove(void *dest, const void *src, size_t n) {
     return memmove_impl(dest, src, n);
 }
 

--- a/c/aws-c-common/aws_array_list_push_back_harness.i
+++ b/c/aws-c-common/aws_array_list_push_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7476,7 +7476,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7505,7 +7505,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7524,7 +7524,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7575,7 +7575,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7603,17 +7603,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_set_at_harness.i
+++ b/c/aws-c-common/aws_array_list_set_at_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7476,7 +7476,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7505,7 +7505,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7524,7 +7524,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7575,7 +7575,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7603,17 +7603,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
+++ b/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,11 +2059,11 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
-extern void *memmove (void *__dest, const void *__src, size_t __n)
+extern void *my_memmove (void *__dest, const void *__src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3381,7 +3381,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *restrict list, size_t n) 
         size_t popping_bytes = list->item_size * n;
         size_t remaining_items = aws_array_list_length(list) - n;
         size_t remaining_bytes = remaining_items * list->item_size;
-        memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
+        my_memmove(list->data, (uint8_t *)list->data + popping_bytes, remaining_bytes);
         list->length = remaining_items;
 
 
@@ -3412,7 +3412,7 @@ int aws_array_list_erase(struct aws_array_list *restrict list, size_t index) {
         uint8_t *next_item_ptr = item_ptr + list->item_size;
         size_t trailing_items = (length - index) - 1;
         size_t trailing_bytes = trailing_items * list->item_size;
-        memmove(item_ptr, next_item_ptr, trailing_bytes);
+        my_memmove(item_ptr, next_item_ptr, trailing_bytes);
 
         aws_array_list_pop_back(list);
     }
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7442,7 +7442,7 @@ void *memmove_impl(void *dest, const void *src, size_t n) {
     return dest;
 }
 
-void *memmove(void *dest, const void *src, size_t n) {
+void *my_memmove(void *dest, const void *src, size_t n) {
     return memmove_impl(dest, src, n);
 }
 
@@ -7460,7 +7460,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7517,7 +7517,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7546,7 +7546,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7565,7 +7565,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7616,7 +7616,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7644,17 +7644,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -7836,7 +7836,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_array_list_sort_harness.i
+++ b/c/aws-c-common/aws_array_list_sort_harness.i
@@ -225,7 +225,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1625,7 +1625,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -1711,7 +1711,7 @@ extern void *bsearch (const void *__key, const void *__base,
 
 
 
-extern void qsort (void *__base, size_t __nmemb, size_t __size,
+extern void my_qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -3576,7 +3576,7 @@ static inline
 void aws_array_list_sort(struct aws_array_list *restrict list, aws_array_list_comparator_fn *compare_fn) {
     __VERIFIER_assume((aws_array_list_is_valid(list)));
     if (list->data) {
-        qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
+        my_qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }
     __VERIFIER_assert((aws_array_list_is_valid(list)));
 }
@@ -6142,7 +6142,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7405,7 +7405,7 @@ void aws_raise_error_private(int err) {
 int aws_last_error(void) {
     return tl_last_error;
 }
-void qsort(void *base, unsigned long num, unsigned long size, int (*compar)(const void *, const void *)) {
+void my_qsort(void *base, unsigned long num, unsigned long size, int (*compar)(const void *, const void *)) {
     __VERIFIER_assume((((num * size) == 0) || (base)));
     __VERIFIER_assume((((num * size) == 0) || (base)));
     unsigned long index_a;

--- a/c/aws-c-common/aws_array_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_contents_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_swap_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7481,7 +7481,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7510,7 +7510,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7529,7 +7529,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7580,7 +7580,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7608,17 +7608,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_byte_buf_advance_harness.i
+++ b/c/aws-c-common/aws_byte_buf_advance_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7454,7 +7454,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7466,7 +7466,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
     memcpy(dest->buffer, src->buffer, src->len);
@@ -7592,7 +7592,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7635,7 +7635,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7648,7 +7648,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7694,7 +7694,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8646,7 +8646,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8893,7 +8893,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7475,7 +7475,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7613,7 +7613,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8042,7 +8042,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr != ((void *)0));
         __VERIFIER_assert(to->buffer != ((void *)0));
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8133,13 +8133,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8156,7 +8156,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr != ((void *)0));
             __VERIFIER_assert(to->buffer != ((void *)0));
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8511,7 +8511,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8677,7 +8677,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_append_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr != ((void *)0));
         __VERIFIER_assert(to->buffer != ((void *)0));
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7475,7 +7475,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7613,7 +7613,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8042,7 +8042,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8133,13 +8133,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8156,7 +8156,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8511,7 +8511,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8677,7 +8677,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_cat_harness.i
+++ b/c/aws-c-common/aws_byte_buf_cat_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_clean_up_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7200,7 +7200,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7235,7 +7235,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7247,7 +7247,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
     memcpy(dest->buffer, src->buffer, src->len);
@@ -7373,7 +7373,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7416,7 +7416,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7429,7 +7429,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7475,7 +7475,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8427,7 +8427,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8674,7 +8674,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7200,7 +7200,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7235,7 +7235,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7247,7 +7247,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
     memcpy(dest->buffer, src->buffer, src->len);
@@ -7373,7 +7373,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7416,7 +7416,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7429,7 +7429,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7475,7 +7475,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8427,7 +8427,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8674,7 +8674,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_array_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_init_copy_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_init_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_reserve_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7443,7 +7443,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7478,7 +7478,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7490,10 +7490,10 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7616,7 +7616,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7631,7 +7631,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -7659,7 +7659,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7672,7 +7672,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7718,7 +7718,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8060,7 +8060,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8151,13 +8151,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8174,7 +8174,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8529,7 +8529,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8670,7 +8670,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8695,7 +8695,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));
@@ -8917,7 +8917,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7206,7 +7206,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7224,7 +7224,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7259,7 +7259,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7271,10 +7271,10 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7397,7 +7397,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7412,7 +7412,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -7440,7 +7440,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7453,7 +7453,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7499,7 +7499,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -7841,7 +7841,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -7932,13 +7932,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -7955,7 +7955,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8310,7 +8310,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8451,7 +8451,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8476,7 +8476,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));
@@ -8698,7 +8698,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_reset_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reset_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7454,7 +7454,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7466,7 +7466,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
     memcpy(dest->buffer, src->buffer, src->len);
@@ -7592,7 +7592,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7635,7 +7635,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7648,7 +7648,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7694,7 +7694,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8646,7 +8646,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8893,7 +8893,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
+++ b/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7454,7 +7454,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     do { if (!(aws_byte_buf_is_valid(src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
     if (!src->buffer) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         dest->allocator = allocator;
         __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
         return (0);
@@ -7466,7 +7466,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (dest->buffer == 
                        ((void *)0)
                            ) {
-        do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+        do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
     memcpy(dest->buffer, src->buffer, src->len);
@@ -7592,7 +7592,7 @@ int aws_byte_buf_init_copy_from_cursor(
     __VERIFIER_assume((dest));
     do { if (!(aws_byte_cursor_is_valid(&src))) { return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT); } } while (0);
 
-    do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
+    do { my_memset(&(*dest), 0, sizeof(*dest)); } while (0);
 
     dest->buffer = (src.len > 0) ? (uint8_t *)aws_mem_acquire(allocator, src.len) : 
                                                                                    ((void *)0)
@@ -7635,7 +7635,7 @@ _Bool
 
     if (substr->ptr > input_str->ptr + input_str->len) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7648,7 +7648,7 @@ _Bool
 
     if (!first_run && substr->len == 0) {
 
-        do { memset(&(*substr), 0, sizeof(*substr)); } while (0);
+        do { my_memset(&(*substr), 0, sizeof(*substr)); } while (0);
         return 
               0
                    ;
@@ -7694,7 +7694,7 @@ int aws_byte_cursor_split_on_char_n(
     size_t split_count = 0;
 
     struct aws_byte_cursor substr;
-    do { memset(&(substr), 0, sizeof(substr)); } while (0);
+    do { my_memset(&(substr), 0, sizeof(substr)); } while (0);
 
 
     while (split_count <= max_splits && aws_byte_cursor_next_split(input_str, split_on, &substr)) {
@@ -8646,7 +8646,7 @@ _Bool
               1
                   ;
     } else {
-        do { memset(&(*output), 0, sizeof(*output)); } while (0);
+        do { my_memset(&(*output), 0, sizeof(*output)); } while (0);
         __VERIFIER_assert((aws_byte_buf_is_valid(buffer)));
         __VERIFIER_assert((aws_byte_buf_is_valid(output)));
         return 
@@ -8893,7 +8893,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_byte_buf_write_be16_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be16_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_write_be32_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be32_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_write_be64_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be64_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_u8_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_u8_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7469,7 +7469,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         do { memset(&(*dest), 0, sizeof(*dest)); } while (0);
         return (-1);
     }
-    memcpy(dest->buffer, src->buffer, src->len);
+    my_memcpy(dest->buffer, src->buffer, src->len);
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
 }
@@ -7607,7 +7607,7 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     if (src.len > 0) {
-        memcpy(dest->buffer, src.ptr, src.len);
+        my_memcpy(dest->buffer, src.ptr, src.len);
     }
     __VERIFIER_assert((aws_byte_buf_is_valid(dest)));
     return (0);
@@ -8036,7 +8036,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
         __VERIFIER_assert(from->ptr);
         __VERIFIER_assert(to->buffer);
-        memcpy(to->buffer + to->len, from->ptr, from->len);
+        my_memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
 
@@ -8127,13 +8127,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
 
         if (to->len > 0) {
-            memcpy(new_buffer, to->buffer, to->len);
+            my_memcpy(new_buffer, to->buffer, to->len);
         }
 
 
 
         if (from->len > 0) {
-            memcpy(new_buffer + to->len, from->ptr, from->len);
+            my_memcpy(new_buffer + to->len, from->ptr, from->len);
         }
 
 
@@ -8150,7 +8150,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
             __VERIFIER_assert(from->ptr);
             __VERIFIER_assert(to->buffer);
-            memcpy(to->buffer + to->len, from->ptr, from->len);
+            my_memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
 
@@ -8505,7 +8505,7 @@ _Bool
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
+        my_memcpy(dest, slice.ptr, len);
         __VERIFIER_assert((aws_byte_cursor_is_valid(cur)));
         __VERIFIER_assert((((((len)) == 0) || ((dest)))));
         return 
@@ -8671,7 +8671,7 @@ _Bool
                    ;
     }
 
-    memcpy(buf->buffer + buf->len, src, len);
+    my_memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
     __VERIFIER_assert((aws_byte_buf_is_valid(buf)));

--- a/c/aws-c-common/aws_byte_cursor_advance_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_array_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_string_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_array_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_array_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_c_string_harness.i
+++ b/c/aws-c-common/aws_hash_c_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_callback_string_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_iter_begin_harness.i
+++ b/c/aws-c-common/aws_hash_iter_begin_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_iter_delete_harness.i
+++ b/c/aws-c-common/aws_hash_iter_delete_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_iter_done_harness.i
+++ b/c/aws-c-common/aws_hash_iter_done_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_iter_next_harness.i
+++ b/c/aws-c-common/aws_hash_iter_next_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_ptr_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5150,7 +5150,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_string_harness.i
+++ b/c/aws-c-common/aws_hash_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_clean_up_harness.i
+++ b/c/aws-c-common/aws_hash_table_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memset_override_0_impl(void *dst, int c, size_t n) {
     return dst;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_override_0_impl(s, c, n);
 }
 
@@ -7591,7 +7591,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9350,7 +9350,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9698,7 +9698,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9880,7 +9880,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9986,7 +9986,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_clear_harness.i
+++ b/c/aws-c-common/aws_hash_table_clear_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memset_override_0_impl(void *dst, int c, size_t n) {
     return dst;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_override_0_impl(s, c, n);
 }
 
@@ -7591,7 +7591,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9350,7 +9350,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9698,7 +9698,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9880,7 +9880,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9986,7 +9986,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_create_harness.i
+++ b/c/aws-c-common/aws_hash_table_create_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7415,7 +7415,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7582,7 +7582,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9341,7 +9341,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9689,7 +9689,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9871,7 +9871,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9977,7 +9977,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_eq_harness.i
+++ b/c/aws-c-common/aws_hash_table_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_find_harness.i
+++ b/c/aws-c-common/aws_hash_table_find_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_foreach_harness.i
+++ b/c/aws-c-common/aws_hash_table_foreach_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
+++ b/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_init_bounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_bounded_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7415,7 +7415,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7582,7 +7582,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9341,7 +9341,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9689,7 +9689,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9871,7 +9871,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9977,7 +9977,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_move_harness.i
+++ b/c/aws-c-common/aws_hash_table_move_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_table_put_harness.i
+++ b/c/aws-c-common/aws_hash_table_put_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7415,7 +7415,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7582,7 +7582,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9341,7 +9341,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9689,7 +9689,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9871,7 +9871,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9977,7 +9977,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_remove_harness.i
+++ b/c/aws-c-common/aws_hash_table_remove_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7415,7 +7415,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7582,7 +7582,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -9341,7 +9341,7 @@ void aws_hash_table_move(struct aws_hash_table *restrict to, struct aws_hash_tab
     __VERIFIER_assume((aws_hash_table_is_valid(from)));
 
     *to = *from;
-    do { memset(&(*from), 0, sizeof(*from)); } while (0);
+    do { my_memset(&(*from), 0, sizeof(*from)); } while (0);
     __VERIFIER_assert((aws_hash_table_is_valid(to)));
 }
 static int s_find_entry1(
@@ -9689,7 +9689,7 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     }
 
 
-    do { memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
+    do { my_memset(&(state->slots[index]), 0, sizeof(state->slots[index])); } while (0);
     do { __VERIFIER_assert((hash_table_state_is_valid(state) && index <= state->size)); return index; } while (0);
 }
 
@@ -9871,7 +9871,7 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     __VERIFIER_assume((aws_hash_table_is_valid(map)));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
-    do { memset(&(iter), 0, sizeof(iter)); } while (0);
+    do { my_memset(&(iter), 0, sizeof(iter)); } while (0);
     iter.map = map;
     iter.limit = state->size;
     s_get_next_element(&iter, 0);
@@ -9977,7 +9977,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     }
 
 
-    memset(state->slots, 0, sizeof(*state->slots) * state->size);
+    my_memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
     __VERIFIER_assert((aws_hash_table_is_valid(map)));

--- a/c/aws-c-common/aws_hash_table_swap_harness.i
+++ b/c/aws-c-common/aws_hash_table_swap_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_is_power_of_two_harness.i
+++ b/c/aws-c-common/aws_is_power_of_two_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 

--- a/c/aws-c-common/aws_linked_list_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_begin_harness.i
+++ b/c/aws-c-common/aws_linked_list_begin_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_end_harness.i
+++ b/c/aws-c-common/aws_linked_list_end_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_front_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_init_harness.i
+++ b/c/aws-c-common/aws_linked_list_init_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_insert_after_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_after_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_insert_before_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_before_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_next_harness.i
+++ b/c/aws-c-common/aws_linked_list_next_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_node_reset_harness.i
+++ b/c/aws-c-common/aws_linked_list_node_reset_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_front_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_prev_harness.i
+++ b/c/aws-c-common/aws_linked_list_prev_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_push_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_back_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_push_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_front_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_rbegin_harness.i
+++ b/c/aws-c-common/aws_linked_list_rbegin_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_remove_harness.i
+++ b/c/aws-c-common/aws_linked_list_remove_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_rend_harness.i
+++ b/c/aws-c-common/aws_linked_list_rend_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_linked_list_swap_contents_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5815,7 +5815,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_mul_size_checked_harness.i
+++ b/c/aws-c-common/aws_mul_size_checked_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
+++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1615,7 +1615,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5814,7 +5814,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_nospec_mask_harness.i
+++ b/c/aws-c-common/aws_nospec_mask_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_priority_queue_capacity_harness.i
+++ b/c/aws-c-common/aws_priority_queue_capacity_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_priority_queue_clean_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_priority_queue_init_static_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_static_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_priority_queue_pop_harness.i
+++ b/c/aws-c-common/aws_priority_queue_pop_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7420,7 +7420,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7477,7 +7477,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7506,7 +7506,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7525,7 +7525,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7576,7 +7576,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7604,17 +7604,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8143,7 +8143,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_push_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7420,7 +7420,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7477,7 +7477,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7506,7 +7506,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7525,7 +7525,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7576,7 +7576,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7604,17 +7604,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8143,7 +8143,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_push_ref_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_ref_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7420,7 +7420,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7477,7 +7477,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7506,7 +7506,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7525,7 +7525,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7576,7 +7576,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7604,17 +7604,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8143,7 +8143,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_remove_harness.i
+++ b/c/aws-c-common/aws_priority_queue_remove_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7420,7 +7420,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7477,7 +7477,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7506,7 +7506,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7525,7 +7525,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7576,7 +7576,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7604,17 +7604,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8143,7 +8143,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -2886,7 +2886,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -2993,7 +2993,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3124,7 +3124,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -4688,7 +4688,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7449,7 +7449,7 @@ void *memcpy_using_uint64_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_using_uint64_impl(dst, src, n);
 }
 
@@ -7467,7 +7467,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7524,7 +7524,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7553,7 +7553,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7572,7 +7572,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7623,7 +7623,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7651,17 +7651,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -7843,7 +7843,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 
@@ -8190,7 +8190,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -8240,7 +8240,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -8269,7 +8269,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -8440,7 +8440,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 

--- a/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7482,7 +7482,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7511,7 +7511,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7530,7 +7530,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7581,7 +7581,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7609,17 +7609,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8148,7 +8148,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7482,7 +7482,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7511,7 +7511,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7530,7 +7530,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7581,7 +7581,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7609,17 +7609,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8148,7 +8148,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7425,7 +7425,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7482,7 +7482,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7511,7 +7511,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7530,7 +7530,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7581,7 +7581,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7609,17 +7609,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8148,7 +8148,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3021,7 +3021,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3106,7 +3106,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3193,7 +3193,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3230,7 +3230,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7419,7 +7419,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7476,7 +7476,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7505,7 +7505,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7524,7 +7524,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7575,7 +7575,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7603,17 +7603,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {
@@ -8142,7 +8142,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {

--- a/c/aws-c-common/aws_priority_queue_size_harness.i
+++ b/c/aws-c-common/aws_priority_queue_size_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_priority_queue_top_harness.i
+++ b/c/aws-c-common/aws_priority_queue_top_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_ptr_eq_harness.i
+++ b/c/aws-c-common/aws_ptr_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -8384,7 +8384,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_ring_buffer_init_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_init_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_ring_buffer_release_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_release_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
+++ b/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 

--- a/c/aws-c-common/aws_string_bytes_harness.i
+++ b/c/aws-c-common/aws_string_bytes_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_compare_harness.i
+++ b/c/aws-c-common/aws_string_compare_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_destroy_harness.i
+++ b/c/aws-c-common/aws_string_destroy_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_destroy_secure_harness.i
+++ b/c/aws-c-common/aws_string_destroy_secure_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_harness.i
+++ b/c/aws-c-common/aws_string_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_ignore_case_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_new_from_array_harness.i
+++ b/c/aws-c-common/aws_string_new_from_array_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_new_from_c_str_harness.i
+++ b/c/aws-c-common/aws_string_new_from_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_new_from_string_harness.i
+++ b/c/aws-c-common/aws_string_new_from_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/makeall
+++ b/c/aws-c-common/makeall
@@ -25,6 +25,19 @@ sed '/^void .memset(/,+8d' -i \
 sed 's/__builtin___mem/___mem/g' -i \
     $SV/c/aws-c-common/*.i
 
+# Rename functions that are defined in the C11 standard.
+# We need to make sure that we rename only where a body exists (for abort this is always the case).
+sed -e 's/\babort\b/my_abort/g' -i $SV/c/aws-c-common/*.i
+sed -e 's/\bqsort\b/my_qsort/g' -i $SV/c/aws-c-common/aws_array_list_sort_harness.i
+for file in $SV/c/aws-c-common/*.i; do
+  for func in memcpy memmove memset; do
+    if grep -q '^void \*'$func'(.*{' $file; then
+      echo "Replacing $func in $file"
+      sed -e 's/\b'$func'\b/'my_$func'/g' -i $file
+    fi
+  done
+done
+
 # fix typo in qsort stub
 sed '1 i int compare(const void *a, const void *b, unsigned long item_size);' -i \
     $SV/c/aws-c-common/./aws_array_list_sort_harness.i

--- a/c/aws-c-common/memcpy_using_uint64_harness.i
+++ b/c/aws-c-common/memcpy_using_uint64_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5150,7 +5150,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/memset_override_0_harness.i
+++ b/c/aws-c-common/memset_override_0_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5150,7 +5150,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/memset_using_uint64_harness.i
+++ b/c/aws-c-common/memset_using_uint64_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5150,7 +5150,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 


### PR DESCRIPTION
Fixes #1043
All these programs define some functions (at least abort)
that are also defined by the C standard,
but these identifiers are reserverd and so this is undefined behavior.

This commit renames functions called "abort", "qsort", "memcpy",
"memmove", and "memset" if they have a body.
These were the only functions I found where this is necessary.

Checking which tasks are affected and the renaming was done automatically, the code for this is in `makeall`.