### PR TITLE
linux-3.4-32_1-drivers--platform--x86--topstar-laptop: allocate var_group1 object

### DIFF
--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3685,6 +3685,9 @@ void main(void)
 
   {
   {
+  var_group1 = ldv_malloc(sizeof(struct acpi_device));
+  if(!var_group1)
+    return;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();
   tmp___7 = topstar_laptop_init();

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3652,6 +3652,9 @@ void main(void)
   int tmp___9 ;
   {
   {
+  var_group1 = ldv_malloc(sizeof(struct acpi_device));
+  if(!var_group1)
+    return;
   LDV_IN_INTERRUPT = 1;
   ldv_initialize();
   tmp___7 = topstar_laptop_init();


### PR DESCRIPTION
The initial counterexample produced by CBMC involved var_group1, which
is passed to acpi_topstar_add, where eventually a member of it is passed to
strcpy, and thus causing undefined behaviour.
