### PR TITLE
openbsd-6.2/if_etherip-fixed-double-free declares incompatible malloc, free

### DIFF
--- a/c/openbsd-6.2/if_etherip-fixed-double-free.yml
+++ b/c/openbsd-6.2/if_etherip-fixed-double-free.yml
@@ -1,7 +1,0 @@
-format_version: '1.0'
-
-input_files: 'if_etherip-fixed-double-free.i'
-
-properties:
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true


### PR DESCRIPTION
This benchmark declares functions malloc and free taking three arguments
each. Furthermore it uses an undefined function m_free. These are
violations of the C standard and the SV-COMP rules, respectively.

This is a PR against the svcomp20-jury branch, removing the corresponding .yml file. I acknowledge that I am submitting this PR approximately 26 hours after having received the final results, which is after the deadline noted in the email. I'll still give it a try, though.
