### PR TITLE
20051113-1: Remove undefined behavior in C90-style structhack

### DIFF
--- a/c/memsafety/20051113-1.c
+++ b/c/memsafety/20051113-1.c
@@ -31,7 +31,7 @@ typedef union
 typedef struct
 {
   int Count;
-  Union List[1];
+  Union List[];
 } __attribute__((packed)) Struct3;
 
 unsigned long long Sum (Struct3 *instrs) __attribute__((noinline));

--- a/c/memsafety/20051113-1.i
+++ b/c/memsafety/20051113-1.i
@@ -535,7 +535,7 @@ typedef union
 typedef struct
 {
   int Count;
-  Union List[1];
+  Union List[];
 } __attribute__((packed)) Struct3;
 unsigned long long Sum (Struct3 *instrs) __attribute__((noinline));
 unsigned long long Sum (Struct3 *instrs)


### PR DESCRIPTION
As per the C99 standard 6.5.6p8:

"If both the pointer operand and the result point to elements of the same array
object, or one past the last element of the array object, the evaluation shall
not produce an overflow; otherwise, the behavior is undefined."

This is only allowed for flexible array member, i.e. declared as zero-sized.
