### PR TITLE
Fix undefined behaviour on c/loops/insertion_sort

### DIFF
--- a/c/loops/insertion_sort-1.c
+++ b/c/loops/insertion_sort-1.c
@@ -7,6 +7,7 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 unsigned int __VERIFIER_nondet_uint();
+extern int __VERIFIER_nondet_int();
 int main() {
    unsigned int SIZE=__VERIFIER_nondet_uint();
    int i, j, k, key;

--- a/c/loops/insertion_sort-1.c
+++ b/c/loops/insertion_sort-1.c
@@ -10,7 +10,9 @@ unsigned int __VERIFIER_nondet_uint();
 int main() {
    unsigned int SIZE=__VERIFIER_nondet_uint();
    int i, j, k, key;
-   int v[SIZE];   
+   int v[SIZE];
+   for (j=0;j<SIZE;j++)
+      v[j] = __VERIFIER_nondet_int();  
    for (j=1;j<SIZE;j++) {	  
       key = v[j];
       i = j - 1;

--- a/c/loops/insertion_sort-2.c
+++ b/c/loops/insertion_sort-2.c
@@ -7,6 +7,7 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 unsigned int __VERIFIER_nondet_uint();
+extern int __VERIFIER_nondet_int();
 int main() {
    unsigned int SIZE=__VERIFIER_nondet_uint();
    int i, j, k, key;

--- a/c/loops/insertion_sort-2.c
+++ b/c/loops/insertion_sort-2.c
@@ -11,6 +11,8 @@ int main() {
    unsigned int SIZE=__VERIFIER_nondet_uint();
    int i, j, k, key;
    int v[SIZE];   
+   for (j=0;j<SIZE;j++)
+      v[j] = __VERIFIER_nondet_int();
    for (j=1;j<SIZE;j++) {	  
       key = v[j];
       i = j - 1;


### PR DESCRIPTION
Value of v is used before being initialized causing an UB

```
int v[SIZE];   
for (j=1;j<SIZE;j++) {	  
   key = v[j];
```

My suggestion is to initialize the array with nondeterministic values.