### PR TITLE
linux-3.4-32_1-drivers--acpi--fan: allocate var_group* objects

### DIFF
--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3558,6 +3558,7 @@ void ldv_check_final_state(void) ;
 extern void ldv_initialize(void) ;
 extern int __VERIFIER_nondet_int(void) ;
 int LDV_IN_INTERRUPT  ;
+void *ldv_malloc(size_t) ;
 void main(void) 
 { struct acpi_device *var_group1 ;
   int var_acpi_fan_remove_4_p1 ;
@@ -3573,6 +3574,12 @@ void main(void)
 
   {
   {
+  var_group1 = ldv_malloc(sizeof(struct acpi_device));
+  if(!var_group1)
+    return;
+  var_group2 = ldv_malloc(sizeof(struct thermal_cooling_device));
+  if(!var_group2)
+    return;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();
   tmp___7 = acpi_fan_init();

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3523,6 +3523,7 @@ void ldv_check_final_state(void) ;
 extern void ldv_initialize(void) ;
 extern int __VERIFIER_nondet_int(void) ;
 int LDV_IN_INTERRUPT ;
+void *ldv_malloc(size_t) ;
 void main(void)
 { struct acpi_device *var_group1 ;
   int var_acpi_fan_remove_4_p1 ;
@@ -3537,6 +3538,12 @@ void main(void)
   int var_acpi_fan_suspend_5_p1_event11 ;
   {
   {
+  var_group1 = ldv_malloc(sizeof(struct acpi_device));
+  if(!var_group1)
+    return;
+  var_group2 = ldv_malloc(sizeof(struct thermal_cooling_device));
+  if(!var_group2)
+    return;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();
   tmp___7 = acpi_fan_init();


### PR DESCRIPTION
The initial counterexample produced by CBMC involved var_group1, which
is passed to acpi_fan_add, where eventually a member of it is passed to
strcpy, and thus causing undefined behaviour.

Further code review of this task revealed further var_group* variables
that are being dereferenced in functions invoked from main. Where
necessary, members are non-deterministically initialised.
