### PR TITLE
LDV: refine skb allocation stubs

### DIFF
--- a/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.i
+++ b/c/ldv-challenges/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0.cil.out.i
@@ -9388,7 +9388,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -57350,7 +57350,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1372() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47067,7 +47067,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74433,7 +74433,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -43478,7 +43478,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -57944,7 +57944,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1372() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47349,7 +47349,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74718,7 +74718,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-sfc-sfc.cil.i
@@ -93957,7 +93957,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -32786,7 +32786,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-b44.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-broadcom-b44.cil.i
@@ -14991,7 +14991,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -45748,7 +45748,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf.cil.i
@@ -23856,7 +23856,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -59208,7 +59208,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1372() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -48957,7 +48957,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -76629,7 +76629,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sfc-sfc.cil.i
@@ -95056,7 +95056,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -33900,7 +33900,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -42655,7 +42655,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf.cil.i
@@ -22163,7 +22163,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33441,7 +33441,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-e1000e-e1000e.cil.i
@@ -57525,7 +57525,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1372() {
   return;

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-igb-igb.cil.i
@@ -47252,7 +47252,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -74760,7 +74760,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-challenges/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sfc-sfc.cil.i
@@ -92027,7 +92027,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -35697,7 +35697,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -43136,7 +43136,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-chelsio-cxgb4-cxgb4.cil.i
@@ -38341,7 +38341,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -35343,7 +35343,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -77409,7 +77409,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-challenges/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -32990,7 +32990,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-challenges/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -19742,7 +19742,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {

--- a/c/ldv-challenges/model/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0_true-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-b44_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-broadcom-b44_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb4vf-cxgb4vf_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-e1000e-e1000e_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-igb-igb_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-chelsio-cxgb4-cxgb4_true-unreach-call.cil.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-challenges/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dynamic_pr_debug

--- a/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.i
+++ b/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.i
@@ -22317,7 +22317,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_empty(const unsigned long *arg0, int arg1) {

--- a/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
+++ b/c/ldv-commit-tester/main0_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.i
@@ -22327,7 +22327,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_empty(const unsigned long *arg0, int arg1) {

--- a/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.env.c
+++ b/c/ldv-commit-tester/model/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_empty

--- a/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
+++ b/c/ldv-commit-tester/model/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_empty

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--infiniband--hw--cxgb3--iw_cxgb3.ko-ldv_main6_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--infiniband--hw--cxgb3--iw_cxgb3.ko-ldv_main6_sequence_infinite_withcheck_stateful.cil.out.i
@@ -23466,7 +23466,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--isdn--hisax--hisax.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--isdn--hisax--hisax.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -59302,7 +59302,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--isdn--i4l--isdn.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--isdn--i4l--isdn.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -27004,7 +27004,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -25049,7 +25049,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -34525,7 +34525,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -41622,7 +41622,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.i
@@ -41622,7 +41622,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.i
@@ -41622,7 +41622,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -26856,7 +26856,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.cil.out.i
@@ -31296,7 +31296,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct net_device *__dev_get_by_name(struct net *arg0, const char *arg1) {
   return ldv_malloc(sizeof(struct net_device));

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.i
@@ -31296,7 +31296,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct net_device *__dev_get_by_name(struct net *arg0, const char *arg1) {
   return ldv_malloc(sizeof(struct net_device));

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--infiniband--hw-cxgb3--iw_cxgb3.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--infiniband--hw-cxgb3--iw_cxgb3.ko-main.cil.out.i
@@ -23689,7 +23689,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.cil.out.i
@@ -8170,7 +8170,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.cil.out.i
@@ -26047,7 +26047,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.i
+++ b/c/ldv-consumption/32_7a_cilled_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.cil.out.i
@@ -30317,7 +30317,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1.cil.out.i
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1.cil.out.i
@@ -35940,7 +35940,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--infiniband--hw--cxgb3--iw_cxgb3.ko-ldv_main6_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--infiniband--hw--cxgb3--iw_cxgb3.ko-ldv_main6_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--isdn--hisax--hisax.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--isdn--hisax--hisax.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--isdn--i4l--isdn.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--isdn--i4l--isdn.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -15,7 +15,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
@@ -24,7 +24,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main2_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--sfc--sfc.ko-ldv_main3_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main13_sequence_infinite_withcheck_stateful.env.c
@@ -15,7 +15,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dev_get_by_name

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-net--netfilter--ipvs--ip_vs.ko-ldv_main1_sequence_infinite_withcheck_stateful.env.c
@@ -15,7 +15,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dev_get_by_name

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--infiniband--hw-cxgb3--iw_cxgb3.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--infiniband--hw-cxgb3--iw_cxgb3.ko-main.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--isdn--mISDN--l1oip.ko-main.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __init_waitqueue_head

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-main.env.c
@@ -15,7 +15,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--ipw2x00--ipw2200.ko-main.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_true-unreach-call.env.c
+++ b/c/ldv-consumption/model/linux-3.8-rc1-32_7a-drivers--net--ethernet--intel--e1000e--e1000e.ko-ldv_main1_true-unreach-call.env.c
@@ -24,7 +24,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dynamic_pr_debug

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-gigaset-gigaset.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-gigaset-gigaset.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __init_waitqueue_head

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-isdn-mISDN-mISDN_core.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __class_register

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __class_create

--- a/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-bluetooth-btmrvl.ko.cil.out.i
@@ -7928,7 +7928,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-isdn-gigaset-gigaset.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-isdn-gigaset-gigaset.ko.cil.out.i
@@ -16670,7 +16670,13 @@ void gigaset_isdn_unregdrv(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1) {
   return;

--- a/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-isdn-mISDN-mISDN_core.ko.cil.out.i
@@ -17773,7 +17773,13 @@ void ldv_module_put_3(struct module *ldv_func_arg1 )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __class_register(struct class *arg0, struct lock_class_key *arg1) {

--- a/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
+++ b/c/ldv-linux-3.0/module_get_put-drivers-net-ppp_generic.ko.cil.out.i
@@ -10943,7 +10943,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct class *__class_create(struct module *arg0, const char *arg1, struct lock_class_key *arg2) {
   return ldv_malloc(sizeof(struct class));

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point.cil.out.i
@@ -11318,7 +11318,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __dynamic_netdev_dbg(struct _ddebug *arg0, const struct net_device *arg1, const char *arg2, ...) {

--- a/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.12-rc1/model/linux-3.12-rc1.tar.xz-144_2a-drivers--staging--gdm72xx--gdmwm.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dynamic_netdev_dbg

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -42495,7 +42495,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33275,7 +33275,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-ethernet-sfc-sfc.cil.i
@@ -91837,7 +91837,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-fddi-skfp-skfp.cil.i
@@ -24139,7 +24139,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -31997,7 +31997,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-drivers-clk1_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -32504,7 +32504,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-radio-wl128x-fm_drv.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-media-radio-wl128x-fm_drv.cil.i
@@ -12108,7 +12108,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33559,7 +33559,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-fddi-skfp-skfp.cil.i
@@ -24421,7 +24421,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-mutex_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -34273,7 +34273,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-radio-wl128x-fm_drv.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-media-radio-wl128x-fm_drv.cil.i
@@ -12555,7 +12555,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -35404,7 +35404,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-micrel-ksz884x.cil.i
@@ -17513,7 +17513,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -13254,7 +13254,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -25544,7 +25544,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-hippi-rrunner.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-hippi-rrunner.cil.i
@@ -12810,7 +12810,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -34486,7 +34486,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-ethernet-sun-sunhme.cil.i
@@ -11898,7 +11898,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-fddi-skfp-skfp.cil.i
@@ -24298,7 +24298,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -32147,7 +32147,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_complex_emg_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -32663,7 +32663,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -39883,7 +39883,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33214,7 +33214,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75213,7 +75213,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-fddi-skfp-skfp.cil.i
@@ -23754,7 +23754,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-drivers-clk1_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -31087,7 +31087,13 @@ void ldv_assert_linux_drivers_clk1__more_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -40866,7 +40866,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33498,7 +33498,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75498,7 +75498,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-fddi-skfp-skfp.cil.i
@@ -24036,7 +24036,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-mutex_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -31872,7 +31872,13 @@ void ldv_assert_linux_kernel_locking_mutex__one_thread_locked_at_exit(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-sun-sunhme.cil.i
@@ -12768,7 +12768,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-fddi-skfp-skfp.cil.i
@@ -25159,7 +25159,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -33801,7 +33801,13 @@ void ldv_assert_linux_kernel_locking_spinlock__one_thread_locked_at_exit(int exp
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-chelsio-cxgb3-cxgb3.cil.i
@@ -40043,7 +40043,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-e1000-e1000.cil.i
@@ -33380,7 +33380,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_4117() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-intel-ixgbe-ixgbe.cil.i
@@ -75540,7 +75540,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, int arg1) {

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-sun-sunhme.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-ethernet-sun-sunhme.cil.i
@@ -11412,7 +11412,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-fddi-skfp-skfp.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-fddi-skfp-skfp.cil.i
@@ -23913,7 +23913,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-b43legacy-b43legacy.cil.i
@@ -31237,7 +31237,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_1820() {
   return;

--- a/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2200.cil.i
+++ b/c/ldv-linux-3.14/linux-3.14_linux-usb-dev_drivers-net-wireless-ipw2x00-ipw2200.cil.i
@@ -31978,7 +31978,13 @@ void ldv_assert_linux_usb_dev__unincremented_counter_decrement(int expr )
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-ethernet-sfc-sfc_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-drivers-clk1__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-radio-wl128x-fm_drv_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-radio-wl128x-fm_drv_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-radio-wl128x-fm_drv_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-radio-wl128x-fm_drv_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-micrel-ksz884x_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-micrel-ksz884x_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-hippi-rrunner_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-hippi-rrunner_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__complex_emg__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-drivers-clk1__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-mutex__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-kernel-locking-spinlock__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-chelsio-cxgb3-cxgb3_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-e1000-e1000_true-unreach-call.cil.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-intel-ixgbe-ixgbe_true-unreach-call.cil.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-ethernet-sun-sunhme_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-fddi-skfp-skfp_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-b43legacy-b43legacy_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_1820

--- a/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
+++ b/c/ldv-linux-3.14/model/linux-3.14__linux-usb-dev__drivers-net-wireless-ipw2x00-ipw2200_true-unreach-call.cil.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--arc-rawmode.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--arc-rawmode.ko-entry_point.cil.out.c
@@ -5741,6 +5741,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--arc-rawmode.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--arc-rawmode.ko-entry_point.cil.out.i
@@ -5680,6 +5680,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point.cil.out.c
@@ -5878,6 +5878,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point.cil.out.i
@@ -5803,6 +5803,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point.cil.out.c
@@ -5790,6 +5790,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point.cil.out.i
@@ -5727,6 +5727,11 @@ __inline static struct sk_buff *ldv_alloc_skb_14(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_hsi.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_hsi.ko-entry_point.cil.out.c
@@ -8669,6 +8669,11 @@ __inline static struct sk_buff *ldv_alloc_skb_21(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_hsi.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--caif--caif_hsi.ko-entry_point.cil.out.i
@@ -8310,6 +8310,11 @@ __inline static struct sk_buff *ldv_alloc_skb_21(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1201.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1201.ko-entry_point.cil.out.c
@@ -6010,6 +6010,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1201.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1201.ko-entry_point.cil.out.i
@@ -5917,6 +5917,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ieee802154--mrf24j40.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ieee802154--mrf24j40.ko-entry_point.cil.out.c
@@ -7411,6 +7411,11 @@ __inline static struct sk_buff *ldv_alloc_skb_13(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ieee802154--mrf24j40.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ieee802154--mrf24j40.ko-entry_point.cil.out.i
@@ -7209,6 +7209,11 @@ __inline static struct sk_buff *ldv_alloc_skb_13(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.c
@@ -11500,6 +11500,11 @@ __inline static struct sk_buff *ldv_alloc_skb_16(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ppp--ppp_generic.ko-entry_point.cil.out.i
@@ -10958,6 +10958,11 @@ __inline static struct sk_buff *ldv_alloc_skb_16(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--team--team.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--team--team.ko-entry_point.cil.out.c
@@ -13411,6 +13411,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--team--team.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--team--team.ko-entry_point.cil.out.i
@@ -12618,6 +12618,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cdc_ncm.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cdc_ncm.ko-entry_point.cil.out.c
@@ -10251,6 +10251,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cdc_ncm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cdc_ncm.ko-entry_point.cil.out.i
@@ -9811,6 +9811,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.c
@@ -6283,6 +6283,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--cx82310_eth.ko-entry_point.cil.out.i
@@ -6183,6 +6183,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.c
@@ -6230,6 +6230,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--usb--gl620a.ko-entry_point.cil.out.i
@@ -6139,6 +6139,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--virtio_net.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--virtio_net.ko-entry_point.cil.out.c
@@ -10364,6 +10364,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--virtio_net.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--virtio_net.ko-entry_point.cil.out.i
@@ -9865,6 +9865,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.c
@@ -9316,6 +9316,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--ath9k--ath9k_htc.ko-entry_point.cil.out.i
@@ -9212,6 +9212,11 @@ __inline static struct sk_buff *ldv_alloc_skb_12(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--wcn36xx--wcn36xx.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--wcn36xx--wcn36xx.ko-entry_point.cil.out.c
@@ -10950,6 +10950,11 @@ __inline static struct sk_buff *ldv_alloc_skb_27(unsigned int size , gfp_t prior
 
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--wcn36xx--wcn36xx.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wireless--ath--wcn36xx--wcn36xx.ko-entry_point.cil.out.i
@@ -10535,6 +10535,11 @@ __inline static struct sk_buff *ldv_alloc_skb_27(unsigned int size , gfp_t prior
   struct sk_buff *tmp ;
   {
   tmp = ldv_skb_alloc();
+  if(tmp)
+  {
+    tmp->head = ldv_malloc(size);
+    tmp->data = tmp->head;
+  }
   return (tmp);
 }
 }

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point.cil.out.i
@@ -11679,7 +11679,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point.cil.out.i
@@ -11705,7 +11705,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point.cil.out.i
@@ -7926,7 +7926,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point.cil.out.i
@@ -9506,7 +9506,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point.cil.out.i
@@ -13798,7 +13798,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct class *__class_create(struct module *arg0, const char *arg1, struct lock_class_key *arg2) {
   return ldv_malloc(sizeof(struct class));

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point.cil.out.i
@@ -11326,7 +11326,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point.cil.out.i
@@ -4424,7 +4424,13 @@ int ldv_spin_trylock(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...) {

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point.cil.out.i
@@ -31818,7 +31818,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point.cil.out.i
@@ -15197,7 +15197,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--broadcom--b44.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -11,7 +11,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_bitvector_linux-3.16-rc1.tar.xz-43_2a-net--atm--lec.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--bluetooth--btmrvl_sdio.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--hardware--mISDN--hfcsusb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_return_address

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--isdn--mISDN--mISDN_dsp.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_alloca

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--net--ethernet--sun--sungem.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -11,7 +11,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--nfc--st21nfca--st21nfca_i2c.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __dynamic_dev_dbg

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-fs--dlm--dlm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -22,7 +22,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.16-rc1/model/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-net--core--pktgen.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -29,7 +29,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_alloca

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5458,7 +5458,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void arcnet_unregister_proto(struct ArcProto *arg0) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5665,7 +5665,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void arcnet_unregister_proto(struct ArcProto *arg0) {
   return;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -7714,7 +7714,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void arcnet_unregister_proto(struct ArcProto *arg0) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--net--wireless--p54--p54usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--net--wireless--p54--p54usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -11173,7 +11173,13 @@ void ___udelay(unsigned long arg0) {
   return;
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __init_waitqueue_head(wait_queue_head_t *arg0, char *arg1, struct lock_class_key *arg2) {
   return;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--scsi--libfc--libfc.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_const_ok_linux-32_1-drivers--scsi--libfc--libfc.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.i
@@ -57223,7 +57223,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-phy-dp83640.cil.out.i
@@ -30146,7 +30146,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_and(unsigned long *arg0, const unsigned long *arg1, const unsigned long *arg2, int arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-mwl8k.cil.out.i
@@ -36965,7 +36965,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_and(unsigned long *arg0, const unsigned long *arg1, const unsigned long *arg2, int arg3) {

--- a/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
+++ b/c/ldv-linux-3.4-simple/32_7_cpp_single_drivers-net-wireless-p54-p54usb.cil.out.i
@@ -35319,7 +35319,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_and(unsigned long *arg0, const unsigned long *arg1, const unsigned long *arg2, int arg3) {

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5205,7 +5205,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, gfp_t arg2) {
   struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -5405,7 +5405,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, gfp_t arg2) {
   struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -6990,7 +6990,13 @@ void *ldv_malloc(size_t size )
   return malloc(size);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, gfp_t arg2) {
   struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: arcnet_unregister_proto

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: arcnet_unregister_proto

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: arcnet_unregister_proto

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--net--wireless--p54--p54usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--net--wireless--p54--p54usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -15,7 +15,13 @@ void ___udelay(unsigned long arg0) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __init_waitqueue_head

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--scsi--libfc--libfc.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--scsi--libfc--libfc.ko-ldv_main5_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -15,7 +15,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-phy-dp83640.cil.out.env.c
@@ -32,7 +32,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_and

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-mwl8k.cil.out.env.c
@@ -32,7 +32,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_and

--- a/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cpp_false-unreach-call_single_drivers-net-wireless-p54-p54usb.cil.out.env.c
@@ -32,7 +32,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_and

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __netdev_alloc_skb

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __netdev_alloc_skb

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -7,7 +7,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __netdev_alloc_skb

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point.cil.out.i
@@ -7615,7 +7615,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point.cil.out.i
@@ -28896,7 +28896,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
@@ -34096,7 +34096,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
@@ -45481,7 +45481,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -27101,7 +27101,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point.cil.out.i
@@ -44070,7 +44070,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -42041,7 +42041,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, unsigned int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -58076,7 +58076,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, unsigned int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -61441,7 +61441,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
   return;
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--fddi--skfp--skfp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--fddi--skfp--skfp.ko-entry_point.cil.out.i
@@ -19795,7 +19795,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point.cil.out.i
@@ -13825,7 +13825,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __compiletime_assert_402() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -38732,7 +38732,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point.cil.out.i
@@ -35092,7 +35092,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -28797,7 +28797,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
   return;
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -32566,7 +32566,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point.cil.out.i
@@ -45976,7 +45976,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--xen-netback--xen-netback.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--xen-netback--xen-netback.ko-entry_point.cil.out.i
@@ -13301,7 +13301,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, unsigned int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--isdn--i4l--isdn.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--isdn--i4l--isdn.ko-entry_point.cil.out.i
@@ -29912,7 +29912,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point.cil.out.i
@@ -35871,7 +35871,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point.cil.out.i
@@ -46727,7 +46727,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point.cil.out.i
@@ -27773,7 +27773,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
   return __VERIFIER_nondet_int();
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point.cil.out.i
@@ -43122,7 +43122,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, unsigned int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point.cil.out.i
@@ -59766,7 +59766,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
   return ldv_malloc(0UL);
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_weight(const unsigned long *arg0, unsigned int arg1) {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point.cil.out.i
@@ -65341,7 +65341,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
   return;
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--fddi--skfp--skfp.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--fddi--skfp--skfp.ko-entry_point.cil.out.i
@@ -21353,7 +21353,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point.cil.out.i
@@ -41292,7 +41292,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __copy_from_user_overflow() {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point.cil.out.i
@@ -38238,7 +38238,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point.cil.out.i
@@ -30471,7 +30471,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
   return;
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point.cil.out.i
@@ -34441,7 +34441,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point.cil.out.i
@@ -49045,7 +49045,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point.cil.out.i
@@ -27969,7 +27969,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
   return ldv_malloc(sizeof(struct page));
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 struct workqueue_struct *__alloc_workqueue_key(const char *arg0, unsigned int arg1, int arg2, struct lock_class_key *arg3, const char *arg4, ...) {
   return ldv_malloc(0UL);

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--atm--atmtcp.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -11,7 +11,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--infiniband--hw--cxgb4--iw_cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -18,7 +18,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--e1000e--e1000e.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--fddi--skfp--skfp.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--fddi--skfp--skfp.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--team--team.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __compiletime_assert_402

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--xen-netback--xen-netback.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-08_1a-drivers--net--xen-netback--xen-netback.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -26,7 +26,13 @@ int ___ratelimit(struct ratelimit_state *arg0, const char *arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--isdn--i4l--isdn.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--isdn--i4l--isdn.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb3--cxgb3.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--chelsio--cxgb4--cxgb4.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--e1000--e1000.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -18,7 +18,13 @@ int ___pskb_trim(struct sk_buff *arg0, unsigned int arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--igb--igb.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--ixgbe--ixgbe.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -25,7 +25,13 @@ void *__alloc_percpu(size_t arg0, size_t arg1) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_weight

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--sfc--sfc.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--fddi--skfp--skfp.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--fddi--skfp--skfp.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--ath9k--ath9k.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __copy_from_user_overflow

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ath--wil6210--wil6210.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--b43legacy--b43legacy.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@ void ___might_sleep(const char *arg0, int arg1, int arg2) {
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--ipw2x00--ipw2200.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __const_udelay

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--iwlwifi--dvm--iwldvm.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-4.2-rc1/model/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mediatek--mt7601u--mt7601u.ko-entry_point_true-unreach-call.cil.out.env.c
@@ -26,7 +26,13 @@ struct page *__alloc_pages_nodemask(gfp_t arg0, unsigned int arg1, struct zoneli
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-validator-v0.6/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point.cil.out.i
@@ -38165,7 +38165,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point.cil.out.i
@@ -28082,7 +28082,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_empty(const unsigned long *arg0, int arg1) {

--- a/c/ldv-validator-v0.6/model/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -17,7 +17,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-validator-v0.6/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.6/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.env.c
@@ -19,7 +19,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_empty

--- a/c/ldv-validator-v0.8/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -38767,7 +38767,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 void __const_udelay(unsigned long arg0) {
   return;

--- a/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -29537,7 +29537,13 @@ void ldv_check_final_state(void)
 }
 }
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 int __VERIFIER_nondet_int(void);
 int __bitmap_empty(const unsigned long *arg0, int arg1) {

--- a/c/ldv-validator-v0.8/model/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-1575714-1-150_1a-drivers--net--wireless--b43--b43.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Skip function: __builtin_prefetch

--- a/c/ldv-validator-v0.8/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
+++ b/c/ldv-validator-v0.8/model/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.env.c
@@ -9,7 +9,13 @@
 // with return type: (struct sk_buff)*
 struct sk_buff *__alloc_skb(unsigned int arg0, gfp_t arg1, int arg2, int arg3) {
   // Pointer type
-  return ldv_malloc(sizeof(struct sk_buff));
+  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));
+  if(skb) {
+    skb->head = ldv_malloc(arg0);
+    skb->data = skb->head;
+    skb->tail = 0;
+  }
+  return skb;
 }
 
 // Function: __bitmap_empty


### PR DESCRIPTION
The original implementation of alloc_skb also initialises several fields
of the allocated memory. Not doing so led to spurious results, e.g.,
CBMC running on
ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point.cil.out.i.

The proposed implementation initialises some fields; a further
refinement may be necessary.

The changes were done using the following command:
```
for f in c/ldv-*/*.[ci] c/ldv-*/model/*.[ci]
do
perl -i -e \
  '$s = 0;
   while(<>) {
     if(/^struct sk_buff \*__alloc_skb\(unsigned int arg0, gfp_t arg1, int arg2, int arg3\) \{\s*$/) {
       $s = 1;
     }
     elsif(/^__inline static struct sk_buff \*ldv_alloc_skb_\d+\(unsigned int size , gfp_t priority \)\s*$/) {
       $s = 2;
     }
     elsif($s == 1) {
       if(/^  return ldv_malloc\(sizeof\(struct sk_buff\)\);/) {
         print "  struct sk_buff *skb = ldv_malloc(sizeof(struct sk_buff));\n";
         print "  if(skb) {\n";
         print "    skb->head = ldv_malloc(arg0);\n";
         print "    skb->data = skb->head;\n";
         print "    skb->tail = 0;\n";
         print "  }\n";
         print "  return skb;\n";
         $s = 0;
         next;
       }
       elsif(/^\}/) {
         $s = 0;
       }
     }
     elsif($s == 2) {
       if(/^  tmp = ldv_skb_alloc\(\);/) {
         print;
         print "  if(tmp)\n";
         print "  {\n";
         print "    tmp->head = ldv_malloc(size);\n";
         print "    tmp->data = tmp->head;\n";
         print "  }\n";
         $s = 0;
         next;
       }
       elsif(/^\}/) {
         $s = 0;
       }
     }
     print;
   }' \
  $f
done
```
