### PR TITLE
linux-43_1a-drivers--w1--slaves--w1_ds2431: allocate char buffer

### DIFF
--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1540,7 +1540,7 @@ void main(void)
 { struct file *var_group1 ;
   struct kobject *var_group2 ;
   struct bin_attribute *var_w1_f2d_read_bin_2_p2 ;
-  char *var_w1_f2d_read_bin_2_p3 ;
+  char var_w1_f2d_read_bin_2_p3[8U] ;
   loff_t var_w1_f2d_read_bin_2_p4 ;
   size_t var_w1_f2d_read_bin_2_p5 ;
   struct bin_attribute *var_w1_f2d_write_bin_4_p2 ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1506,7 +1506,7 @@ void main(void)
 { struct file *var_group1 ;
   struct kobject *var_group2 ;
   struct bin_attribute *var_w1_f2d_read_bin_2_p2 ;
-  char *var_w1_f2d_read_bin_2_p3 ;
+  char var_w1_f2d_read_bin_2_p3[8U] ;
   loff_t var_w1_f2d_read_bin_2_p4 ;
   size_t var_w1_f2d_read_bin_2_p5 ;
   struct bin_attribute *var_w1_f2d_write_bin_4_p2 ;


### PR DESCRIPTION
The character array are is used in a call to memcmp. CBMC produced
counterexamples for this benchmark as the use of memcmp with uninitialised
pointers is undefined behaviour.
