### PR TITLE
Test travis build trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: type = pull_request
+
 language: c
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# trigger build for only pull requests.
 if: type = pull_request
 
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-if: type = pull_request
-
 language: c
 env:
   matrix:


### PR DESCRIPTION
Travis build is triggered multiple times. The intention is that it is triggered only on a pull request.

Made changes to the `.travis.yml` file. Now testing that the travis build should trigger.

At the moment not to be considered for pulling into master.