### PR TITLE
LDV: stack-allocate var_group* as they are passed to memcmp

### DIFF
--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--staging--bcm--bcm_wimax.ko-ldv_main17_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--staging--bcm--bcm_wimax.ko-ldv_main17_sequence_infinite_withcheck_stateful.cil.out.c
@@ -26272,7 +26272,7 @@ void unregister_control_device_interface(struct bcm_mini_adapter *Adapter )
 int main(void) 
 { 
   struct inode *var_group1 ;
-  struct file *var_group2 ;
+  struct file var_group2 ;
   int res_bcm_char_open_0 ;
   char *var_bcm_char_read_2_p1 ;
   size_t var_bcm_char_read_2_p2 ;
@@ -26295,7 +26295,7 @@ int main(void)
   case 0: ;
   if (ldv_s_bcm_fops_file_operations == 0) {
     ldv_handler_precall();
-    res_bcm_char_open_0 = bcm_char_open(var_group1, var_group2);
+    res_bcm_char_open_0 = bcm_char_open(var_group1, &var_group2);
     ldv_check_return_value(res_bcm_char_open_0);
     if (res_bcm_char_open_0 != 0) {
       goto ldv_module_exit;
@@ -26310,7 +26310,7 @@ int main(void)
   case 1: ;
   if (ldv_s_bcm_fops_file_operations == 1) {
     ldv_handler_precall();
-    res_bcm_char_read_2 = bcm_char_read(var_group2, var_bcm_char_read_2_p1, var_bcm_char_read_2_p2,
+    res_bcm_char_read_2 = bcm_char_read(&var_group2, var_bcm_char_read_2_p1, var_bcm_char_read_2_p2,
                                         var_bcm_char_read_2_p3);
     ldv_check_return_value((int )res_bcm_char_read_2);
     if (res_bcm_char_read_2 < 0L) {
@@ -26326,7 +26326,7 @@ int main(void)
   case 2: ;
   if (ldv_s_bcm_fops_file_operations == 2) {
     ldv_handler_precall();
-    bcm_char_release(var_group1, var_group2);
+    bcm_char_release(var_group1, &var_group2);
     ldv_s_bcm_fops_file_operations = 0;
   } else {
 
@@ -26334,7 +26334,7 @@ int main(void)
   goto ldv_47101;
   case 3: 
   ldv_handler_precall();
-  bcm_char_ioctl(var_group2, var_bcm_char_ioctl_3_p1, var_bcm_char_ioctl_3_p2);
+  bcm_char_ioctl(&var_group2, var_bcm_char_ioctl_3_p1, var_bcm_char_ioctl_3_p2);
   goto ldv_47101;
   default: ;
   goto ldv_47101;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--staging--bcm--bcm_wimax.ko-ldv_main17_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--staging--bcm--bcm_wimax.ko-ldv_main17_sequence_infinite_withcheck_stateful.cil.out.i
@@ -23941,7 +23941,7 @@ void unregister_control_device_interface(struct bcm_mini_adapter *Adapter )
 int main(void)
 {
   struct inode *var_group1 ;
-  struct file *var_group2 ;
+  struct file var_group2 ;
   int res_bcm_char_open_0 ;
   char *var_bcm_char_read_2_p1 ;
   size_t var_bcm_char_read_2_p2 ;
@@ -23963,7 +23963,7 @@ int main(void)
   case 0: ;
   if (ldv_s_bcm_fops_file_operations == 0) {
     ldv_handler_precall();
-    res_bcm_char_open_0 = bcm_char_open(var_group1, var_group2);
+    res_bcm_char_open_0 = bcm_char_open(var_group1, &var_group2);
     ldv_check_return_value(res_bcm_char_open_0);
     if (res_bcm_char_open_0 != 0) {
       goto ldv_module_exit;
@@ -23976,7 +23976,7 @@ int main(void)
   case 1: ;
   if (ldv_s_bcm_fops_file_operations == 1) {
     ldv_handler_precall();
-    res_bcm_char_read_2 = bcm_char_read(var_group2, var_bcm_char_read_2_p1, var_bcm_char_read_2_p2,
+    res_bcm_char_read_2 = bcm_char_read(&var_group2, var_bcm_char_read_2_p1, var_bcm_char_read_2_p2,
                                         var_bcm_char_read_2_p3);
     ldv_check_return_value((int )res_bcm_char_read_2);
     if (res_bcm_char_read_2 < 0L) {
@@ -23990,14 +23990,14 @@ int main(void)
   case 2: ;
   if (ldv_s_bcm_fops_file_operations == 2) {
     ldv_handler_precall();
-    bcm_char_release(var_group1, var_group2);
+    bcm_char_release(var_group1, &var_group2);
     ldv_s_bcm_fops_file_operations = 0;
   } else {
   }
   goto ldv_47101;
   case 3:
   ldv_handler_precall();
-  bcm_char_ioctl(var_group2, var_bcm_char_ioctl_3_p1, var_bcm_char_ioctl_3_p2);
+  bcm_char_ioctl(&var_group2, var_bcm_char_ioctl_3_p1, var_bcm_char_ioctl_3_p2);
   goto ldv_47101;
   default: ;
   goto ldv_47101;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -7177,8 +7177,8 @@ extern int __VERIFIER_nondet_int(void) ;
 int LDV_IN_INTERRUPT  ;
 static int res_vp7045_usb_probe_6  ;
 void main(void) 
-{ struct dvb_usb_adapter *var_group1 ;
-  struct dvb_usb_device *var_group2 ;
+{ struct dvb_usb_adapter var_group1 ;
+  struct dvb_usb_device var_group2 ;
   int var_vp7045_power_ctrl_2_p1 ;
   u32 *var_vp7045_rc_query_3_p1 ;
   int *var_vp7045_rc_query_3_p2 ;
@@ -7233,17 +7233,17 @@ void main(void)
       if (0) {
         case_0: /* CIL Label */ 
         {
-        vp7045_frontend_attach(var_group1);
+        vp7045_frontend_attach(&var_group1);
         }
         goto switch_break;
         case_1: /* CIL Label */ 
         {
-        vp7045_power_ctrl(var_group2, var_vp7045_power_ctrl_2_p1);
+        vp7045_power_ctrl(&var_group2, var_vp7045_power_ctrl_2_p1);
         }
         goto switch_break;
         case_2: /* CIL Label */ 
         {
-        vp7045_rc_query(var_group2, var_vp7045_rc_query_3_p1, var_vp7045_rc_query_3_p2);
+        vp7045_rc_query(&var_group2, var_vp7045_rc_query_3_p1, var_vp7045_rc_query_3_p2);
         }
         goto switch_break;
         case_3: /* CIL Label */ 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7126,8 +7126,8 @@ extern int __VERIFIER_nondet_int(void) ;
 int LDV_IN_INTERRUPT ;
 static int res_vp7045_usb_probe_6 ;
 void main(void)
-{ struct dvb_usb_adapter *var_group1 ;
-  struct dvb_usb_device *var_group2 ;
+{ struct dvb_usb_adapter var_group1 ;
+  struct dvb_usb_device var_group2 ;
   int var_vp7045_power_ctrl_2_p1 ;
   u32 *var_vp7045_rc_query_3_p1 ;
   int *var_vp7045_rc_query_3_p2 ;
@@ -7179,17 +7179,17 @@ void main(void)
       if (0) {
         case_0:
         {
-        vp7045_frontend_attach(var_group1);
+        vp7045_frontend_attach(&var_group1);
         }
         goto switch_break;
         case_1:
         {
-        vp7045_power_ctrl(var_group2, var_vp7045_power_ctrl_2_p1);
+        vp7045_power_ctrl(&var_group2, var_vp7045_power_ctrl_2_p1);
         }
         goto switch_break;
         case_2:
         {
-        vp7045_rc_query(var_group2, var_vp7045_rc_query_3_p1, var_vp7045_rc_query_3_p2);
+        vp7045_rc_query(&var_group2, var_vp7045_rc_query_3_p1, var_vp7045_rc_query_3_p2);
         }
         goto switch_break;
         case_3:

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3540,7 +3540,7 @@ int LDV_IN_INTERRUPT  ;
 void main(void) 
 { struct tty_struct *var_group1 ;
   int var_usb_debug_break_ctl_0_p1 ;
-  struct urb *var_group2 ;
+  struct urb var_group2 ;
   int tmp ;
   int tmp___0 ;
 
@@ -3570,7 +3570,7 @@ void main(void)
       goto ldv_27713;
       case_1: /* CIL Label */ 
       {
-      usb_debug_process_read_urb(var_group2);
+      usb_debug_process_read_urb(&var_group2);
       }
       goto ldv_27713;
       switch_default: /* CIL Label */ ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -3530,7 +3530,7 @@ int LDV_IN_INTERRUPT ;
 void main(void)
 { struct tty_struct *var_group1 ;
   int var_usb_debug_break_ctl_0_p1 ;
-  struct urb *var_group2 ;
+  struct urb var_group2 ;
   int tmp ;
   int tmp___0 ;
   {
@@ -3559,7 +3559,7 @@ void main(void)
       goto ldv_27713;
       case_1:
       {
-      usb_debug_process_read_urb(var_group2);
+      usb_debug_process_read_urb(&var_group2);
       }
       goto ldv_27713;
       switch_default: ;


### PR DESCRIPTION
CBMC reports counterexamples as access to non-existent objects in memcmp
is undefined behaviour. Use local variables instead of pointers in main
to ensure the necessary var_group* objects exist.
