### PR TITLE
m0_drivers-media-radio-si4713-i2c: allocate var_group* objects

### DIFF
--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.c
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.c
@@ -6224,6 +6224,18 @@ int main(void)
   int tmp___1 ;
 
   {
+  var_group1 = ldv_malloc(sizeof(struct si4713_device));
+  var_group2 = ldv_malloc(sizeof(struct v4l2_queryctrl));
+  if(!var_group2)
+    return 0;
+  var_group2->id = __VERIFIER_nondet_int();
+  var_group3 = ldv_malloc(sizeof(struct v4l2_ext_controls));
+  if(!var_group3)
+    return 0;
+  var_group3->ctrl_class = __VERIFIER_nondet_int();
+  var_group3->controls = ldv_malloc(sizeof(struct v4l2_ext_control));
+  var_group6 = ldv_malloc(sizeof(struct v4l2_modulator));
+  var_group7 = ldv_malloc(sizeof(struct i2c_client));
   ldv_s_si4713_i2c_driver_i2c_driver = 0;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.i
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.i
@@ -6004,6 +6004,18 @@ int main(void)
   int tmp___0 ;
   int tmp___1 ;
   {
+  var_group1 = ldv_malloc(sizeof(struct si4713_device));
+  var_group2 = ldv_malloc(sizeof(struct v4l2_queryctrl));
+  if(!var_group2)
+    return 0;
+  var_group2->id = __VERIFIER_nondet_int();
+  var_group3 = ldv_malloc(sizeof(struct v4l2_ext_controls));
+  if(!var_group3)
+    return 0;
+  var_group3->ctrl_class = __VERIFIER_nondet_int();
+  var_group3->controls = ldv_malloc(sizeof(struct v4l2_ext_control));
+  var_group6 = ldv_malloc(sizeof(struct v4l2_modulator));
+  var_group7 = ldv_malloc(sizeof(struct i2c_client));
   ldv_s_si4713_i2c_driver_i2c_driver = 0;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
@@ -6224,6 +6224,18 @@ int main(void)
   int tmp___1 ;
 
   {
+  var_group1 = ldv_malloc(sizeof(struct si4713_device));
+  var_group2 = ldv_malloc(sizeof(struct v4l2_queryctrl));
+  if(!var_group2)
+    return 0;
+  var_group2->id = __VERIFIER_nondet_int();
+  var_group3 = ldv_malloc(sizeof(struct v4l2_ext_controls));
+  if(!var_group3)
+    return 0;
+  var_group3->ctrl_class = __VERIFIER_nondet_int();
+  var_group3->controls = ldv_malloc(sizeof(struct v4l2_ext_control));
+  var_group6 = ldv_malloc(sizeof(struct v4l2_modulator));
+  var_group7 = ldv_malloc(sizeof(struct i2c_client));
   ldv_s_si4713_i2c_driver_i2c_driver = 0;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
@@ -6004,6 +6004,18 @@ int main(void)
   int tmp___0 ;
   int tmp___1 ;
   {
+  var_group1 = ldv_malloc(sizeof(struct si4713_device));
+  var_group2 = ldv_malloc(sizeof(struct v4l2_queryctrl));
+  if(!var_group2)
+    return 0;
+  var_group2->id = __VERIFIER_nondet_int();
+  var_group3 = ldv_malloc(sizeof(struct v4l2_ext_controls));
+  if(!var_group3)
+    return 0;
+  var_group3->ctrl_class = __VERIFIER_nondet_int();
+  var_group3->controls = ldv_malloc(sizeof(struct v4l2_ext_control));
+  var_group6 = ldv_malloc(sizeof(struct v4l2_modulator));
+  var_group7 = ldv_malloc(sizeof(struct i2c_client));
   ldv_s_si4713_i2c_driver_i2c_driver = 0;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();


### PR DESCRIPTION
The initial counterexample produced by CBMC involved var_group1, which
is passed to si4713_s_ext_ctrls, si4713_write_econtrol_string,
si4713_set_rds_ps_name, where eventually a member of it is passed to
strncpy, and thus causing undefined behaviour.

Further code review of this task revealed further var_group* variables
that are being dereferenced in functions invoked from main. Where
necessary, members are non-deterministically initialised.
