### PR TITLE
Replace VERIFIER_error with reach_error in check.py

### DIFF
--- a/c/check.py
+++ b/c/check.py
@@ -178,7 +178,10 @@ class Checks(object):
         attrs = [getattr(self, a) for a in dir(self)]
         tests = [a for a in attrs if callable(a) and a.__name__.startswith('check')]
         for test in tests:
-            test()
+            try:
+                test()
+            except CheckFailed:
+                self._errors = True
         if not self._quiet and not (self._errors or self._warnings) and self.name:
             logging.info("%s: OK", self.name)
         if self._errors:

--- a/c/check.py
+++ b/c/check.py
@@ -211,6 +211,7 @@ class DirectoryChecks(Checks):
         self.all_patterns = all_patterns
 
     def run(self):
+        ok = True
         try:
             super(DirectoryChecks, self).run()
         except CheckFailed:

--- a/c/check.py
+++ b/c/check.py
@@ -417,7 +417,7 @@ class PropertiesChecks(Checks):
                         "has expected undefined behavior but also a verdict for some other property")
 
         if violates("unreach-call") and fulfills("valid-memcleanup"):
-            # __VERIFIER_error() aborts the program, and if there is still any
+            # calling the error function aborts the program, and if there is still any
             # allocated memory this would violate memcleanup.
             # We think this is probable (though not guaranteed), so we issue a warning.
             self.error("has reachable error location but claims to have no memory leaks (this is not necessarily wrong but should be checked)")
@@ -450,11 +450,11 @@ class InputFileChecks(FileChecks):
         if not "unreach-call" in dict(self.prop_and_verdict):
             return
         if not self.contained_in_category:
-            # Some such files have calls to __VERIFIER_error inside #include
+            # Some such files have calls to reach_error inside #include
             return
 
-        if not any("__VERIFIER_error()" in line for line in self.lines if not "extern" in line):
-            self.error("has property unreach-call, but does not call __VERIFIER_error")
+        if not any("reach_error" in line for line in self.lines if not "void reach_error" in line):
+            self.error("has property unreach-call, but does not call reach_error")
 
     def check_no_include_or_define(self):
         if not self.contained_in_category:

--- a/c/check.py
+++ b/c/check.py
@@ -158,6 +158,10 @@ KNOWN_GLOBAL_PROBLEMS = [
     ]
 
 
+class CheckFailed(Exception):
+    pass
+
+
 class Checks(object):
     """Collections of checks that should be implemented in methods named "check*" in subclasses."""
 
@@ -177,7 +181,8 @@ class Checks(object):
             test()
         if not self._quiet and not (self._errors or self._warnings) and self.name:
             logging.info("%s: OK", self.name)
-        return not self._errors
+        if self._errors:
+            raise CheckFailed()
 
     def error(self, msg, *args):
         """Mark the current check as failed."""
@@ -206,17 +211,25 @@ class DirectoryChecks(Checks):
         self.all_patterns = all_patterns
 
     def run(self):
-        ok = super(DirectoryChecks, self).run()
+        try:
+            super(DirectoryChecks, self).run()
+        except CheckFailed:
+            ok = False
 
         for entry in self.content:
             if BENCHMARK_PATTERN.match(entry):
                 dir_and_name = os.path.join(self.name, entry)
-                ok &= TaskDefinitionFileChecks(
-                    path=os.path.join(self.path, entry),
-                    name=dir_and_name,
-                    contained_in_category=self.all_patterns.match(dir_and_name)
-                    ).run()
-        return ok
+                try:
+                    TaskDefinitionFileChecks(
+                        path=os.path.join(self.path, entry),
+                        name=dir_and_name,
+                        contained_in_category=self.all_patterns.match(dir_and_name)
+                        ).run()
+                except CheckFailed:
+                    ok = False
+
+        if not ok:
+            raise CheckFailed()
 
     def check_has_benchmarks(self):
         for entry in self.content:
@@ -299,17 +312,23 @@ class TaskDefinitionFileChecks(FileChecks):
             return None
         input_files = self._get_input_files()
         properties_and_verdicts = self._get_properties()
+        ok = True
         for f in input_files:
             f_path = os.path.join(self.directory, f)
             if not os.path.exists(f_path):
                 self.error("references inaccessible file: " + f_path)
             else:
-                InputFileChecks(
-                    path=f_path,
-                    name=f_path,
-                    contained_in_category=self.contained_in_category,
-                    properties_and_verdicts=properties_and_verdicts,
-                ).run()
+                try:
+                    InputFileChecks(
+                        path=f_path,
+                        name=f_path,
+                        contained_in_category=self.contained_in_category,
+                        properties_and_verdicts=properties_and_verdicts,
+                    ).run()
+                except CheckFailed:
+                    ok = False
+        if not ok:
+            raise CheckFailed()
 
     def check_properties(self):
         prop_and_verdict = self._get_properties()
@@ -318,6 +337,7 @@ class TaskDefinitionFileChecks(FileChecks):
             contained_in_category=self.contained_in_category,
             name=self.name,
         ).run()
+
 
     def _get_input_files(self) -> list:
         if 'input_files' not in self.content:
@@ -614,18 +634,24 @@ def main():
     for entry in entries:
         path = os.path.join(main_directory, entry)
         if not (entry[0] == '.' or entry == "bin" or entry.endswith("-todo")):
-            if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
-                ok &= DirectoryChecks(path, all_patterns, entry).run()
-            elif entry.endswith(".set"):
-                check = SetFileChecks(path, entry)
-                all_matched_files.update(check.matched_files)
-                ok &= check.run()
-            else:
-                logging.debug("%s: skipped", entry)
+            try:
+                if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
+                    DirectoryChecks(path, all_patterns, entry).run()
+                elif entry.endswith(".set"):
+                    check = SetFileChecks(path, entry)
+                    all_matched_files.update(check.matched_files)
+                    check.run()
+                else:
+                    logging.debug("%s: skipped", entry)
+            except CheckFailed:
+                ok = False
         else:
             logging.debug("%s: skipped", entry)
 
-    ok &= GlobalChecks(all_matched_files, main_directory).run()
+    try:
+        GlobalChecks(all_matched_files, main_directory).run()
+    except CheckFailed:
+        ok = False
 
     if not ok:
         sys.exit(1)


### PR DESCRIPTION
Error-function `__VERIFIER_error` has been replaced with a defined method `reach_error` in e3f389a61aea5fc43e1d8380ef15cd405269f887.
Currently, the `check.py` script still checks for calls to function `__VERIFIER_error`, and thus creates a large set of false alarms.
To avoid this, apply the rename to `check.py`, as well.