### PR TITLE
Fixup preprocessing of pthread-driver-races after d2bfcfc1599

### DIFF
--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
@@ -6558,7 +6558,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set.i
@@ -6632,7 +6632,6 @@ void cpu_relax() {
   return;
 }
 void *external_alloc(unsigned int size);
-void assume_abort_if_not(int);
 struct timespec current_kernel_time() {
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));
   assume_abort_if_not(tmp != 0);

--- a/c/pthread-driver-races/model/undef_funcs_generic_nvram.h
+++ b/c/pthread-driver-races/model/undef_funcs_generic_nvram.h
@@ -123,10 +123,6 @@ void cpu_relax() {
 // with type: struct timespec current_kernel_time()
 // with return type: struct timespec
 void *external_alloc(unsigned int size);
-void abort(void); 
-void assume_abort_if_not(int cond) { 
-  if(!cond) {abort();}
-}
 struct timespec current_kernel_time() {
   // Composite type
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));

--- a/c/pthread-driver-races/model/undef_funcs_pc8736x_gpio.h
+++ b/c/pthread-driver-races/model/undef_funcs_pc8736x_gpio.h
@@ -147,10 +147,6 @@ void cpu_relax() {
 // with type: struct timespec current_kernel_time()
 // with return type: struct timespec
 void *external_alloc(unsigned int size);
-void abort(void); 
-void assume_abort_if_not(int cond) { 
-  if(!cond) {abort();}
-}
 struct timespec current_kernel_time() {
   // Composite type
   struct timespec *tmp = (struct timespec*)external_alloc(sizeof(struct timespec));


### PR DESCRIPTION
In d2bfcfc1599, not all preprocessed files received the latest version
of the changes to the svcomp.h header.

