### PR TITLE
array-memsafety/reverse_array_alloca_unsafe: Fix typo in function name

### DIFF
--- a/c/array-memsafety/reverse_array_alloca_unsafe.c
+++ b/c/array-memsafety/reverse_array_alloca_unsafe.c
@@ -12,7 +12,7 @@ int main() {
 	
 	for(int i = 0; i < length; i++)
 	{
-	  arr[i] = __VERIFIER_nondet_nt();
+	  arr[i] = __VERIFIER_nondet_int();
   }
 
   // make sure the marker occurs only once


### PR DESCRIPTION
Change `__VERIFIER_nondet_nt` to `__VERIFIER_nondet_int`.