### PR TITLE
Change parameter of asserts/assumes from int to _Bool #1087

### DIFF
--- a/c/aws-c-common/Makefile
+++ b/c/aws-c-common/Makefile
@@ -3,7 +3,6 @@ LEVEL := ../
 CC.Arch := 64
 
 COMMON_WARNINGS := \
-	-Wno-error=int-conversion \
 	-Wno-error=address \
 	-Wno-error=incompatible-pointer-types
 

--- a/c/aws-c-common/aws_add_size_checked_harness.i
+++ b/c/aws-c-common/aws_add_size_checked_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_add_size_saturating_harness.i
+++ b/c/aws-c-common/aws_add_size_saturating_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_eq_harness.i
+++ b/c/aws-c-common/aws_array_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_back_harness.i
+++ b/c/aws-c-common/aws_array_list_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_capacity_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_clean_up_harness.i
+++ b/c/aws-c-common/aws_array_list_clean_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_clear_harness.i
+++ b/c/aws-c-common/aws_array_list_clear_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_comparator_string_harness.i
+++ b/c/aws-c-common/aws_array_list_comparator_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_copy_harness.i
+++ b/c/aws-c-common/aws_array_list_copy_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
+++ b/c/aws-c-common/aws_array_list_ensure_capacity_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_erase_harness.i
+++ b/c/aws-c-common/aws_array_list_erase_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_front_harness.i
+++ b/c/aws-c-common/aws_array_list_front_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_get_at_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
+++ b/c/aws-c-common/aws_array_list_get_at_ptr_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_array_list_init_dynamic_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_init_static_harness.i
+++ b/c/aws-c-common/aws_array_list_init_static_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_length_harness.i
+++ b/c/aws-c-common/aws_array_list_length_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_pop_front_n_harness.i
+++ b/c/aws-c-common/aws_array_list_pop_front_n_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_push_back_harness.i
+++ b/c/aws-c-common/aws_array_list_push_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_set_at_harness.i
+++ b/c/aws-c-common/aws_array_list_set_at_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
+++ b/c/aws-c-common/aws_array_list_shrink_to_fit_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_sort_harness.i
+++ b/c/aws-c-common/aws_array_list_sort_harness.i
@@ -207,7 +207,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -219,7 +219,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_contents_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_array_list_swap_harness.i
+++ b/c/aws-c-common/aws_array_list_swap_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_advance_harness.i
+++ b/c/aws-c-common/aws_byte_buf_advance_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_dynamic_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_append_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_buf_append_with_lookup_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_cat_harness.i
+++ b/c/aws-c-common/aws_byte_buf_cat_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_clean_up_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
+++ b/c/aws-c-common/aws_byte_buf_clean_up_secure_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_array_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
+++ b/c/aws-c-common/aws_byte_buf_from_empty_array_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_from_cursor_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_init_copy_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_copy_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_init_harness.i
+++ b/c/aws-c-common/aws_byte_buf_init_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_reserve_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reserve_relative_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_reset_harness.i
+++ b/c/aws-c-common/aws_byte_buf_reset_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
+++ b/c/aws-c-common/aws_byte_buf_secure_zero_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_be16_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be16_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_be32_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be32_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_be64_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_be64_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_cursor_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_buf_write_u8_harness.i
+++ b/c/aws-c-common/aws_byte_buf_write_u8_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_advance_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_advance_nospec_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_array_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_array_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_buf_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_from_string_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_from_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_left_trim_pred_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_and_fill_buffer_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_right_trim_pred_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_satisfies_pred_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_trim_pred_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_array_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_array_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
+++ b/c/aws-c-common/aws_hash_byte_cursor_ptr_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_c_string_harness.i
+++ b/c/aws-c-common/aws_hash_c_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_destroy_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_callback_string_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_iter_begin_harness.i
+++ b/c/aws-c-common/aws_hash_iter_begin_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_iter_delete_harness.i
+++ b/c/aws-c-common/aws_hash_iter_delete_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_iter_done_harness.i
+++ b/c/aws-c-common/aws_hash_iter_done_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_iter_next_harness.i
+++ b/c/aws-c-common/aws_hash_iter_next_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_ptr_harness.i
+++ b/c/aws-c-common/aws_hash_ptr_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_string_harness.i
+++ b/c/aws-c-common/aws_hash_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_clean_up_harness.i
+++ b/c/aws-c-common/aws_hash_table_clean_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 
@@ -10196,7 +10196,7 @@ void aws_hash_table_clean_up_harness() {
     struct hash_table_state *state = map.p_impl;
     size_t empty_slot_idx;
     size_t size_in_bytes = sizeof(struct hash_table_state) + sizeof(struct hash_table_entry) * state->size;
-    __CPROVER_allocated_memory(state, size_in_bytes);
+    __CPROVER_allocated_memory((unsigned long)state, size_in_bytes);
 
     assume_abort_if_not(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
     aws_hash_table_clean_up(&map);

--- a/c/aws-c-common/aws_hash_table_clear_harness.i
+++ b/c/aws-c-common/aws_hash_table_clear_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_create_harness.i
+++ b/c/aws-c-common/aws_hash_table_create_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_eq_harness.i
+++ b/c/aws-c-common/aws_hash_table_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_find_harness.i
+++ b/c/aws-c-common/aws_hash_table_find_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_foreach_harness.i
+++ b/c/aws-c-common/aws_hash_table_foreach_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
+++ b/c/aws-c-common/aws_hash_table_get_entry_count_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_init_bounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_bounded_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
+++ b/c/aws-c-common/aws_hash_table_init_unbounded_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_move_harness.i
+++ b/c/aws-c-common/aws_hash_table_move_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_put_harness.i
+++ b/c/aws-c-common/aws_hash_table_put_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_remove_harness.i
+++ b/c/aws-c-common/aws_hash_table_remove_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_hash_table_swap_harness.i
+++ b/c/aws-c-common/aws_hash_table_swap_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_is_power_of_two_harness.i
+++ b/c/aws-c-common/aws_is_power_of_two_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_begin_harness.i
+++ b/c/aws-c-common/aws_linked_list_begin_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_end_harness.i
+++ b/c/aws-c-common/aws_linked_list_end_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_front_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_init_harness.i
+++ b/c/aws-c-common/aws_linked_list_init_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_insert_after_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_after_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_insert_before_harness.i
+++ b/c/aws-c-common/aws_linked_list_insert_before_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_next_harness.i
+++ b/c/aws-c-common/aws_linked_list_next_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_node_reset_harness.i
+++ b/c/aws-c-common/aws_linked_list_node_reset_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_pop_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_pop_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_pop_front_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_prev_harness.i
+++ b/c/aws-c-common/aws_linked_list_prev_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_push_back_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_back_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_push_front_harness.i
+++ b/c/aws-c-common/aws_linked_list_push_front_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_rbegin_harness.i
+++ b/c/aws-c-common/aws_linked_list_rbegin_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_remove_harness.i
+++ b/c/aws-c-common/aws_linked_list_remove_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_rend_harness.i
+++ b/c/aws-c-common/aws_linked_list_rend_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_linked_list_swap_contents_harness.i
+++ b/c/aws-c-common/aws_linked_list_swap_contents_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_mul_size_checked_harness.i
+++ b/c/aws-c-common/aws_mul_size_checked_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_mul_size_saturating_harness.i
+++ b/c/aws-c-common/aws_mul_size_saturating_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_nospec_mask_harness.i
+++ b/c/aws-c-common/aws_nospec_mask_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_capacity_harness.i
+++ b/c/aws-c-common/aws_priority_queue_capacity_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_clean_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_clean_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_dynamic_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_init_static_harness.i
+++ b/c/aws-c-common/aws_priority_queue_init_static_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_pop_harness.i
+++ b/c/aws-c-common/aws_priority_queue_pop_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_push_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_push_ref_harness.i
+++ b/c/aws-c-common/aws_priority_queue_push_ref_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_remove_harness.i
+++ b/c/aws-c-common/aws_priority_queue_remove_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_remove_node_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_either_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_s_swap_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_swap_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_size_harness.i
+++ b/c/aws-c-common/aws_priority_queue_size_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_priority_queue_top_harness.i
+++ b/c/aws-c-common/aws_priority_queue_top_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ptr_eq_harness.i
+++ b/c/aws-c-common/aws_ptr_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ring_buffer_acquire_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_acquire_up_to_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_clean_up_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ring_buffer_init_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_init_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_ring_buffer_release_harness.i
+++ b/c/aws-c-common/aws_ring_buffer_release_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
+++ b/c/aws-c-common/aws_round_up_to_power_of_two_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_bytes_harness.i
+++ b/c/aws-c-common/aws_string_bytes_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_compare_harness.i
+++ b/c/aws-c-common/aws_string_compare_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_destroy_harness.i
+++ b/c/aws-c-common/aws_string_destroy_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_destroy_secure_harness.i
+++ b/c/aws-c-common/aws_string_destroy_secure_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 
@@ -9670,7 +9670,7 @@ void aws_string_destroy_secure_harness() {
     char *bytes = str->bytes;
     size_t len = str->len;
 
-    __CPROVER_allocated_memory(bytes, len);
+    __CPROVER_allocated_memory((unsigned long)bytes, len);
     
    _Bool 
         nondet_parameter;

--- a/c/aws-c-common/aws_string_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_cursor_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_c_str_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_harness.i
+++ b/c/aws-c-common/aws_string_eq_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_string_eq_ignore_case_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_new_from_array_harness.i
+++ b/c/aws-c-common/aws_string_new_from_array_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_new_from_c_str_harness.i
+++ b/c/aws-c-common/aws_string_new_from_c_str_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/aws_string_new_from_string_harness.i
+++ b/c/aws-c-common/aws_string_new_from_string_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/memcpy_using_uint64_harness.i
+++ b/c/aws-c-common/memcpy_using_uint64_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/memset_override_0_harness.i
+++ b/c/aws-c-common/memset_override_0_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/memset_using_uint64_harness.i
+++ b/c/aws-c-common/memset_using_uint64_harness.i
@@ -206,7 +206,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -218,7 +218,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();}
 }
 

--- a/c/aws-c-common/prelude.h
+++ b/c/aws-c-common/prelude.h
@@ -5,7 +5,7 @@ typedef _Bool bool;
 extern void abort(void); 
 void reach_error(){}
 extern void abort(void); 
-void assume_abort_if_not(int cond) { 
+void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}
 }
 extern const void *__VERIFIER_base_pointer(const void *ptr);
@@ -17,7 +17,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 extern unsigned long __VERIFIER_nondet_ulong();
 extern unsigned char __VERIFIER_nondet_uchar();
 
-void __VERIFIER_assert(int cond) {
+void __VERIFIER_assert(_Bool cond) {
     if(!cond) {reach_error();abort();} 
 }
 


### PR DESCRIPTION
Address issue #1087
- type `_Bool` instead of `int` for assert/assume helper functions
- add explicit cast of first parameter at calls to `__CPROVER_allocated_memory`
- don't ignore `int-conversions` compiler warning