### PR TITLE
Rename functions that collide with the C standard in part of AWS-C-Common

### DIFF
--- a/c/aws-c-common/aws_array_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_capacity_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_clean_up_harness.i
+++ b/c/aws-c-common/aws_array_list_clean_up_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_clear_harness.i
+++ b/c/aws-c-common/aws_array_list_clear_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_comparator_string_harness.i
+++ b/c/aws-c-common/aws_array_list_comparator_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_array_list_init_dynamic_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_init_static_harness.i
+++ b/c/aws-c-common/aws_array_list_init_static_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_length_harness.i
+++ b/c/aws-c-common/aws_array_list_length_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_array_list_sort_harness.i
+++ b/c/aws-c-common/aws_array_list_sort_harness.i
@@ -225,7 +225,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1625,7 +1625,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -1711,7 +1711,7 @@ extern void *bsearch (const void *__key, const void *__base,
 
 
 
-extern void qsort (void *__base, size_t __nmemb, size_t __size,
+extern void my_qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -3576,7 +3576,7 @@ static inline
 void aws_array_list_sort(struct aws_array_list *restrict list, aws_array_list_comparator_fn *compare_fn) {
     __VERIFIER_assume((aws_array_list_is_valid(list)));
     if (list->data) {
-        qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
+        my_qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }
     __VERIFIER_assert((aws_array_list_is_valid(list)));
 }
@@ -6142,7 +6142,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7405,7 +7405,7 @@ void aws_raise_error_private(int err) {
 int aws_last_error(void) {
     return tl_last_error;
 }
-void qsort(void *base, unsigned long num, unsigned long size, int (*compar)(const void *, const void *)) {
+void my_qsort(void *base, unsigned long num, unsigned long size, int (*compar)(const void *, const void *)) {
     __VERIFIER_assume((((num * size) == 0) || (base)));
     __VERIFIER_assume((((num * size) == 0) || (base)));
     unsigned long index_a;

--- a/c/aws-c-common/aws_array_list_swap_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2059,7 +2059,7 @@ enum aws_common_error {
 
 
 
-extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+extern void *my_memcpy (void *__restrict __dest, const void *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 
@@ -3345,7 +3345,7 @@ int aws_array_list_front(const struct aws_array_list *restrict list, void *val) 
 
                                                                                      ;
     if (aws_array_list_length(list) > 0) {
-        memcpy(val, list->data, list->item_size);
+        my_memcpy(val, list->data, list->item_size);
         __VERIFIER_assert(((1)));
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -3430,7 +3430,7 @@ int aws_array_list_back(const struct aws_array_list *restrict list, void *val) {
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3517,7 +3517,7 @@ int aws_array_list_get_at(const struct aws_array_list *restrict list, void *val,
 
                                                                                      ;
     if (aws_array_list_length(list) > index) {
-        memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
+        my_memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
     }
@@ -3554,7 +3554,7 @@ int aws_array_list_set_at(struct aws_array_list *restrict list, const void *val,
 
     __VERIFIER_assume((list->data));
 
-    memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
+    my_memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 
 
 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7424,7 +7424,7 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
     return dst;
 }
 
-void *memcpy(void *dst, const void *src, size_t n) {
+void *my_memcpy(void *dst, const void *src, size_t n) {
     return memcpy_impl(dst, src, n);
 }
 
@@ -7481,7 +7481,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *restrict list) {
                     return (-1);
                 }
 
-                memcpy(raw_data, list->data, ideal_size);
+                my_memcpy(raw_data, list->data, ideal_size);
                 aws_mem_release(list->alloc, list->data);
             }
             list->data = raw_data;
@@ -7510,7 +7510,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
 
     if (to->current_size >= copy_size) {
         if (copy_size > 0) {
-            memcpy(to->data, from->data, copy_size);
+            my_memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
         __VERIFIER_assert((aws_array_list_is_valid(from)));
@@ -7529,7 +7529,7 @@ int aws_array_list_copy(const struct aws_array_list *restrict from, struct aws_a
             return (-1);
         }
 
-        memcpy(tmp, from->data, copy_size);
+        my_memcpy(tmp, from->data, copy_size);
         if (to->data) {
             aws_mem_release(to->alloc, to->data);
         }
@@ -7580,7 +7580,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *restrict list, size_t 
         }
 
         if (list->data) {
-            memcpy(temp, list->data, list->current_size);
+            my_memcpy(temp, list->data, list->current_size);
 
 
 
@@ -7608,17 +7608,17 @@ static void aws_array_list_mem_swap(void *restrict item1, void *restrict item2, 
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
     for (size_t i = 0; i < slice_count; i++) {
-        memcpy((void *)temp, (void *)item1, SLICE);
-        memcpy((void *)item1, (void *)item2, SLICE);
-        memcpy((void *)item2, (void *)temp, SLICE);
+        my_memcpy((void *)temp, (void *)item1, SLICE);
+        my_memcpy((void *)item1, (void *)item2, SLICE);
+        my_memcpy((void *)item2, (void *)temp, SLICE);
         item1 = (uint8_t *)item1 + SLICE;
         item2 = (uint8_t *)item2 + SLICE;
     }
 
     size_t remainder = item_size & (SLICE - 1);
-    memcpy((void *)temp, (void *)item1, remainder);
-    memcpy((void *)item1, (void *)item2, remainder);
-    memcpy((void *)item2, (void *)temp, remainder);
+    my_memcpy((void *)temp, (void *)item1, remainder);
+    my_memcpy((void *)item1, (void *)item2, remainder);
+    my_memcpy((void *)item2, (void *)temp, remainder);
 }
 
 void aws_array_list_swap(struct aws_array_list *restrict list, size_t a, size_t b) {

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_is_power_of_two_harness.i
+++ b/c/aws-c-common/aws_is_power_of_two_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 

--- a/c/aws-c-common/aws_linked_list_node_reset_harness.i
+++ b/c/aws-c-common/aws_linked_list_node_reset_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_linked_list_remove_harness.i
+++ b/c/aws-c-common/aws_linked_list_remove_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_mul_size_checked_harness.i
+++ b/c/aws-c-common/aws_mul_size_checked_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
+++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1615,7 +1615,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5814,7 +5814,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -2077,7 +2077,7 @@ extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
 
 
 
-extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *my_memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
@@ -3210,7 +3210,7 @@ int aws_array_list_init_dynamic(
    ));
     __VERIFIER_assume((item_size > 0));
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
@@ -3317,7 +3317,7 @@ void aws_array_list_clean_up(struct aws_array_list *restrict list) {
         aws_mem_release(list->alloc, list->data);
     }
 
-    do { memset(&(*list), 0, sizeof(*list)); } while (0);
+    do { my_memset(&(*list), 0, sizeof(*list)); } while (0);
 }
 
 static inline
@@ -3448,7 +3448,7 @@ int aws_array_list_pop_back(struct aws_array_list *restrict list) {
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
-        memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
+        my_memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         __VERIFIER_assert((aws_array_list_is_valid(list)));
         return (0);
@@ -5012,7 +5012,7 @@ static inline void aws_linked_list_node_reset(struct aws_linked_list_node *node)
     __VERIFIER_assume((node != 
    ((void *)0)
    ));
-    do { memset(&(*node), 0, sizeof(*node)); } while (0);
+    do { my_memset(&(*node), 0, sizeof(*node)); } while (0);
     __VERIFIER_assert((aws_is_mem_zeroed(&(*node), sizeof(*node))));
 }
 static inline 
@@ -6141,7 +6141,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 
@@ -7418,7 +7418,7 @@ void *memset_impl(void *s, int c, size_t n) {
     return s;
 }
 
-void *memset(void *s, int c, size_t n) {
+void *my_memset(void *s, int c, size_t n) {
     return memset_impl(s, c, n);
 }
 
@@ -7543,7 +7543,7 @@ static
 
         if (aws_array_list_get_at_ptr(&queue->container, &parent_item, parent) ||
             aws_array_list_get_at_ptr(&queue->container, &child_item, index)) {
-            abort();
+            my_abort();
         }
 
         if (queue->pred(parent_item, child_item) > 0) {
@@ -7593,7 +7593,7 @@ int aws_priority_queue_init_dynamic(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == (0)) {
@@ -7622,7 +7622,7 @@ void aws_priority_queue_init_static(
     __VERIFIER_assume((item_size > 0));
 
     queue->pred = pred;
-    do { memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
+    do { my_memset(&(queue->backpointers), 0, sizeof(queue->backpointers)); } while (0);
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
@@ -7793,7 +7793,7 @@ int aws_priority_queue_push_ref(
         }
 
 
-        memset(queue->backpointers.data, 0, queue->backpointers.current_size);
+        my_memset(queue->backpointers.data, 0, queue->backpointers.current_size);
     }
 
 
@@ -8058,7 +8058,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
-    memset(pBuf, 0, bufsize);
+    my_memset(pBuf, 0, bufsize);
 
 
 

--- a/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
+++ b/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 

--- a/c/aws-c-common/aws_string_compare_harness.i
+++ b/c/aws-c-common/aws_string_compare_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/aws_string_eq_harness.i
+++ b/c/aws-c-common/aws_string_eq_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5817,7 +5817,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 

--- a/c/aws-c-common/memset_override_0_harness.i
+++ b/c/aws-c-common/memset_override_0_harness.i
@@ -224,7 +224,7 @@ void __VERIFIER_assert(int cond) {
 
 
 
-void abort(void) {
+void my_abort(void) {
     __VERIFIER_error();
 }
 void __CPROVER_allocated_memory(unsigned long address, unsigned long extent) { }
@@ -1624,7 +1624,7 @@ extern void *aligned_alloc (size_t __alignment, size_t __size)
 
 
 
-extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void my_abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
 
@@ -5150,7 +5150,7 @@ static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
         case aws_memory_order_seq_cst:
             return 5;
         default:
-            abort();
+            my_abort();
     }
 }
 


### PR DESCRIPTION
Part of #1043.
All these programs define some functions (at least abort)
that are also defined by the C standard,
but these identifiers are reserverd and so this is undefined
behavior.

This commit renames functions called "abort", "qsort", "memcpy",
"memmove", and "memset" if they have a body.
These were the only functions I found where this is necessary.

Checking which tasks are affected and the renaming was done
automatically, the code for this is in [`makeall`](https://github.com/sosy-lab/sv-benchmarks/pull/1047/files#diff-6e91d3085a54899adfa01a201ac91950) of #1047.

This PR is a subset of the fixes of #1047
where it is relevant for SV-COMP'20.