### PR TITLE
Extension of task-definition to an 'options' field; the plan is to ge…

### DIFF
--- a/c/loops/array-1.yml
+++ b/c/loops/array-1.yml
@@ -13,6 +13,6 @@ properties:
   - property_file: ../properties/coverage-statements.prp
 
 options:
-  - language: C
-  - data_model: ILP32
+  language: C
+  data_model: ILP32
 

--- a/c/loops/array-1.yml
+++ b/c/loops/array-1.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '1.1'
 
 # old file name: array_true-unreach-call_true-termination.c
 input_files: 'array-1.c'
@@ -11,3 +11,8 @@ properties:
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp
+
+options:
+  - language: C
+  - data_model: ILP32
+


### PR DESCRIPTION
Extension of task-definition to an 'options' field; the long-term plan is to get rid of the .cfg files for the benchmark-set definitions.

This PR adds an options map that can contain various fields.
For the C categories: Language and data_model.