### PR TITLE
linux-3.4-32_1-drivers--usb--serial--usb_debug: stack-allocate var_group2

### DIFF
--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3664,7 +3664,7 @@ int LDV_IN_INTERRUPT  ;
 void main(void) 
 { struct tty_struct *var_group1 ;
   int var_usb_debug_break_ctl_0_p1 ;
-  struct urb *var_group2 ;
+  struct urb var_group2 ;
   int tmp___7 ;
   int tmp___8 ;
 
@@ -3703,7 +3703,7 @@ void main(void)
         goto switch_break;
         case_1: /* CIL Label */ 
         {
-        usb_debug_process_read_urb(var_group2);
+        usb_debug_process_read_urb(&var_group2);
         }
         goto switch_break;
         switch_default: /* CIL Label */ 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3649,7 +3649,7 @@ int LDV_IN_INTERRUPT ;
 void main(void)
 { struct tty_struct *var_group1 ;
   int var_usb_debug_break_ctl_0_p1 ;
-  struct urb *var_group2 ;
+  struct urb var_group2 ;
   int tmp___7 ;
   int tmp___8 ;
   {
@@ -3686,7 +3686,7 @@ void main(void)
         goto switch_break;
         case_1:
         {
-        usb_debug_process_read_urb(var_group2);
+        usb_debug_process_read_urb(&var_group2);
         }
         goto switch_break;
         switch_default:


### PR DESCRIPTION
The initial counterexample produced by CBMC involved var_group2, which
is passed to usb_debug_process_read_urb, where the underlying
(non-allocated) storage is accessed via memcmp. Just allocate it as a
local object.
