### PR TITLE
Speed-up check.py through multiprocessing

### DIFF
--- a/c/check.py
+++ b/c/check.py
@@ -624,19 +624,25 @@ def _check_known_errors_consistent(main_dir):
 
 def _check_benchmark_entry(entry, main_directory, all_patterns):
     path = os.path.join(main_directory, entry)
-    try:
-        if not (entry[0] == "." or entry == "bin" or entry.endswith("-todo")):
-            if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
-                check = DirectoryChecks(path, all_patterns, entry)
-                return check.run(), set()
-            elif entry.endswith(".set"):
+    if not (entry[0] == "." or entry == "bin" or entry.endswith("-todo")):
+        if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
+            try:
+                DirectoryChecks(path, all_patterns, entry).run()
+            except CheckFailed:
+                return False, set()
+            else:
+                return True, set()
+
+        elif entry.endswith(".set"):
+            try:
                 check = SetFileChecks(path, entry)
-                return check.run(), check.matched_files
-        logging.debug("%s: skipped", entry)
-    except CheckFailed:
-        return False, set()
-    else:
-        return True, set()
+                check.run()
+            except CheckFailed:
+                return False, check.matched_files
+            else:
+                return True, set()
+    logging.debug("%s: skipped", entry)
+    return True, set()
 
 
 def main(num_processes):

--- a/c/check.py
+++ b/c/check.py
@@ -622,25 +622,32 @@ def _check_known_errors_consistent(main_dir):
         assert os.path.exists(path), "Whitelisted file doesn't exist: %s" % path
 
 
+def _run_directory_checks(directory, all_patterns, entry):
+    try:
+        DirectoryChecks(directory, all_patterns, entry).run()
+    except CheckFailed:
+        return False, set()
+    else:
+        return True, set()
+
+
+def _run_set_file_checks(set_file, all_patterns, entry):
+    try:
+        check = SetFileChecks(set_file, entry)
+        check.run()
+    except CheckFailed:
+        return False, check.matched_files
+    else:
+        return True, check.matched_files
+
+
 def _check_benchmark_entry(entry, main_directory, all_patterns):
     path = os.path.join(main_directory, entry)
     if not (entry[0] == "." or entry == "bin" or entry.endswith("-todo")):
         if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
-            try:
-                DirectoryChecks(path, all_patterns, entry).run()
-            except CheckFailed:
-                return False, set()
-            else:
-                return True, set()
-
+            return _run_directory_checks(path, all_patterns, entry)
         elif entry.endswith(".set"):
-            try:
-                check = SetFileChecks(path, entry)
-                check.run()
-            except CheckFailed:
-                return False, check.matched_files
-            else:
-                return True, set()
+            return _run_set_file_checks(path, all_patterns, entry)
     logging.debug("%s: skipped", entry)
     return True, set()
 

--- a/c/check.py
+++ b/c/check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import collections
 import fnmatch
 import functools
@@ -638,7 +639,7 @@ def _check_benchmark_entry(entry, main_directory, all_patterns):
         return True, set()
 
 
-def main():
+def main(num_processes):
     if not yaml:
         logging.warning("Missing python-yaml, not all checks can be executed")
 
@@ -655,7 +656,7 @@ def main():
     check_func = functools.partial(
         _check_benchmark_entry, main_directory=main_directory, all_patterns=all_patterns
     )
-    with multiprocessing.Pool(4) as p:
+    with multiprocessing.Pool(num_processes) as p:
         check_results, matched_file_sets = zip(*p.map(check_func, entries))
     ok = all(check_results)
     all_matched_files = set(f for f_set in matched_file_sets for f in f_set)
@@ -669,5 +670,20 @@ def main():
         sys.exit(1)
     sys.exit(0)
 
+
+def _parse_arguments(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=4,
+        help="Number of concurrent processes to use",
+    )
+
+    return parser.parse_args(args)
+
+
 if __name__ == "__main__":
-    main()
+    args = _parse_arguments(sys.argv[1:])
+
+    main(num_processes=args.num_processes)

--- a/c/check.py
+++ b/c/check.py
@@ -177,7 +177,7 @@ class Checks(object):
         self._warnings = False
 
     def run(self):
-        """Run all checks of this instance and return success status."""
+        """Run all checks of this instance. Raise an exception if any check fails."""
         attrs = [getattr(self, a) for a in dir(self)]
         tests = [a for a in attrs if callable(a) and a.__name__.startswith('check')]
         for test in tests:

--- a/c/check.py
+++ b/c/check.py
@@ -8,6 +8,8 @@ import logging
 import os
 import re
 import sys
+from multiprocessing import Pool
+from functools import partial
 
 from typing import List, Tuple
 
@@ -619,6 +621,23 @@ def _check_known_errors_consistent(main_dir):
         assert os.path.exists(path), "Whitelisted file doesn't exist: %s" % path
 
 
+def _check_benchmark_entry(entry, main_directory, all_patterns):
+    path = os.path.join(main_directory, entry)
+    try:
+        if not (entry[0] == "." or entry == "bin" or entry.endswith("-todo")):
+            if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
+                check = DirectoryChecks(path, all_patterns, entry)
+                return check.run(), set()
+            elif entry.endswith(".set"):
+                check = SetFileChecks(path, entry)
+                return check.run(), check.matched_files
+        logging.debug("%s: skipped", entry)
+    except CheckFailed:
+        return False, set()
+    else:
+        return True, set()
+
+
 def main():
     if not yaml:
         logging.warning("Missing python-yaml, not all checks can be executed")
@@ -632,25 +651,14 @@ def main():
         for entry in entries if entry.endswith(".set")
         for pattern in read_set_file(os.path.join(main_directory, entry)))
     all_patterns = re.compile("^(" + "|".join(all_patterns_re) + ")$")
-    all_matched_files = set()
 
-    ok = True
-    for entry in entries:
-        path = os.path.join(main_directory, entry)
-        if not (entry[0] == '.' or entry == "bin" or entry.endswith("-todo")):
-            try:
-                if os.path.isdir(path) and not entry in IGNORED_DIRECTORIES:
-                    DirectoryChecks(path, all_patterns, entry).run()
-                elif entry.endswith(".set"):
-                    check = SetFileChecks(path, entry)
-                    all_matched_files.update(check.matched_files)
-                    check.run()
-                else:
-                    logging.debug("%s: skipped", entry)
-            except CheckFailed:
-                ok = False
-        else:
-            logging.debug("%s: skipped", entry)
+    check_func = partial(
+        _check_benchmark_entry, main_directory=main_directory, all_patterns=all_patterns
+    )
+    with Pool(4) as p:
+        check_results, matched_file_sets = zip(*p.map(check_func, entries))
+    ok = all(check_results)
+    all_matched_files = set(f for f_set in matched_file_sets for f in f_set)
 
     try:
         GlobalChecks(all_matched_files, main_directory).run()

--- a/c/check.py
+++ b/c/check.py
@@ -2,14 +2,14 @@
 
 import collections
 import fnmatch
+import functools
 import glob
 import hashlib
 import logging
+import multiprocessing
 import os
 import re
 import sys
-from multiprocessing import Pool
-from functools import partial
 
 from typing import List, Tuple
 
@@ -652,10 +652,10 @@ def main():
         for pattern in read_set_file(os.path.join(main_directory, entry)))
     all_patterns = re.compile("^(" + "|".join(all_patterns_re) + ")$")
 
-    check_func = partial(
+    check_func = functools.partial(
         _check_benchmark_entry, main_directory=main_directory, all_patterns=all_patterns
     )
-    with Pool(4) as p:
+    with multiprocessing.Pool(4) as p:
         check_results, matched_file_sets = zip(*p.map(check_func, entries))
     ok = all(check_results)
     all_matched_files = set(f for f_set in matched_file_sets for f in f_set)


### PR DESCRIPTION
Currently, check.py takes quite some time to execute.
This PR halves the walltime of check.py by introducing multiprocessing.

This halves the walltime required by check.py on my machine.
(measured with runexec, walltime drops from ~100s to ~50s)

I understand that entries are sorted in the main method before checking. I assume this was done to get log results in the same order.
Deterministic output will of course be gone with this PR, but IMHO, the script's output is detailed enough to be fully understandable, even if not in lexicographic order.

In this PR, multiprocessing is applied on the directory level.
I also tested multiprocessing on the file level within each directory (within method `DirectoryChecks#run`).
This did not yield any further improvement on walltime.

Even if multiprocessing is not wanted, I hope this PR serves as documentation for the potential yield.