### PR TITLE
Fix {vmalloc,__kmalloc}{,_node} implementation to use size

### DIFF
--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -57885,7 +57885,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47672,7 +47672,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74469,7 +74469,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -75189,7 +75189,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -30375,7 +30375,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-pci-zoran-zr36067.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-pci-zoran-zr36067.cil.i
@@ -25993,7 +25993,7 @@ int videocodec_detach(struct videocodec *arg0) {
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-usb-dvb-usb-dvb-usb-cxusb.cil.i
@@ -16138,7 +16138,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -58470,7 +58470,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47951,7 +47951,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74754,7 +74754,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -75471,7 +75471,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -30654,7 +30654,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-realtek-r8169.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-realtek-r8169.cil.i
@@ -25799,7 +25799,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_sleep(const char *arg0, int arg1, int arg2) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-zoran-zr36067.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-zoran-zr36067.cil.i
@@ -25792,7 +25792,7 @@ int videocodec_detach(struct videocodec *arg0) {
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -59742,7 +59742,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -49561,7 +49561,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -18193,7 +18193,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -76665,7 +76665,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __ldv_spin_lock(spinlock_t *arg0) {
   return;
@@ -77384,7 +77384,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -32100,7 +32100,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -19362,7 +19362,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -34059,7 +34059,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -58057,7 +58057,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47854,7 +47854,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74796,7 +74796,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -75513,7 +75513,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -30531,7 +30531,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -35723,7 +35723,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -36306,7 +36306,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -38367,7 +38367,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -38959,7 +38959,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -77445,7 +77445,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __ldv_spin_lock(spinlock_t *arg0) {
   return;
@@ -78164,7 +78164,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-neterion-vxge-vxge.cil.i
@@ -31581,7 +31581,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-cassini.cil.i
@@ -19030,7 +19030,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -79576,7 +79576,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -79576,7 +79576,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--scsi--osst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--scsi--osst.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -12045,7 +12045,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--misc--sisusbvga--sisusbvga.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--usb--misc--sisusbvga--sisusbvga.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -12842,7 +12842,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-challenges/main7-linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko.cil.out.i
+++ b/c/ldv-challenges/main7-linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko.cil.out.i
@@ -20376,7 +20376,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -1369,7 +1369,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1539,7 +1539,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1936,7 +1936,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
@@ -830,7 +830,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
@@ -624,7 +624,7 @@ int videocodec_detach(struct videocodec *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-usb-dvb-usb-dvb-usb-cxusb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-usb-dvb-usb-dvb-usb-cxusb_true-unreach-call.cil.env.c
@@ -254,6 +254,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -1345,7 +1345,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1531,7 +1531,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1928,7 +1928,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
@@ -822,7 +822,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-realtek-r8169_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-realtek-r8169_true-unreach-call.cil.env.c
@@ -44,7 +44,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_sleep

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
@@ -656,7 +656,7 @@ int videocodec_detach(struct videocodec *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -1368,7 +1368,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1538,7 +1538,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
@@ -786,7 +786,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __ldv_spin_lock
@@ -1935,7 +1935,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
@@ -830,7 +830,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -907,7 +907,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
@@ -607,6 +607,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -1361,7 +1361,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -1531,7 +1531,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1928,7 +1928,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
@@ -822,7 +822,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
@@ -87,7 +87,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1573,7 +1573,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
@@ -87,7 +87,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1597,7 +1597,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __ldv_spin_lock
@@ -1935,7 +1935,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-neterion-vxge-vxge_true-unreach-call.cil.env.c
@@ -830,7 +830,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -907,7 +907,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -1375,7 +1375,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main3_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-ldv_main3_sequence_infinite_withcheck_stateful_false-unreach-call.cil.out.env.c
@@ -1375,7 +1375,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--scsi--osst.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--scsi--osst.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -514,7 +514,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--misc--sisusbvga--sisusbvga.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--usb--misc--sisusbvga--sisusbvga.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -319,7 +319,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-challenges/model/main7-linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/main7-linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko_true-unreach-call.cil.out.env.c
@@ -1486,7 +1486,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/m0_drivers-net-myri10ge-myri10ge-ko--138_1a--7cb2521.i
+++ b/c/ldv-commit-tester/m0_drivers-net-myri10ge-myri10ge-ko--138_1a--7cb2521.i
@@ -12058,7 +12058,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-commit-tester/main0_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
+++ b/c/ldv-commit-tester/main0_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
@@ -12729,7 +12729,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main0_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
+++ b/c/ldv-commit-tester/main0_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
@@ -12940,7 +12940,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.i
+++ b/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.i
@@ -22770,7 +22770,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
+++ b/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
@@ -22780,7 +22780,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-commit-tester/main1_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
+++ b/c/ldv-commit-tester/main1_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
@@ -12729,7 +12729,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main1_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
+++ b/c/ldv-commit-tester/main1_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
@@ -12719,7 +12719,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main1_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
+++ b/c/ldv-commit-tester/main1_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
@@ -13672,7 +13672,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main1_sound-oss-sound-ko--32_7a--c4cb1dd.i
+++ b/c/ldv-commit-tester/main1_sound-oss-sound-ko--32_7a--c4cb1dd.i
@@ -13674,7 +13674,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main2_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
+++ b/c/ldv-commit-tester/main2_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
@@ -12729,7 +12729,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main2_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
+++ b/c/ldv-commit-tester/main2_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
@@ -12719,7 +12719,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main3_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
+++ b/c/ldv-commit-tester/main3_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
@@ -11279,7 +11279,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main3_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
+++ b/c/ldv-commit-tester/main3_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
@@ -11294,7 +11294,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main3_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
+++ b/c/ldv-commit-tester/main3_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.i
@@ -12826,7 +12826,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main3_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
+++ b/c/ldv-commit-tester/main3_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.i
@@ -12812,7 +12812,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-commit-tester/main4_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
+++ b/c/ldv-commit-tester/main4_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.i
@@ -11279,7 +11279,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main4_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
+++ b/c/ldv-commit-tester/main4_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.i
@@ -11294,7 +11294,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main7_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
+++ b/c/ldv-commit-tester/main7_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
@@ -13672,7 +13672,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main7_sound-oss-sound-ko--32_7a--c4cb1dd.i
+++ b/c/ldv-commit-tester/main7_sound-oss-sound-ko--32_7a--c4cb1dd.i
@@ -13674,7 +13674,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main8_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
+++ b/c/ldv-commit-tester/main8_sound-oss-sound-ko--32_7a--c4cb1dd-1.i
@@ -13672,7 +13672,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/main8_sound-oss-sound-ko--32_7a--c4cb1dd.i
+++ b/c/ldv-commit-tester/main8_sound-oss-sound-ko--32_7a--c4cb1dd.i
@@ -13674,7 +13674,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-net-myri10ge-myri10ge-ko--138_1a--7cb2521.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-net-myri10ge-myri10ge-ko--138_1a--7cb2521.env.c
@@ -1077,7 +1077,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.env.c
+++ b/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1.env.c
@@ -850,7 +850,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.env.c
+++ b/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.env.c
@@ -1176,7 +1176,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.env.c
+++ b/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa.env.c
@@ -862,7 +862,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
+++ b/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
@@ -1176,7 +1176,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
@@ -850,7 +850,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
@@ -850,7 +850,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
@@ -850,7 +850,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main2_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
@@ -850,7 +850,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.env.c
+++ b/c/ldv-commit-tester/model/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.env.c
@@ -905,7 +905,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.env.c
+++ b/c/ldv-commit-tester/model/main3_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.env.c
@@ -905,7 +905,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main3_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main3_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa-1_false-termination.env.c
@@ -854,7 +854,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main3_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
+++ b/c/ldv-commit-tester/model/main3_true-unreach-call_drivers-media-video-tlg2300-poseidon-ko--32_7a--4a349aa_false-termination.env.c
@@ -854,7 +854,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-commit-tester/model/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.env.c
+++ b/c/ldv-commit-tester/model/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef-1.env.c
@@ -905,7 +905,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.env.c
+++ b/c/ldv-commit-tester/model/main4_true-unreach-call_arch-x86-oprofile-oprofile-ko--131_1a--79db8ef.env.c
@@ -905,7 +905,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -430,7 +430,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
@@ -15418,7 +15418,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
@@ -28249,7 +28249,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-core--dvb-core.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--media--dvb-core--dvb-core.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
@@ -21040,7 +21040,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -24972,7 +24972,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -25072,7 +25072,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -25558,7 +25558,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -34973,7 +34973,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -24047,7 +24047,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -18447,7 +18447,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -10296,7 +10296,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--video--smscufx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--video--smscufx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7817,7 +7817,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int vmalloc_to_pfn(const void *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7270,7 +7270,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int vmalloc_to_pfn(const void *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
@@ -55091,7 +55091,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -55091,7 +55091,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.cil.out.i
@@ -31833,7 +31833,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -31833,7 +31833,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-sound--core--seq--snd-seq.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-sound--core--seq--snd-seq.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
@@ -12956,7 +12956,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.cil.out.i
@@ -14081,7 +14081,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-main.cil.out.i
@@ -30067,7 +30067,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--md--dm-snapshot.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--md--dm-snapshot.ko-main.cil.out.i
@@ -9541,7 +9541,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.cil.out.i
@@ -26070,7 +26070,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -26599,7 +26599,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--qlogic--qlge--qlge.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--qlogic--qlge--qlge.ko-main.cil.out.i
@@ -19128,7 +19128,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.cil.out.i
@@ -25537,7 +25537,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--video--udlfb.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--video--udlfb.ko-main.cil.out.i
@@ -7665,7 +7665,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int vmalloc_to_pfn(const void *arg0) {

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main4.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main4.cil.out.i
@@ -24481,7 +24481,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1.cil.out.i
@@ -36439,7 +36439,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0.cil.out.i
@@ -18251,7 +18251,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
@@ -1568,7 +1568,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
@@ -1261,7 +1261,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-32_7a-fs--ubifs--ubifs.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
@@ -1261,7 +1261,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-main.env.c
@@ -1745,7 +1745,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--gpu--drm--ttm--ttm.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
@@ -67,7 +67,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--dvb-core--dvb-core.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--dvb-core--dvb-core.ko-ldv_main5_sequence_infinite_withcheck_stateful.env.c
@@ -816,7 +816,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
@@ -830,7 +830,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -75,7 +75,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1305,7 +1305,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
@@ -1147,7 +1147,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
@@ -781,7 +781,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -997,7 +997,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -577,7 +577,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--smscufx.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--smscufx.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -493,7 +493,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_pfn

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--video--udlfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -532,7 +532,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_pfn

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.env.c
@@ -1389,7 +1389,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
@@ -1389,7 +1389,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-sound--core--seq--snd-seq.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-sound--core--seq--snd-seq.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
@@ -557,7 +557,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Skip function: vsnprintf

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--gpu--drm--ast--ast.ko-main.env.c
@@ -1263,7 +1263,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--md--dm-snapshot.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--md--dm-snapshot.ko-main.env.c
@@ -629,7 +629,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.env.c
@@ -75,7 +75,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1414,7 +1414,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--qlogic--qlge--qlge.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--qlogic--qlge--qlge.ko-main.env.c
@@ -1038,7 +1038,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--iwlwifi--iwlwifi.ko-main.env.c
@@ -1187,7 +1187,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--video--udlfb.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--video--udlfb.ko-main.env.c
@@ -576,7 +576,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_pfn

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main4_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--mtd--ubi--ubi.ko-ldv_main4_true-unreach-call.env.c
@@ -830,7 +830,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_true-unreach-call.env.c
@@ -1278,7 +1278,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-ldv_main0_true-unreach-call.env.c
@@ -986,7 +986,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __pci_register_driver

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
@@ -68,7 +68,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1274,7 +1274,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
@@ -68,7 +68,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1274,7 +1274,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __const_udelay(unsigned long arg0) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __register_chrdev

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
@@ -41,7 +41,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
@@ -32,7 +32,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __raw_spin_lock_init

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -48,7 +48,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-hid-hid-magicmouse.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-hid-hid-magicmouse.ko_true-unreach-call.cil.out.env.c
@@ -16,7 +16,7 @@ int __hid_register_driver(struct hid_driver *arg0, struct module *arg1, const ch
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: dev_err

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-gigaset-gigaset.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-gigaset-gigaset.ko_false-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
@@ -40,7 +40,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
@@ -32,7 +32,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __napi_schedule

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
@@ -39,7 +39,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-sis900.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-sis900.ko_true-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __const_udelay(unsigned long arg0) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __netif_schedule

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __netif_schedule

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-scsi-megaraid.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-scsi-megaraid.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __netif_schedule

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
@@ -40,7 +40,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-hid-usbhid-usbmouse.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-hid-usbhid-usbmouse.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-input-misc-keyspan_remote.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-input-misc-keyspan_remote.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: _dev_info

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __const_udelay(unsigned long arg0) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_sleep

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __wake_up

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-misc-c2port-core.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-misc-c2port-core.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __const_udelay(unsigned long arg0) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-mtd-sm_ftl.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-mtd-sm_ftl.ko_true-unreach-call.cil.out.env.c
@@ -84,7 +84,7 @@ unsigned int __kfifo_out_r(struct __kfifo *arg0, void *arg1, unsigned int arg2, 
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-net-can-usb-ems_usb.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-net-can-usb-ems_usb.ko_false-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __netif_schedule

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-scsi-dc395x.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-scsi-dc395x.ko_true-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __const_udelay(unsigned long arg0) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-staging-lirc-lirc_imon.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-staging-lirc-lirc_imon.ko_false-unreach-call.cil.out.env.c
@@ -50,7 +50,7 @@ unsigned int __kfifo_in_r(struct __kfifo *arg0, const void *arg1, unsigned int a
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-ir-usb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-ir-usb.ko_true-unreach-call.cil.out.env.c
@@ -25,7 +25,7 @@ unsigned int __kfifo_out_r(struct __kfifo *arg0, void *arg1, unsigned int arg2, 
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: _raw_spin_lock_irqsave

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.env.c
@@ -23,7 +23,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko_true-unreach-call.cil.out.env.c
@@ -15,7 +15,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: _dev_info

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.env.c
@@ -24,7 +24,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
@@ -16,7 +16,7 @@ int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __mutex_init

--- a/c/ldv-linux-3.0/module_get_put-drivers-atm-eni.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-atm-eni.ko.cil.out.i
@@ -10527,7 +10527,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const char *arg2) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-drbd-drbd.ko.cil.out-1.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-drbd-drbd.ko.cil.out-1.i
@@ -49086,7 +49086,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -49558,7 +49558,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-drbd-drbd.ko.cil.out-2.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-drbd-drbd.ko.cil.out-2.i
@@ -49054,7 +49054,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -49526,7 +49526,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-loop.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-loop.ko.cil.out.i
@@ -7306,7 +7306,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-paride-pt.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-paride-pt.ko.cil.out.i
@@ -4893,7 +4893,7 @@ void __const_udelay(unsigned long arg0) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int __register_chrdev(unsigned int arg0, unsigned int arg1, unsigned int arg2, const char *arg3, const struct file_operations *arg4) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-block-pktcdvd.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-block-pktcdvd.ko.cil.out.i
@@ -9819,7 +9819,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl.ko.cil.out.i
@@ -7938,7 +7938,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-gpu-drm-i915-i915.ko.cil.out.i
@@ -71524,7 +71524,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-hid-hid-magicmouse.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-hid-hid-magicmouse.ko.cil.out.i
@@ -4156,7 +4156,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-hwmon-it87.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-hwmon-it87.ko.cil.out.i
@@ -6872,7 +6872,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-isdn-gigaset-gigaset.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-isdn-gigaset-gigaset.ko.cil.out.i
@@ -16676,7 +16676,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
@@ -17786,7 +17786,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-atl1c-atl1c.ko.cil.out.i
@@ -13403,7 +13403,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __napi_schedule(struct napi_struct *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
@@ -10955,7 +10955,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-sis900.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-sis900.ko.cil.out.i
@@ -8809,7 +8809,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __netif_schedule(struct Qdisc *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-wan-farsync.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-wan-farsync.ko.cil.out.i
@@ -8047,7 +8047,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __netif_schedule(struct Qdisc *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-scsi-megaraid.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-scsi-megaraid.ko.cil.out.i
@@ -10978,7 +10978,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-staging-et131x-et131x.ko.cil.out.i
@@ -10811,7 +10811,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-tty-synclink_gt.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-tty-synclink_gt.ko.cil.out.i
@@ -14718,7 +14718,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __netif_schedule(struct Qdisc *arg0) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-usb-core-usbcore.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-usb-core-usbcore.ko.cil.out.i
@@ -32829,7 +32829,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-input-tablet-kbtab.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-input-tablet-kbtab.ko.cil.out.i
@@ -4193,7 +4193,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *dev_get_drvdata(const struct device *arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko.cil.out.i
@@ -10211,7 +10211,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-video-c-qcam.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-video-c-qcam.ko.cil.out.i
@@ -7248,7 +7248,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_sleep(const char *arg0, int arg1, int arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-video-msp3400.ko.cil.out.i
@@ -9592,7 +9592,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-misc-c2port-core.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-misc-c2port-core.ko.cil.out.i
@@ -5437,7 +5437,7 @@ void __const_udelay(unsigned long arg0) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-mtd-sm_ftl.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-mtd-sm_ftl.ko.cil.out.i
@@ -6554,7 +6554,7 @@ unsigned int __kfifo_out_r(struct __kfifo *arg0, void *arg1, unsigned int arg2, 
   return __VERIFIER_nondet_uint();
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-net-can-usb-ems_usb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-net-can-usb-ems_usb.ko.cil.out.i
@@ -6901,7 +6901,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __netif_schedule(struct Qdisc *arg0) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-scsi-dc395x.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-scsi-dc395x.ko.cil.out.i
@@ -12855,7 +12855,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-staging-lirc-lirc_imon.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-staging-lirc-lirc_imon.ko.cil.out.i
@@ -5561,7 +5561,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-misc-iowarrior.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-misc-iowarrior.ko.cil.out.i
@@ -5684,7 +5684,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-ir-usb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-ir-usb.ko.cil.out.i
@@ -5064,7 +5064,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _raw_spin_lock_irqsave(raw_spinlock_t *arg0) {

--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko.cil.out.i
@@ -7809,7 +7809,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko.cil.out.i
@@ -5437,7 +5437,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int _dev_info(const struct device *arg0, const char *arg1, ...) {

--- a/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-vhost-vhost_net.ko.cil.out.i
@@ -13906,7 +13906,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.0/usb_urb-drivers-video-arkfb.ko.cil.out.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-video-arkfb.ko.cil.out.i
@@ -7169,7 +7169,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
@@ -14391,7 +14391,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmap(struct page **arg0, unsigned int arg1, unsigned long arg2, pgprot_t arg3) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified.cil.out.i
@@ -14087,7 +14087,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmap(struct page **arg0, unsigned int arg1, unsigned long arg2, pgprot_t arg3) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-118_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-118_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
@@ -79270,7 +79270,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -25569,7 +25569,7 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
@@ -9926,7 +9926,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point.cil.out.i
@@ -13989,7 +13989,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_simplified_true-unreach-call.cil.out.env.c
@@ -669,7 +669,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmap

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -682,7 +682,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmap

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-118_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-118_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1979,7 +1979,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -853,6 +853,6 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -634,7 +634,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--tlg2300--poseidon.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -864,7 +864,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-media-pci-zoran-zr36067.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-media-pci-zoran-zr36067.cil.i
@@ -24753,7 +24753,7 @@ int videocodec_detach(struct videocodec *arg0) {
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -16633,7 +16633,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -23902,7 +23902,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -31894,7 +31894,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -36089,7 +36089,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -16914,7 +16914,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -24302,7 +24302,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sun-cassini.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sun-cassini.cil.i
@@ -17414,7 +17414,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -32173,7 +32173,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -36368,7 +36368,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-dvb-core-dvb-core.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-dvb-core-dvb-core.cil.i
@@ -27823,7 +27823,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-meye-meye.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-meye-meye.cil.i
@@ -13054,7 +13054,7 @@ void video_unregister_device(struct video_device *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_32(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-ngene-ngene.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-pci-ngene-ngene.cil.i
@@ -15600,7 +15600,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbevf-ixgbevf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbevf-ixgbevf.cil.i
@@ -21225,7 +21225,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -19522,7 +19522,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -25750,7 +25750,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -37964,7 +37964,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-media-pci-zoran-zr36067.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-media-pci-zoran-zr36067.cil.i
@@ -24957,7 +24957,7 @@ int videocodec_detach(struct videocodec *arg0) {
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igbvf-igbvf.cil.i
@@ -16795,7 +16795,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbevf-ixgbevf.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbevf-ixgbevf.cil.i
@@ -19507,7 +19507,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -24072,7 +24072,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-realtek-r8169.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-realtek-r8169.cil.i
@@ -25585,7 +25585,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_sleep(const char *arg0, int arg1, int arg2) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -32105,7 +32105,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -36300,7 +36300,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75249,7 +75249,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -75969,7 +75969,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -34887,7 +34887,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75534,7 +75534,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -76251,7 +76251,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -35166,7 +35166,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
@@ -19128,7 +19128,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -25369,7 +25369,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee.cil.i
@@ -32842,7 +32842,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -36762,7 +36762,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75576,7 +75576,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -76293,7 +76293,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-qlogic-qlge-qlge.cil.i
@@ -23691,7 +23691,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae.cil.i
@@ -35098,7 +35098,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
@@ -657,7 +657,7 @@ int videocodec_detach(struct videocodec *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
@@ -786,7 +786,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1045,7 +1045,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
@@ -608,6 +608,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -511,6 +511,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
@@ -778,7 +778,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1021,7 +1021,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sun-cassini_true-unreach-call.cil.env.c
@@ -884,7 +884,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
@@ -600,6 +600,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -503,6 +503,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-dvb-core-dvb-core_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-dvb-core-dvb-core_true-unreach-call.cil.env.c
@@ -926,7 +926,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-meye-meye_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-meye-meye_true-unreach-call.cil.env.c
@@ -560,7 +560,7 @@ void video_unregister_device(struct video_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_32

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-ngene-ngene_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-pci-ngene-ngene_true-unreach-call.cil.env.c
@@ -676,7 +676,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbevf-ixgbevf_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbevf-ixgbevf_true-unreach-call.cil.env.c
@@ -927,7 +927,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-myricom-myri10ge-myri10ge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-myricom-myri10ge-myri10ge_true-unreach-call.cil.env.c
@@ -1200,7 +1200,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1044,7 +1044,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -510,6 +510,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-media-pci-zoran-zr36067_true-unreach-call.cil.env.c
@@ -649,7 +649,7 @@ int videocodec_detach(struct videocodec *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igbvf-igbvf_true-unreach-call.cil.env.c
@@ -778,7 +778,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbevf-ixgbevf_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbevf-ixgbevf_true-unreach-call.cil.env.c
@@ -919,7 +919,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1037,7 +1037,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-realtek-r8169_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-realtek-r8169_true-unreach-call.cil.env.c
@@ -44,7 +44,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_sleep

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
@@ -600,6 +600,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -503,6 +503,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1936,7 +1936,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -511,6 +511,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1928,7 +1928,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -503,6 +503,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-myricom-myri10ge-myri10ge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-myricom-myri10ge-myri10ge_true-unreach-call.cil.env.c
@@ -1200,7 +1200,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1044,7 +1044,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8188ee-rtl8188ee_true-unreach-call.cil.env.c
@@ -607,6 +607,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -510,6 +510,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -118,7 +118,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1928,7 +1928,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-qlogic-qlge-qlge_true-unreach-call.cil.env.c
@@ -1037,7 +1037,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-rtlwifi-rtl8723ae-rtl8723ae_true-unreach-call.cil.env.c
@@ -503,6 +503,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
@@ -12363,7 +12363,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--igbvf--igbvf.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--igbvf--igbvf.ko-entry_point.cil.out.i
@@ -14280,7 +14280,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -19593,7 +19593,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtlwifi--rtl8723ae--rtl8723ae.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtlwifi--rtl8723ae--rtl8723ae.ko-entry_point.cil.out.i
@@ -27893,7 +27893,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -31220,7 +31220,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point.cil.out.i
@@ -11563,7 +11563,7 @@ void unregister_netdev(struct net_device *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point.cil.out.i
@@ -35507,7 +35507,7 @@ int unregister_netevent_notifier(struct notifier_block *arg0) {
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -26862,7 +26862,7 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--mtd--ubi--ubi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--mtd--ubi--ubi.ko-entry_point.cil.out.i
@@ -26522,7 +26522,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point.cil.out.i
@@ -26387,7 +26387,7 @@ void unregister_netdev(struct net_device *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void vxlan_get_rx_port(struct net_device *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
@@ -23657,7 +23657,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -24312,10 +24312,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void vxlan_get_rx_port(struct net_device *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point.cil.out.i
@@ -26505,7 +26505,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -19824,7 +19824,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--qla2xxx--tcm_qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--qla2xxx--tcm_qla2xxx.ko-entry_point.cil.out.i
@@ -15579,7 +15579,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--target--sbp--sbp_target.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--target--sbp--sbp_target.ko-entry_point.cil.out.i
@@ -12234,7 +12234,7 @@ void usleep_range(unsigned long arg0, unsigned long arg1) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_-test.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_-test.cil.out.i
@@ -27301,7 +27301,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
@@ -32323,7 +32323,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--pci--cs46xx--snd-cs46xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--pci--cs46xx--snd-cs46xx.ko-entry_point.cil.out.i
@@ -17231,7 +17231,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -35,7 +35,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--igbvf--igbvf.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--intel--igbvf--igbvf.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -725,7 +725,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -995,7 +995,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtlwifi--rtl8723ae--rtl8723ae.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--rtlwifi--rtl8723ae--rtl8723ae.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -803,6 +803,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1276,7 +1276,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--xen-netfront.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -764,7 +764,7 @@ void unregister_netdev(struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--infiniband--hw--nes--iw_nes.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1370,7 +1370,7 @@ int unregister_netevent_notifier(struct notifier_block *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -932,6 +932,6 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--mtd--ubi--ubi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--mtd--ubi--ubi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1122,7 +1122,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--emulex--benet--be2net.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1148,7 +1148,7 @@ void unregister_netdev(struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vxlan_get_rx_port

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -97,7 +97,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1737,7 +1737,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -1745,7 +1745,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vxlan_get_rx_port

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -860,7 +860,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1057,7 +1057,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--qla2xxx--tcm_qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--qla2xxx--tcm_qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -690,7 +690,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--target--sbp--sbp_target.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--target--sbp--sbp_target.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -528,7 +528,7 @@ void usleep_range(unsigned long arg0, unsigned long arg1) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call-test.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call-test.cil.out.env.c
@@ -65,7 +65,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1320,7 +1320,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--pci--cs46xx--snd-cs46xx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-sound--pci--cs46xx--snd-cs46xx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -946,7 +946,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1571,7 +1571,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7827,7 +7827,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4858,7 +4858,7 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3949,7 +3949,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3213,7 +3213,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -55471,7 +55471,7 @@ void vfree(void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(char *arg0, int arg1, char *arg2, ...) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.i
@@ -18458,7 +18458,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
@@ -30256,7 +30256,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
@@ -37092,7 +37092,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
@@ -35443,7 +35443,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.i
@@ -23881,7 +23881,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-usb-image-microtek.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-usb-image-microtek.cil.out.i
@@ -25388,7 +25388,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1468,7 +1468,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7930,7 +7930,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4773,7 +4773,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -4522,7 +4522,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int default_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void *arg3) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3902,7 +3902,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3247,7 +3247,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -12086,7 +12086,7 @@ int transport_send_check_condition_and_sense(struct se_cmd *arg0, u8 arg1, int a
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int autoremove_wake_function(wait_queue_t *arg0, unsigned int arg1, int arg2, void * arg3) {

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--devices--mtdram.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -55,6 +55,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -112,6 +112,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mtd--onenand--onenand_sim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -88,6 +88,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -53,6 +53,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -204,7 +204,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: default_wake_function

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--gpu--drm--vmwgfx--vmwgfx.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1455,7 +1455,7 @@ void vfree(void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-media-video-vivi.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-media-video-vivi.cil.out.env.c
@@ -236,7 +236,7 @@ void __invalid_creds(const struct cred *arg0, const char *arg1, unsigned arg2) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-mtd-chips-cfi_cmdset_0001.cil.out.env.c
@@ -237,7 +237,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
@@ -305,7 +305,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
@@ -352,7 +352,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
@@ -344,7 +344,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-staging-media-dt3155v4l-dt3155v4l.cil.out.env.c
@@ -271,7 +271,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-usb-image-microtek.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-usb-image-microtek.cil.out.env.c
@@ -279,7 +279,7 @@ void __irq_set_handler(unsigned int arg0, irq_flow_handler_t arg1, int arg2, con
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--mtdram_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -79,6 +79,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ftl.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -136,6 +136,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -202,7 +202,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: default_wake_function

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -236,7 +236,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: default_wake_function

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--onenand--onenand_sim_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -112,6 +112,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -75,6 +75,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -712,7 +712,7 @@ int transport_send_check_condition_and_sense(struct se_cmd *arg0, u8 arg1, int a
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: autoremove_wake_function

--- a/c/ldv-linux-3.7.3/main17_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.i
+++ b/c/ldv-linux-3.7.3/main17_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.i
@@ -26214,7 +26214,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-3.7.3/main3_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.i
+++ b/c/ldv-linux-3.7.3/main3_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.i
@@ -26214,7 +26214,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-3.7.3/model/main17_false-unreach-call_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.env.c
+++ b/c/ldv-linux-3.7.3/model/main17_false-unreach-call_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.env.c
@@ -1511,7 +1511,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-3.7.3/model/main3_false-unreach-call_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.env.c
+++ b/c/ldv-linux-3.7.3/model/main3_false-unreach-call_drivers-gpu-drm-vmwgfx-vmwgfx-ko--32_7a--linux-3.5.env.c
@@ -1511,7 +1511,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -16330,10 +16330,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point.cil.out.i
@@ -137775,7 +137775,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
@@ -15174,7 +15174,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point.cil.out.i
@@ -54867,7 +54867,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -55634,7 +55634,7 @@ unsigned long int vm_mmap(struct file *arg0, unsigned long arg1, unsigned long a
   return __VERIFIER_nondet_ulong();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_32(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
@@ -19743,7 +19743,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
@@ -29440,7 +29440,7 @@ struct net_device *vlan_dev_real_dev(const struct net_device *arg0) {
   return ldv_malloc(sizeof(struct net_device));
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--dvb-core--dvb-core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--dvb-core--dvb-core.ko-entry_point.cil.out.i
@@ -21357,7 +21357,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -27756,7 +27756,7 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-cxusb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-cxusb.ko-entry_point.cil.out.i
@@ -11275,7 +11275,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
@@ -15740,7 +15740,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmap(struct page **arg0, unsigned int arg1, unsigned long arg2, pgprot_t arg3) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
@@ -87214,7 +87214,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
@@ -33224,7 +33224,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __local_bh_disable_ip(unsigned long arg0, unsigned int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point.cil.out.i
@@ -22599,7 +22599,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -22938,7 +22938,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
@@ -45516,10 +45516,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -46197,7 +46197,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
@@ -44671,7 +44671,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -42075,7 +42075,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_fault(const char *arg0, int arg1) {
   return;
@@ -42718,7 +42718,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -58108,10 +58108,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -58962,7 +58962,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void vxlan_get_rx_port(struct net_device *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -31852,7 +31852,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -21014,7 +21014,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -61488,7 +61488,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -39879,7 +39879,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
@@ -68649,7 +68649,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
@@ -68356,7 +68356,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_sleep(const char *arg0, int arg1, int arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -34911,7 +34911,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -35400,7 +35400,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point.cil.out.i
@@ -50157,7 +50157,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--esas2r--esas2r.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--esas2r--esas2r.ko-entry_point.cil.out.i
@@ -19480,7 +19480,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--osst.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--osst.ko-entry_point.cil.out.i
@@ -12375,7 +12375,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
@@ -87573,7 +87573,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--sg.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--sg.ko-entry_point.cil.out.i
@@ -11647,7 +11647,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point.cil.out.i
@@ -14321,7 +14321,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_fault(const char *arg0, int arg1) {
   return;
@@ -14546,7 +14546,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmap(struct page **arg0, unsigned int arg1, unsigned long arg2, pgprot_t arg3) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -34260,7 +34260,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -34535,10 +34535,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -31183,7 +31183,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -31340,10 +31340,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rtl8723au--r8723au.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rtl8723au--r8723au.ko-entry_point.cil.out.i
@@ -79319,7 +79319,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rts5208--rts5208.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rts5208--rts5208.ko-entry_point.cil.out.i
@@ -37973,7 +37973,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
@@ -27015,7 +27015,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point.cil.out.i
@@ -13282,7 +13282,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -18535,10 +18535,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point.cil.out.i
@@ -9930,7 +9930,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point.cil.out.i
@@ -17058,7 +17058,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point.cil.out.i
@@ -14496,7 +14496,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_null(const char *arg0, const int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--qxl--qxl.ko-entry_point.cil.out.i
@@ -24109,7 +24109,7 @@ bool vgacon_text_force() {
   return __VERIFIER_nondet_bool();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point.cil.out.i
@@ -8170,7 +8170,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point.cil.out.i
@@ -23783,7 +23783,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point.cil.out.i
@@ -30607,7 +30607,7 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
   return __VERIFIER_nondet_int();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void free(void *);
 void kfree(void const *p) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.i
@@ -20690,7 +20690,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point.cil.out.i
@@ -17623,7 +17623,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmap(struct page **arg0, unsigned int arg1, unsigned long arg2, pgprot_t arg3) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--mtd--ubi--ubi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--mtd--ubi--ubi.ko-entry_point.cil.out.i
@@ -30892,7 +30892,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point.cil.out.i
@@ -89894,7 +89894,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point.cil.out.i
@@ -33692,7 +33692,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __local_bh_disable_ip(unsigned long arg0, unsigned int arg1) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
@@ -46762,10 +46762,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -47447,7 +47447,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
   return __VERIFIER_nondet_ushort();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -43156,7 +43156,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_fault(const char *arg0, int arg1) {
   return;
@@ -43809,7 +43809,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -59798,10 +59798,10 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -60662,7 +60662,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void vxlan_get_rx_port(struct net_device *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point.cil.out.i
@@ -30494,10 +30494,10 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -31236,10 +31236,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void vxlan_get_rx_port(struct net_device *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point.cil.out.i
@@ -34752,7 +34752,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point.cil.out.i
@@ -26980,7 +26980,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point.cil.out.i
@@ -21874,7 +21874,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -65388,7 +65388,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--usb--r8152.ko-entry_point.cil.out.i
@@ -14598,7 +14598,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -42443,7 +42443,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
@@ -71667,7 +71667,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point.cil.out.i
@@ -69836,7 +69836,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __might_sleep(const char *arg0, int arg1, int arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point.cil.out.i
@@ -36813,7 +36813,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -37306,7 +37306,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point.cil.out.i
@@ -52471,7 +52471,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point.cil.out.i
@@ -16741,7 +16741,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point.cil.out.i
@@ -66442,7 +66442,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--esas2r--esas2r.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--esas2r--esas2r.ko-entry_point.cil.out.i
@@ -20563,7 +20563,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--osst.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--osst.ko-entry_point.cil.out.i
@@ -13278,7 +13278,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point.cil.out.i
@@ -91348,7 +91348,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point.cil.out.i
@@ -43906,7 +43906,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point.cil.out.i
@@ -23138,7 +23138,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point.cil.out.i
@@ -36401,7 +36401,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -36680,10 +36680,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point.cil.out.i
@@ -32540,7 +32540,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -32701,10 +32701,10 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 int __VERIFIER_nondet_int(void);
 int wake_up_process(struct task_struct *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point.cil.out.i
@@ -32632,7 +32632,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -32982,10 +32982,10 @@ ssize_t vfs_write(struct file *arg0, const char *arg1, size_t arg2, loff_t *arg3
   return __VERIFIER_nondet_long();
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vmalloc_node(unsigned long arg0, int arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rtl8723au--r8723au.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rtl8723au--r8723au.ko-entry_point.cil.out.i
@@ -84134,7 +84134,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rts5208--rts5208.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rts5208--rts5208.ko-entry_point.cil.out.i
@@ -39452,7 +39452,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void *vzalloc(unsigned long arg0) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--fotg210-hcd.ko-entry_point.cil.out.i
@@ -12869,7 +12869,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--xhci-hcd.ko-entry_point.cil.out.i
@@ -28276,7 +28276,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--video--fbdev--udlfb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--video--fbdev--udlfb.ko-entry_point.cil.out.i
@@ -8613,7 +8613,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;
@@ -8836,7 +8836,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int vmalloc_to_pfn(const void *arg0) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point.cil.out.i
@@ -16434,7 +16434,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
   return;
 }
 void *__kmalloc(size_t arg0, gfp_t arg1) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -67,7 +67,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -75,7 +75,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--amd--amdgpu--amdgpu.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -81,7 +81,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--ast--ast.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1390,7 +1390,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--drm.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -95,7 +95,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -2065,7 +2065,7 @@ unsigned long int vm_mmap(struct file *arg0, unsigned long arg1, unsigned long a
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_32

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -399,7 +399,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--qxl--qxl.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--gpu--drm--qxl--qxl.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1876,7 +1876,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Skip function: vsnprintf

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1405,7 +1405,7 @@ struct net_device *vlan_dev_real_dev(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--dvb-core--dvb-core.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--dvb-core--dvb-core.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -892,7 +892,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -990,6 +990,6 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-cxusb.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-cxusb.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -232,6 +232,6 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -721,7 +721,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1940,7 +1940,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--broadcom--tg3.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -76,7 +76,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __local_bh_disable_ip

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--cavium--liquidio--liquidio.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -91,7 +91,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -962,7 +962,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -111,7 +111,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -119,7 +119,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1842,7 +1842,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1523,7 +1523,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -108,7 +108,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_fault
@@ -1727,7 +1727,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -109,7 +109,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -117,7 +117,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -2246,7 +2246,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vxlan_get_rx_port

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -101,7 +101,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1043,7 +1043,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -145,7 +145,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2952,7 +2952,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43--b43.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -107,7 +107,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -66,7 +66,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_sleep

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -68,7 +68,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1309,7 +1309,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1321,7 +1321,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--esas2r--esas2r.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--esas2r--esas2r.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -41,7 +41,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--osst.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--osst.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -541,7 +541,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2037,7 +2037,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--sg.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--scsi--sg.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -85,7 +85,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--comedi--comedi.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -65,7 +65,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_fault
@@ -661,7 +661,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -41,7 +41,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -759,7 +759,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -767,7 +767,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -175,7 +175,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -593,7 +593,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -601,7 +601,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rtl8723au--r8723au.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rtl8723au--r8723au.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -57,7 +57,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rts5208--rts5208.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--staging--rts5208--rts5208.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -615,7 +615,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -59,7 +59,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--block--rsxx--rsxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -953,7 +953,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -67,7 +67,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -75,7 +75,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--firewire--firewire-ohci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -50,7 +50,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--ast--ast.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1398,7 +1398,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -399,7 +399,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--mgag200--mgag200.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1187,7 +1187,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_null

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--qxl--qxl.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--qxl--qxl.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1884,7 +1884,7 @@ bool vgacon_text_force() {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Skip function: vsnprintf

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point_false-unreach-call-small-test.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point_false-unreach-call-small-test.cil.out.env.c
@@ -9,7 +9,7 @@
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--md--dm-raid.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -17,7 +17,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1028,7 +1028,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--cx231xx--cx231xx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -999,6 +999,6 @@ int videobuf_waiton(struct videobuf_queue *arg0, struct videobuf_buffer *arg1, i
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -58,7 +58,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--vmw_vmci--vmw_vmci.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -730,7 +730,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmap

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--mtd--ubi--ubi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--mtd--ubi--ubi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1186,7 +1186,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--bnx2x--bnx2x.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1949,7 +1949,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--broadcom--tg3.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -76,7 +76,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __local_bh_disable_ip

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -111,7 +111,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -119,7 +119,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1851,7 +1851,7 @@ u16 vlan_dev_vlan_id(const struct net_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -108,7 +108,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_fault
@@ -1752,7 +1752,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -109,7 +109,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -117,7 +117,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -2271,7 +2271,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vxlan_get_rx_port

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx4--mlx4_en.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -91,7 +91,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __kmalloc_node
@@ -99,7 +99,7 @@ void *__kmalloc(size_t arg0, gfp_t arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1941,7 +1941,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -1949,7 +1949,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vxlan_get_rx_port

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--mellanox--mlx5--core--mlx5_core.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -101,7 +101,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--neterion--vxge--vxge.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -874,7 +874,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--qlogic--qlge--qlge.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1052,7 +1052,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -145,7 +145,7 @@ void __iowrite64_copy(void *arg0, const void *arg1, size_t arg2) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--usb--r8152.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -25,7 +25,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2961,7 +2961,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43--b43.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -107,7 +107,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--brcm80211--brcmsmac--brcmsmac.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -66,7 +66,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __might_sleep

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--iwlwifi.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -68,7 +68,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -1318,7 +1318,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1346,7 +1346,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwl8k.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -49,7 +49,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--bfa--bfa.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1017,7 +1017,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--esas2r--esas2r.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--esas2r--esas2r.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -41,7 +41,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--osst.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--osst.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -550,7 +550,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla2xxx--qla2xxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -2046,7 +2046,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--qla4xxx--qla4xxx.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -1628,7 +1628,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--scsi--snic--snic.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -923,7 +923,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion_timeout

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--lnet--lnet.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -41,7 +41,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -768,7 +768,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -776,7 +776,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lnet--selftest--lnet_selftest.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -175,7 +175,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -602,7 +602,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -610,7 +610,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wake_up_process

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--libcfs--libcfs.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -80,7 +80,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc_node(size_t arg0, gfp_t arg1, int arg2) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -991,7 +991,7 @@ ssize_t vfs_write(struct file *arg0, const char *arg1, size_t arg2, loff_t *arg3
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_node
@@ -999,7 +999,7 @@ void *vmalloc(unsigned long arg0) {
 // with return type: (void)*
 void *vmalloc_node(unsigned long arg0, int arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Skip function: vsnprintf

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rtl8723au--r8723au.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rtl8723au--r8723au.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -57,7 +57,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rts5208--rts5208.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--rts5208--rts5208.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -624,7 +624,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vzalloc

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--fotg210-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--fotg210-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -676,7 +676,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -59,7 +59,7 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--video--fbdev--udlfb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--video--fbdev--udlfb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -35,7 +35,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add
@@ -613,7 +613,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_pfn

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-43_2a-drivers--crypto--qat--qat_common--intel_qat.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -67,7 +67,7 @@ void __init_work(struct work_struct *arg0, int arg1) {
 // with return type: (void)*
 void *__kmalloc(size_t arg0, gfp_t arg1) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: __list_add

--- a/c/ldv-validator-v0.6/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point.cil.out.i
@@ -13890,7 +13890,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point.cil.out.i
@@ -28703,7 +28703,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-validator-v0.6/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point.cil.out.i
@@ -14523,7 +14523,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-validator-v0.6/model/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -890,7 +890,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-validator-v0.6/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -1563,7 +1563,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-validator-v0.6/model/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -423,7 +423,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt

--- a/c/ldv-validator-v0.8/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -14746,7 +14746,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -17654,7 +17654,7 @@ void video_unregister_device(struct video_device *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 struct page *vmalloc_to_page(const void *arg0) {
   return ldv_malloc(sizeof(struct page));

--- a/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -30164,7 +30164,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void wait_for_completion(struct completion *arg0) {
   return;

--- a/c/ldv-validator-v0.8/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -14597,7 +14597,7 @@ void vfree(const void *arg0) {
   return;
 }
 void *vmalloc(unsigned long arg0) {
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 void warn_slowpath_fmt(const char *arg0, const int arg1, const char *arg2, ...) {
   return;

--- a/c/ldv-validator-v0.8/model/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-4a349aa-1-32_7a-drivers--media--video--tlg2300--poseidon.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -904,7 +904,7 @@ void videobuf_vmalloc_free(struct videobuf_buffer *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-validator-v0.8/model/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -425,7 +425,7 @@ void video_unregister_device(struct video_device *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: vmalloc_to_page

--- a/c/ldv-validator-v0.8/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -1569,7 +1569,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: wait_for_completion

--- a/c/ldv-validator-v0.8/model/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-torvalds-645ef9e-32_7a-sound--oss--sound.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -425,7 +425,7 @@ void vfree(const void *arg0) {
 // with return type: (void)*
 void *vmalloc(unsigned long arg0) {
   // Pointer type
-  return ldv_malloc(0UL);
+  return ldv_malloc(arg0);
 }
 
 // Function: warn_slowpath_fmt


### PR DESCRIPTION
In cddc3e65, (void *)external_alloc() was replaced by ldv_malloc(0UL).
This did include calls in __kmalloc and __kmalloc_node, where the size
actually is known.

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci] c/ldv-*/model/*.[ci]
do
perl -i -e \
  '$s = 0;
   while(<>) {
     if(/^void \*__kmalloc(_node)?\(size_t arg0, gfp_t arg1(, int arg2)?\) \{$/) {
       $s = 1;
     }
     elsif(/^void \*vmalloc(_node)?\(unsigned long arg0(, int arg1)?\) \{$/) {
       $s = 1;
     }
     elsif($s == 1) {
       if(/^  return ldv_malloc\(0UL\);/) {
         print "  return ldv_malloc(arg0);\n";
         next;
       }
       elsif(/^\}/) {
         $s = 2;
       }
     }
     print;
   }' \
  $f
done
```
