### PR TITLE
New tasks from Witnesses journal paper

### DIFF
--- a/c/loop-invariants/Makefile
+++ b/c/loop-invariants/Makefile
@@ -1,3 +1,6 @@
 LEVEL := ../
 
+CLANG_WARNINGS := \
+	-Wno-error=tautological-constant-out-of-range-compare \
+
 include $(LEVEL)/Makefile.config

--- a/c/loop-invariants/README
+++ b/c/loop-invariants/README
@@ -1,15 +1,2 @@
 Hand-crafted examples from PDR study by Dirk Beyer and Matthias Dangl;
 contributed by the CPAchecker team.
-
-Unfortunately, the file names do not match those from the article
-because the CI checks of the repository require a very specific naming
-where properties are encoded into the file name.
-The following table relates the file names from the paper to those in this repository:
-
-bin-suffix-5.c | bin-suffix-5_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-const.c        | const_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-eq1.c          | eq1_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-eq2.c          | eq2_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-even.c         | even_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-mod4.c         | mod4_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c
-odd.c          | odd_true-unreach-call_true-valid-memsafety_true-no-overflow_false-termination.c

--- a/c/loop-invariants/README
+++ b/c/loop-invariants/README
@@ -1,2 +1,16 @@
-Hand-crafted examples from PDR study by Dirk Beyer and Matthias Dangl;
-contributed by the CPAchecker team.
+These tasks are contributed by the CPAchecker team.
+
+The following hand-crafted examples are taken from the PDR study by Dirk Beyer and Matthias Dangl [1]:
+bin-suffix-5.c
+const.c
+eq1.c
+eq2.c
+even.c
+mod4.c
+odd.c
+
+The following hand-crafted examples are taken from the journal paper on witnesses by Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig:
+linear-inequality-inv-a.c
+linear-inequality-inv-b.c
+
+[1] D. Beyer and M. Dangl. Software Verification with PDR: Implementation and Empirical Evaluation of the State of the Art, August 2019. http://arxiv.org/abs/1908.06271.

--- a/c/loop-invariants/linear-inequality-inv-a.c
+++ b/c/loop-invariants/linear-inequality-inv-a.c
@@ -1,0 +1,25 @@
+void reach_error(){}
+extern unsigned char __VERIFIER_nondet_uchar(void);
+int main() {
+  unsigned char n = __VERIFIER_nondet_uchar();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned char v = 0;
+  unsigned int  s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uchar();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 65025) {
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/c/loop-invariants/linear-inequality-inv-a.yml
+++ b/c/loop-invariants/linear-inequality-inv-a.yml
@@ -1,0 +1,13 @@
+format_version: '1.0'
+
+input_files: 'linear-inequality-inv-a.c'
+
+properties:
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true

--- a/c/loop-invariants/linear-inequality-inv-b.c
+++ b/c/loop-invariants/linear-inequality-inv-b.c
@@ -1,0 +1,25 @@
+void reach_error(){}
+extern unsigned char __VERIFIER_nondet_uchar(void);
+int main() {
+  unsigned char n = __VERIFIER_nondet_uchar();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned char v = 0;
+  unsigned char s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uchar();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 65025) {
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/c/loop-invariants/linear-inequality-inv-b.yml
+++ b/c/loop-invariants/linear-inequality-inv-b.yml
@@ -1,0 +1,13 @@
+format_version: '1.0'
+
+input_files: 'linear-inequality-inv-b.c'
+
+properties:
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+  - property_file: ../properties/unreach-call.prp
+    expected_verdict: false
+  - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true


### PR DESCRIPTION
- Fixes outdates (and now wrong) documentation of tasks
- Add two new tasks

Reasoning for unchecked bullet points:
- Not sure if two tasks warrent creating a new directory. If this is preferable, please suggest a directory name.
- No preprocessing required.

Please review this pull request carefully; while I have contributed in the past, there seem to have been some changes to how things are done (yml, reach_error(), ...). I tried to comply but may have missed something.

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
