### PR TITLE
hwmon-ibmpex: stack-allocate objects passed to memcpy

### DIFF
--- a/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.c
+++ b/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.c
@@ -2406,8 +2406,8 @@ int main(void)
   int var_ibmpex_register_bmc_17_p0 ;
   struct device *var_group1 ;
   int var_ibmpex_bmc_gone_19_p0 ;
-  struct ipmi_recv_msg *var_group2 ;
-  void *var_ibmpex_msg_handler_20_p1 ;
+  struct ipmi_recv_msg var_group2 ;
+  struct ibmpex_bmc_data var_ibmpex_msg_handler_20_p1 ;
   int tmp ;
   int tmp___0 ;
   int tmp___1 ;
@@ -2436,7 +2436,7 @@ int main(void)
   goto ldv_17792;
   case 2: 
   ldv_handler_precall();
-  ibmpex_msg_handler(var_group2, var_ibmpex_msg_handler_20_p1);
+  ibmpex_msg_handler(&var_group2, &var_ibmpex_msg_handler_20_p1);
   goto ldv_17792;
   default: ;
   goto ldv_17792;

--- a/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.i
+++ b/c/ldv-commit-tester/m0_drivers-hwmon-ibmpex-ko--130_7a--d631323.i
@@ -2315,8 +2315,8 @@ int main(void)
   int var_ibmpex_register_bmc_17_p0 ;
   struct device *var_group1 ;
   int var_ibmpex_bmc_gone_19_p0 ;
-  struct ipmi_recv_msg *var_group2 ;
-  void *var_ibmpex_msg_handler_20_p1 ;
+  struct ipmi_recv_msg var_group2 ;
+  struct ibmpex_bmc_data var_ibmpex_msg_handler_20_p1 ;
   int tmp ;
   int tmp___0 ;
   int tmp___1 ;
@@ -2343,7 +2343,7 @@ int main(void)
   goto ldv_17792;
   case 2:
   ldv_handler_precall();
-  ibmpex_msg_handler(var_group2, var_ibmpex_msg_handler_20_p1);
+  ibmpex_msg_handler(&var_group2, &var_ibmpex_msg_handler_20_p1);
   goto ldv_17792;
   default: ;
   goto ldv_17792;


### PR DESCRIPTION
CBMC reported a counterexample involving use of invalid pointers being
passed to memcpy. Allocate the objects involved, and do so by just
declaring them as local objects in main.
