### PR TITLE
Implement missing ldv_malloc in models

### DIFF
--- a/c/ldv-challenges/model/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.10-rc1-43_1a-bitvector-drivers--net--ethernet--broadcom--b44.ko--ldv_main0_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
+++ b/c/ldv-challenges/model/linux-3.8-rc1-32_7a-drivers--net--fddi--skfp--skfp.ko-ldv_main0_sequence_infinite_withcheck_stateful_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-dvb-ko--32_7a--d47b389-1.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-dvb-ko--32_7a--d47b389-1.env.c
@@ -26,6 +26,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-dvb-ko--32_7a--d47b389.env.c
+++ b/c/ldv-commit-tester/model/m0_true-unreach-call_drivers-media-video-cx88-cx88-dvb-ko--32_7a--d47b389.env.c
@@ -26,6 +26,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main1_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main7_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
+++ b/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd-1.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
+++ b/c/ldv-commit-tester/model/main8_true-unreach-call_sound-oss-sound-ko--32_7a--c4cb1dd.env.c
@@ -170,6 +170,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: device_create
 // with type: struct device *device_create(struct class *, struct device *, dev_t , void *, const char *, ...)

--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--hwmon--abituguru3.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--hwmon--abituguru3.ko-main.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--block--paride--pf.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--block--paride--pf.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -53,6 +53,13 @@ void blk_cleanup_queue(struct request_queue *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: blk_fetch_request
 // with type: struct request *blk_fetch_request(struct request_queue *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--usb--gspca--gspca_topro.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--media--usb--gspca--gspca_topro.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -153,6 +153,13 @@ int v4l2_ctrl_handler_init(struct v4l2_ctrl_handler *arg0, unsigned int arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: v4l2_ctrl_new_std
 // with type: struct v4l2_ctrl *v4l2_ctrl_new_std(struct v4l2_ctrl_handler *, const struct v4l2_ctrl_ops *, u32 , s32 , s32 , u32 , s32 )

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--arcnet--arcnet.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--arcnet--arcnet.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -58,6 +58,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_netdev_mqs
 // with type: struct net_device *alloc_netdev_mqs(int, const char *, void (*)(struct net_device *), unsigned int, unsigned int)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--realtek--atp.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--realtek--atp.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--net--ethernet--tehuti--tehuti.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -17,6 +17,13 @@ void __napi_schedule(struct napi_struct *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-lib--rbtree_test.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-lib--rbtree_test.ko-ldv_main0_sequence_infinite_withcheck_stateful.env.c
@@ -69,6 +69,14 @@ void rb_erase(struct rb_node *arg0, struct rb_root *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+typedef unsigned long size_t;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: rb_first
 // with type: struct rb_node *rb_first(const struct rb_root *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __devm_request_region
 // with type: struct resource *__devm_request_region(struct device *, struct resource *, resource_size_t , resource_size_t , const char *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--block--paride--pcd.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--block--paride--pcd.ko-main.env.c
@@ -61,6 +61,13 @@ void blk_cleanup_queue(struct request_queue *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: blk_fetch_request
 // with type: struct request *blk_fetch_request(struct request_queue *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--block--paride--pf.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--block--paride--pf.ko-main.env.c
@@ -53,6 +53,13 @@ void blk_cleanup_queue(struct request_queue *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: blk_fetch_request
 // with type: struct request *blk_fetch_request(struct request_queue *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--amc6821.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--amc6821.ko-main.env.c
@@ -36,6 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--asb100.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--asb100.ko-main.env.c
@@ -36,6 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--max16065.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--max16065.ko-main.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83781d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83781d.ko-main.env.c
@@ -36,6 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83791d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83791d.ko-main.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83792d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83792d.ko-main.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--isdn--hardware--eicon--divadidd.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--isdn--hardware--eicon--divadidd.ko-main.env.c
@@ -63,6 +63,13 @@ int printk(const char *arg0, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: proc_create_data
 // with type: struct proc_dir_entry *proc_create_data(const char *, umode_t , struct proc_dir_entry *, const struct file_operations *, void *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--usb--b2c2--b2c2-flexcop-usb.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--usb--b2c2--b2c2-flexcop-usb.ko-main.env.c
@@ -17,6 +17,13 @@ void debug_dma_free_coherent(struct device *arg0, size_t arg1, void *arg2, dma_a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.env.c
@@ -27,6 +27,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--ethernet--3com--3c59x.ko-main.env.c
@@ -18,6 +18,13 @@ int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko-main.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--regulator--isl6271a-regulator.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--regulator--isl6271a-regulator.ko-main.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-consumption/model/32_7a_newdeg_true-unreach-call_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_newdeg_true-unreach-call_linux-3.8-rc1-drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko-main.env.c
@@ -27,6 +27,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-atm-eni.ko_true-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
@@ -62,6 +62,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
@@ -62,6 +62,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
@@ -35,6 +35,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-char-ipmi-ipmi_watchdog.ko_true-unreach-call.cil.out.env.c
@@ -316,6 +316,13 @@ unsigned long int simple_strtoul(const char *arg0, char **arg1, unsigned int arg
   // Simple type
   return __VERIFIER_nondet_ulong();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: strcmp
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-hid-hid-magicmouse.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-hid-hid-magicmouse.ko_true-unreach-call.cil.out.env.c
@@ -10,6 +10,13 @@ int __hid_register_driver(struct hid_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-atl1c-atl1c.ko_true-unreach-call.cil.out.env.c
@@ -26,6 +26,13 @@ void __init_work(struct work_struct *arg0, int arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-sis900.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-sis900.ko_true-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-scsi-megaraid.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-scsi-megaraid.ko_true-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-staging-et131x-et131x.ko_true-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_work(struct work_struct *arg0, int arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-tty-synclink_gt.ko_false-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_work(struct work_struct *arg0, int arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t , gfp_t )

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-video-aty-aty128fb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-video-aty-aty128fb.ko_true-unreach-call.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-c-qcam.ko_true-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-media-video-msp3400.ko_true-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-misc-c2port-core.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-misc-c2port-core.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-mtd-sm_ftl.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-mtd-sm_ftl.ko_true-unreach-call.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-net-can-usb-ems_usb.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-net-can-usb-ems_usb.ko_false-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-net-usb-catc.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-net-usb-catc.ko_false-unreach-call.cil.out.env.c
@@ -34,6 +34,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_etherdev_mqs
 // with type: struct net_device *alloc_etherdev_mqs(int sizeof_priv, unsigned int txqs, unsigned int rxqs)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-scsi-dc395x.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-scsi-dc395x.ko_true-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-staging-lirc-lirc_imon.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-staging-lirc-lirc_imon.ko_false-unreach-call.cil.out.env.c
@@ -44,6 +44,13 @@ unsigned int __kfifo_in_r(struct __kfifo *arg0, const void *arg1, unsigned int a
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-misc-iowarrior.ko_false-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-ir-usb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-ir-usb.ko_true-unreach-call.cil.out.env.c
@@ -19,6 +19,13 @@ unsigned int __kfifo_out_r(struct __kfifo *arg0, void *arg1, unsigned int arg2, 
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.env.c
@@ -17,6 +17,13 @@ void __init_work(struct work_struct *arg0, int arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-uwb-i1480-dfu-i1480-dfu-usb.ko_true-unreach-call.cil.out.env.c
@@ -9,6 +9,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-vhost-vhost_net.ko_true-unreach-call.cil.out.env.c
@@ -18,6 +18,13 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/usb_urb-drivers-video-arkfb.ko_true-unreach-call.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __kmalloc
 // with type: void *__kmalloc(size_t size, gfp_t flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--acpi--ec_sys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--acpi--ec_sys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -90,6 +90,13 @@ void sysfs_remove_link(struct kobject *arg0, const char *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: thermal_cooling_device_register
 // with type: struct thermal_cooling_device *thermal_cooling_device_register(char *, void *, const struct thermal_cooling_device_ops *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ void ldv_initialize() {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: pci_iomap
 // with type: void *pci_iomap(struct pci_dev *dev, int bar, unsigned long max)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--auxdisplay--cfag12864bfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--auxdisplay--cfag12864bfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ unsigned char cfag12864b_isinited() {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--auxdisplay--ks0108.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--auxdisplay--ks0108.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ int parport_claim(struct pardevice *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: parport_find_base
 // with type: struct parport *parport_find_base(unsigned long)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -84,6 +84,13 @@ int virtqueue_add_buf(struct virtqueue *arg0, struct scatterlist *arg1, unsigned
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: virtqueue_get_buf
 // with type: void *virtqueue_get_buf(struct virtqueue *vq, unsigned int *len)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--ipmi--ipmi_poweroff.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--char--ipmi--ipmi_poweroff.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -98,6 +98,13 @@ int printk(const char *arg0, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: register_sysctl_table
 // with type: struct ctl_table_header *register_sysctl_table(struct ctl_table *table)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,6 +20,14 @@ void clockevents_register_device(struct clock_event_device *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+typedef unsigned long size_t;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cs5535_mfgpt_alloc_timer
 // with type: struct cs5535_mfgpt_timer *cs5535_mfgpt_alloc_timer(int timer, int domain)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--cpufreq--pcc-cpufreq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--cpufreq--pcc-cpufreq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ide--cmd640.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ide--cmd640.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ide--ide-pnp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--ide--ide-pnp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--cma3000_d0x_i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--cma3000_d0x_i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void cma3000_exit(struct cma3000_accl_data *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cma3000_init
 // with type: struct cma3000_accl_data *cma3000_init(struct device *dev, int irq, const struct cma3000_bus_ops *bops)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--mouse--gpio_mouse.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--mouse--gpio_mouse.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--cyttsp_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cyttsp_probe
 // with type: struct cyttsp *cyttsp_probe(const struct cyttsp_bus_ops *bus_ops, struct device *dev, int irq, size_t xfer_buf_size)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--b1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--b1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--b1pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--b1pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ int attach_capi_ctr(struct capi_ctr *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: b1_alloc_card
 // with type: avmcard *b1_alloc_card(int nr_controllers)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--t1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--avm--t1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--eicon--divadidd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--isdn--hardware--eicon--divadidd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,6 +54,13 @@ int printk(const char *arg0, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: proc_create_data
 // with type: struct proc_dir_entry *proc_create_data(const char *name, umode_t mode, struct proc_dir_entry *parent, const struct file_operations *proc_fops, void *data)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dtv5100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dtv5100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-gl861.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-gl861.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-umt-010.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-umt-010.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ int printk(const char *arg0, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: usb_alloc_coherent
 // with type: void *usb_alloc_coherent(struct usb_device *dev, size_t size, gfp_t mem_flags, dma_addr_t *dma)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_finepix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--video--gspca--gspca_finepix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: get_device
 // with type: struct device *get_device(struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--misc--c2port--c2port-duramar2150.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--misc--c2port--c2port-duramar2150.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,14 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+typedef unsigned long size_t;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -61,6 +61,13 @@ int mmc_add_host(struct mmc_host *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: mmc_alloc_host
 // with type: struct mmc_host *mmc_alloc_host(int extra, struct device *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_orinocodev
 // with type: struct orinoco_private *alloc_orinocodev(int sizeof_card, struct device *device, int (*hard_reset)(struct orinoco_private *), int (*stop_fw)(struct orinoco_private *, int))

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_orinocodev
 // with type: struct orinoco_private *alloc_orinocodev(int sizeof_card, struct device *device, int (*hard_reset)(struct orinoco_private *), int (*stop_fw)(struct orinoco_private *, int))

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_orinocodev
 // with type: struct orinoco_private *alloc_orinocodev(int sizeof_card, struct device *device, int (*hard_reset)(struct orinoco_private *), int (*stop_fw)(struct orinoco_private *, int))

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--pci--pci-stub.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--pci--pci-stub.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -61,6 +61,13 @@ int printk(const char *arg0, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: sscanf
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ unsigned char bin2bcd(unsigned int arg0) {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ unsigned char bin2bcd(unsigned int arg0) {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ unsigned char bin2bcd(unsigned int arg0) {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--scsi--dmx3191d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--scsi--dmx3191d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -42,6 +42,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--scsi--qlogicfas408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--scsi--qlogicfas408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ void scsi_cmd_get_serial(struct Scsi_Host *arg0, struct scsi_cmnd *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: sg_next
 // with type: struct scatterlist *sg_next(struct scatterlist *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad5930.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad5930.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9832.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9832.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9850.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9850.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9852.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9852.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9910.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9910.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--dds--ad9951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--resolver--ad2s90.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--iio--resolver--ad2s90.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_acntsa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_acntsa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -34,6 +34,13 @@ int serial_synth_probe(struct spk_synth *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: spk_synth_immediate
 // with type: const char *spk_synth_immediate(struct spk_synth *synth, const char *buff)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_ltlk.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--speakup--speakup_ltlk.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ unsigned char spk_serial_in() {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: spk_synth_immediate
 // with type: const char *spk_synth_immediate(struct spk_synth *synth, const char *buff)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--vme--boards--vme_vmivme7805.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--staging--vme--boards--vme_vmivme7805.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ unsigned int ioread32(void *arg0) {
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t offset, unsigned long size)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--altera_jtaguart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--altera_jtaguart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -42,6 +42,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t offset, unsigned long size)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--altera_uart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--altera_uart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--uartlite.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--uartlite.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--xilinx_uartps.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--tty--serial--xilinx_uartps.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--usb--atm--xusbatm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--usb--atm--xusbatm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--video--n411.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--video--n411.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ int platform_device_add_data(struct platform_device *arg0, const void *arg1, siz
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: platform_device_alloc
 // with type: struct platform_device *platform_device_alloc(const char *name, int id)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--watchdog--sbc_epx_c3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--watchdog--sbc_epx_c3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -25,6 +25,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--watchdog--wm831x_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--watchdog--wm831x_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ad714x-i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ad714x-i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int ad714x_enable(struct ad714x_chip *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ad714x_probe
 // with type: struct ad714x_chip *ad714x_probe(struct device *dev, u16 bus_type, int irq, int (*read)(struct ad714x_chip *, unsigned short, unsigned short *, size_t ), int (*write)(struct ad714x_chip *, unsigned short, unsigned short))

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ad714x-spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ad714x-spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int ad714x_enable(struct ad714x_chip *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ad714x_probe
 // with type: struct ad714x_chip *ad714x_probe(struct device *dev, u16 bus_type, int irq, int (*read)(struct ad714x_chip *, unsigned short, unsigned short *, size_t ), int (*write)(struct ad714x_chip *, unsigned short, unsigned short))

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--adxl34x-spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--adxl34x-spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: adxl34x_probe
 // with type: struct adxl34x *adxl34x_probe(struct device *dev, int irq, bool fifo_delay_default, const struct adxl34x_bus_ops *bops)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcspkr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcspkr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: calloc
 

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *symbol)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--staging--android--switch--switch_class.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--staging--android--switch--switch_class.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--staging--iio--meter--ade7854-i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--staging--iio--meter--ade7854-i2c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int ade7854_remove(struct iio_dev *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--usb--dwc3--dwc3-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--usb--dwc3--dwc3-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--xen--xenfs--xenfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--xen--xenfs--xenfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ struct timespec current_kernel_time() {
   // Composite type
   return *(struct timespec *)ldv_xmalloc(sizeof(struct timespec));
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: d_alloc_name
 // with type: struct dentry *d_alloc_name(struct dentry *, const char *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--xen--xenfs--xenfs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--xen--xenfs--xenfs.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ struct timespec current_kernel_time() {
   // Composite type
   return *(struct timespec *)ldv_xmalloc(sizeof(struct timespec));
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: d_alloc_name
 // with type: struct dentry *d_alloc_name(struct dentry *, const char *)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--apei--einj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--apei--einj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--acpi--bgrt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -14,6 +14,13 @@ acpi_status acpi_get_table(acpi_string arg0, u32 arg1, struct acpi_table_header 
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t offset, unsigned long size)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--char--tpm--tpm_nsc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--char--tpm--tpm_nsc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--edac--mce_amd_inj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--edac--mce_amd_inj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int amd_decode_mce(struct notifier_block *arg0, unsigned long arg1, void *arg2) 
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: edac_get_sysfs_subsys
 // with type: struct bus_type *edac_get_sysfs_subsys()

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--misc--apanel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--misc--apanel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int check_signature(const volatile void *arg0, const unsigned char *arg1, int ar
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *dev)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--touchscreen--mk712.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--touchscreen--mk712.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--misc--vmw_balloon.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--misc--vmw_balloon.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -51,6 +51,13 @@ int _cond_resched() {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_pages_current
 // with type: struct page *alloc_pages_current(gfp_t gfp_mask, unsigned int order)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--netsc520.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--netsc520.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--nettel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--nettel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--sbc_gxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--ts5500_flash.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--maps--ts5500_flash.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--mtd--mtdoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -198,6 +198,13 @@ void vfree(const void *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: vmalloc
 // with type: void *vmalloc(unsigned long size)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--arc-rawmode.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--arcnet--rfc1201.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--tokenring--abyss.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--net--tokenring--abyss.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pci--hotplug--cpcihp_generic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pci--hotplug--cpcihp_generic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pps--clients--pps-ktimer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pps--clients--pps-ktimer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -60,6 +60,13 @@ void pps_event(struct pps_device *arg0, struct pps_event_time *arg1, int arg2, v
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: pps_register_source
 // with type: struct pps_device *pps_register_source(struct pps_source_info *info, int default_params)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pps--clients--pps-ldisc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--pps--clients--pps-ldisc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ void pps_event(struct pps_device *arg0, struct pps_event_time *arg1, int arg2, v
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: pps_register_source
 // with type: struct pps_device *pps_register_source(struct pps_source_info *info, int default_params)

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--video--vfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--video--vfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--watchdog--cpu5wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--watchdog--cpu5wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -34,6 +34,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, const char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--video--aty--atyfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--video--aty--atyfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -50,6 +50,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t start, resource_size_t n, char *name, int flags)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--mv_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--mv_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void ___udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __alloc_workqueue_key
 // with type: struct workqueue_struct *__alloc_workqueue_key(char *, unsigned int, int, struct lock_class_key *, char *, ...)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--pch_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--pch_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -103,6 +103,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--apei--einj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--apei--einj.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--bgrt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -14,6 +14,13 @@ acpi_status acpi_get_table(acpi_string arg0, u32 arg1, struct acpi_table_header 
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t , unsigned long)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--container.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -144,6 +144,13 @@ acpi_status acpi_walk_namespace(acpi_object_type arg0, acpi_handle arg1, u32 arg
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: free
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--ec_sys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--ec_sys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -56,6 +56,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: free
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,6 +46,13 @@ unsigned int ioread8(void *arg0) {
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_netcell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_netcell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ void ata_print_version(const struct device *arg0, const char *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_opti.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ata--pata_opti.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ata_dev_pair
 // with type: struct ata_device *ata_dev_pair(struct ata_device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--atm--adummy_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--atm--adummy_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--auxdisplay--cfag12864bfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--auxdisplay--cfag12864bfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ unsigned char cfag12864b_isinited() {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--auxdisplay--ks0108_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--auxdisplay--ks0108_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -34,6 +34,13 @@ void hwrng_unregister(struct hwrng *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--tpm--tpm_nsc_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--tpm--tpm_nsc_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--uv_mmtimer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--uv_mmtimer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int is_uv_system() {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--clocksource--cs5535-clockevt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,6 +20,13 @@ void clockevents_register_device(struct clock_event_device *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cs5535_mfgpt_alloc_timer
 // with type: struct cs5535_mfgpt_timer *cs5535_mfgpt_alloc_timer(int, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--cpufreq--cpufreq_powersave.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--cpufreq--cpufreq_powersave.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ void cpufreq_unregister_governor(struct cpufreq_governor *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--cpufreq--pcc-cpufreq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--cpufreq--pcc-cpufreq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -132,6 +132,13 @@ void iowrite32(u32 arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--edac--mce_amd_inj_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--edac--mce_amd_inj_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int amd_decode_mce(struct notifier_block *arg0, unsigned long arg1, void *arg2) 
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: edac_get_sysfs_subsys
 // with type: struct bus_type *edac_get_sysfs_subsys()

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--edd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--edd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--gsmi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--gsmi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ int atomic_notifier_chain_unregister(struct atomic_notifier_head *arg0, struct n
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dma_pool_alloc
 // with type: void *dma_pool_alloc(struct dma_pool *, gfp_t , dma_addr_t *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--memconsole_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--memconsole_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dmi_check_system(const struct dmi_system_id *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-74x164.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-74x164.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-max7301.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-max7301.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ void driver_unregister(struct device_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-mc33880.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-mc33880.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-tps65912.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-tps65912.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpio--gpio-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--drm_usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--drm_usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ void drm_ut_debug_printk(unsigned int arg0, const char *arg1, const char *arg2, 
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--i2c--sil164.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--i2c--sil164.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ int i2c_master_send(const struct i2c_client *arg0, const char *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: i2c_new_device
 // with type: struct i2c_client *i2c_new_device(struct i2c_adapter *, const struct i2c_board_info *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--tdfx--tdfx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--drm--tdfx--tdfx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int drm_pci_init(struct drm_driver *arg0, struct pci_driver *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--stub--poulsbo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--gpu--stub--poulsbo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void acpi_video_unregister() {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-cherry.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-cherry.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-chicony.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-chicony.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-elecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-elecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-ezkey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-ezkey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void input_event(struct input_dev *arg0, unsigned int arg1, unsigned int arg2, i
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-gyration.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-gyration.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void input_event(struct input_dev *arg0, unsigned int arg1, unsigned int arg2, i
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-kensington.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-kensington.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-keytouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-keytouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-lcpower.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-lcpower.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-monterey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-monterey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-ortek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-ortek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-petalynx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-petalynx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-primax.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-primax.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -61,6 +61,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-saitek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-saitek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-samsung.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-samsung.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-speedlink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-speedlink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-sunplus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-sunplus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-topseed.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-topseed.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-twinhan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-twinhan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-uclogic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-uclogic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void hid_unregister_driver(struct hid_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-wacom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-wacom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-waltop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-waltop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-zydacron.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hid--hid-zydacron.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: hwmon_device_register
 // with type: struct device *hwmon_device_register(struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--asus_atk0110.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--asus_atk0110.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -83,6 +83,13 @@ acpi_status acpi_evaluate_object_typed(acpi_handle arg0, acpi_string arg1, struc
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: acpi_format_exception
 // with type: const char *acpi_format_exception(acpi_status )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--emc1403.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--emc1403.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--f71805f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--f71805f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -52,6 +52,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pcf8591.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pcf8591.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max16064.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pmbus--max8688.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--smsc47b397_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--smsc47b397_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--algos--i2c-algo-pca_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--algos--i2c-algo-pca_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int i2c_add_numbered_adapter(struct i2c_adapter *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-diolan-u2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-diolan-u2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-stub_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-stub_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int i2c_del_adapter(struct i2c_adapter *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-tiny-usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--busses--i2c-tiny-usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--i2c-smbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--i2c--i2c-smbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -38,6 +38,13 @@ bool cancel_work_sync(struct work_struct *arg0) {
   // Simple type
   return __VERIFIER_nondet_bool();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ide--ide-pnp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--ide--ide-pnp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--gameport--lightning.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--gameport--lightning.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--gpio_keys_polled_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--gpio_keys_polled_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -72,6 +72,13 @@ int gpio_request(unsigned int arg0, const char *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: input_allocate_polled_device
 // with type: struct input_polled_dev *input_allocate_polled_device()

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ab8500-ponkey_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ab8500-ponkey_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ad714x_probe
 // with type: struct ad714x_chip *ad714x_probe(struct device *, u16 , int, int (*)(struct ad714x_chip *, unsigned short, unsigned short *, size_t ), int (*)(struct ad714x_chip *, unsigned short, unsigned short))

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--adxl34x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--adxl34x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: adxl34x_probe
 // with type: struct adxl34x *adxl34x_probe(struct device *, int, bool , const struct adxl34x_bus_ops *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--apanel_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--apanel_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int check_signature(const volatile void *arg0, const unsigned char *arg1, int ar
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -87,6 +87,13 @@ void input_unregister_device(struct input_dev *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--cma3000_d0x_i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--cma3000_d0x_i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mma8450_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mma8450_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ s32 i2c_smbus_write_byte_data(const struct i2c_client *arg0, u8 arg1, u8 arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: input_allocate_polled_device
 // with type: struct input_polled_dev *input_allocate_polled_device()

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mpu3050_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mpu3050_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,6 +46,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcf50633-input_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcf50633-input_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcspkr_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcspkr_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,6 +46,13 @@ int input_register_device(struct input_dev *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--rotary_encoder_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--rotary_encoder_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -114,6 +114,13 @@ void input_unregister_device(struct input_dev *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--wm831x-on_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--wm831x-on_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int bind_evtchn_to_irqhandler(unsigned int arg0, irqreturn_t (*arg1)(int, void *
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--gpio_mouse_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--gpio_mouse_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -63,6 +63,13 @@ int gpio_request(unsigned int arg0, const char *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: input_allocate_polled_device
 // with type: struct input_polled_dev *input_allocate_polled_device()

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--serio--ct82c710_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--serio--ct82c710_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -25,6 +25,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--serio--parkbd_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--serio--parkbd_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __serio_register_port(struct serio *arg0, struct module *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--ad7879-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--ad7879-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ad7879_probe
 // with type: struct ad7879 *ad7879_probe(struct device *, u8 , unsigned int, const struct ad7879_bus_ops *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cyttsp_probe
 // with type: struct cyttsp *cyttsp_probe(const struct cyttsp_bus_ops *, struct device *, int, size_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--eeti_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--eeti_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,6 +46,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--egalax_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--egalax_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -155,6 +155,13 @@ void input_set_abs_params(struct input_dev *arg0, unsigned int arg1, int arg2, i
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--max11801_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--max11801_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -93,6 +93,13 @@ void input_set_abs_params(struct input_dev *arg0, unsigned int arg1, int arg2, i
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mk712_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mk712_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--stmpe-ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--stmpe-ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int __serio_register_driver(struct serio_driver *arg0, struct module *arg1, cons
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ void complete(struct completion *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--avm_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--avm_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--b1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--b1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--b1pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--b1pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--t1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hardware--avm--t1pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--avma1_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--avma1_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int hisax_init_pcmcia(void *arg0, int *arg1, IsdnCard_t *arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--elsa_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--elsa_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int hisax_init_pcmcia(void *arg0, int *arg1, IsdnCard_t *arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--sedlbauer_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--sedlbauer_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int hisax_init_pcmcia(void *arg0, int *arg1, IsdnCard_t *arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--teles_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--isdn--hisax--teles_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int hisax_init_pcmcia(void *arg0, int *arg1, IsdnCard_t *arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--dell-led_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--dell-led_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-bd2802.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -51,6 +51,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-dac124s085_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-dac124s085_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -60,6 +60,13 @@ bool cancel_work_sync(struct work_struct *arg0) {
   // Simple type
   return __VERIFIER_nondet_bool();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-ot200.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-regulator_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-regulator_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -55,6 +55,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-backlight.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-default-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--ledtrig-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -85,6 +85,13 @@ void input_unregister_handler(struct input_handler *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--md--dm-zero.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--md--dm-zero.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void dm_unregister_target(struct target_type *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--max2165_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--max2165_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mc44s803_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mc44s803_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2060_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2060_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt20xx_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt20xx_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2131.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mt2266.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--mxl5007t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -34,6 +34,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--qt1010_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--qt1010_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda18212_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda18212_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda18218_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda18218_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -12,6 +12,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda8290.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--common--tuners--tda9887.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-cinergyT2_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-common_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dibusb-mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-digitv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtt200u_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtv5100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-dtv5100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-gl861.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-gl861.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf_false-termination.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-mxl111sf_false-termination.ko-ldv_main3_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-nova-t-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-nova-t-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-pctv452e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-ttusb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-umt-010.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-umt-010.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--dvb-usb-vp7045_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--dvb-usb--mxl111sf-demod.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--cxd2820r.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ unsigned int intlog2(u32 arg0) {
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dib3000mc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void dibx000_exit_i2c_master(struct dibx000_i2c_master *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dibx000_get_i2c_adapter
 // with type: struct i2c_adapter *dibx000_get_i2c_adapter(struct dibx000_i2c_master *, enum dibx000_i2c_interface , int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dvb_dummy_fe_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--dvb_dummy_fe_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--ec100.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--rtl2830_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--rtl2830_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--stb6000_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--stb6000_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda18271c2dd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda826x_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tda826x_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tua6100_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--dvb--frontends--tua6100_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-adstech-dvb-t-pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-alink-dtu-m.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-anysee.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-apac-viewcomp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-asus-pc39.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-tv-wonder-hd-600.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-ati-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-a16d.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-cardbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-dvbt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m135a.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-m733a-rm-k6.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia-rm-ks.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avermedia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-avertv-303.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-azurewave-ad-tu700.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold-columbus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-behold.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-budget-ci-old.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy-1400.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-cinergy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dib0700-rc5.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digitalnow-tinytwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-digittrade.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dm1105-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvb-t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-dntv-live-dvbt-pro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-em-terratec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv-fm53.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-encore-enltv2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-evga-indtube.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-eztv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flydvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-flyvideo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-fusionhdtv-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gadmei-rm008z.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-genius-tvgo-a11mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-gotview7135.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-hauppauge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-imon-pad.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-iodata-bctv7e.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-it913x-v2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kaiomy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-315u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-pc150u.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-kworld-plus-tv-analog.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-leadtek-y04g0051.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lirc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-lme2510.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-manli.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-medion-x10.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-ii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-digivox-iii.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere-plus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-msi-tvanywhere.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nebula.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-nec-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-norwood.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-npgtech.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pctv-sedna.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-color.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-grey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pinnacle-pctv-hd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-002t.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-mk12.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview-new.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pixelview.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-powercolor-real-angel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-proteus-2309.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-purpletv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-pv951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-rc6-mce.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-real-audio-220-32-keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-snapstream-firefly.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-streamzap.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tbs-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-technisat-usb2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-cinergy-xs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim-2.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-terratec-slim.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tevii-nec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tivo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-total-media-in-hand.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-trekstor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-tt-1500.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-twinhan1027.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-m1f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-s350.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-videomate-tv-pvr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast-usbii-deluxe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--rc--keymaps--rc-winfast.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--cx231xx--cx231xx-dvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--cx231xx--cx231xx-dvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--cx88--cx88-vp3054-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--cx88--cx88-vp3054-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--em28xx--em28xx-dvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--em28xx--em28xx-dvb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_benq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void gspca_frame_add(struct gspca_dev *arg0, enum gspca_packet_type arg1, const 
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_finepix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_finepix.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_pac207.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ void input_event(struct input_dev *arg0, unsigned int arg1, unsigned int arg2, i
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_stv0680.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--gspca--gspca_stv0680.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void gspca_frame_add(struct gspca_dev *arg0, enum gspca_packet_type arg1, const 
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--videobuf-vmalloc_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--videobuf-vmalloc_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--zoran--zr36016.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--media--video--zoran--zr36016.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: get_device
 // with type: struct device *get_device(struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--janz-cmodio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--janz-cmodio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--rdc321x-southbridge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--rdc321x-southbridge.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--timberdale_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--timberdale_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps6507x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--ucb1400_core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--ucb1400_core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wl1273-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--apds9802als.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,6 +54,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--bmp085.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--bmp085.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--c2port--c2port-duramar2150.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--c2port--c2port-duramar2150.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--eeprom--eeprom_93xx46.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -52,6 +52,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--isl29020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -59,6 +59,13 @@ s32 i2c_smbus_write_byte_data(const struct i2c_client *arg0, u8 arg1, u8 arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--sgi-xp--xp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--sgi-xp--xp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,6 +54,13 @@ int is_uv_system() {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--ti_dac7512.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--tifm_core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--tifm_core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--vmw_balloon_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--vmw_balloon_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -51,6 +51,13 @@ int _cond_resched() {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: alloc_pages_current
 // with type: struct page *alloc_pages_current(gfp_t , unsigned int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mmc--host--sdricoh_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ar7part_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ar7part_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--block2mtd_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--block2mtd_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ unsigned long int invalidate_mapping_pages(struct address_space *arg0, unsigned 
   // Simple type
   return __VERIFIER_nondet_ulong();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--devices--docprobe.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __symbol_get
 // with type: void *__symbol_get(const char *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--intel_vr_nor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--intel_vr_nor.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __pci_register_driver(struct pci_driver *arg0, struct module *arg1, const ch
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--netsc520_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--netsc520_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--nettel_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--nettel_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--sbc_gxx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--ts5500_flash_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--maps--ts5500_flash_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -69,6 +69,13 @@ int deregister_mtd_blktrans(struct mtd_blktrans_ops *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock_ro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdblock_ro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int deregister_mtd_blktrans(struct mtd_blktrans_ops *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--mtdoops_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ bool flush_work_sync(struct work_struct *arg0) {
   // Simple type
   return __VERIFIER_nondet_bool();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ubi--gluebi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ubi--gluebi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rawmode_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rimi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--arc-rimi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com20020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com20020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com20020_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com20020_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int __dynamic_netdev_dbg(struct _ddebug *arg0, const struct net_device *arg1, co
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com90io.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com90io.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com90xx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--com90xx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1051_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--arcnet--rfc1201_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--act200l-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--act200l-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--esi-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--esi-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--girbil-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--girbil-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--litelink-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--litelink-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--ma600-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--ma600-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--mcp2120-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--mcp2120-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--old_belkin-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--old_belkin-sir_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--tekram-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--irda--tekram-sir.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--amd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--amd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--broadcom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--broadcom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--cicada.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--cicada.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--davicom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--davicom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--et1011c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--et1011c.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--icplus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--icplus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--lxt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--lxt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--marvell.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--micrel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--micrel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--national.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--national.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--qsemi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--qsemi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--realtek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--realtek.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--smsc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--smsc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -43,6 +43,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--ste10Xp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--ste10Xp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--vitesse.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--phy--vitesse.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--ppp--bsd_comp.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--team--team_mode_roundrobin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--team--team_mode_roundrobin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--tokenring--abyss_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--tokenring--abyss_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--usb--cdc_subset_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--usb--cdc_subset_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--usb--plusb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--usb--plusb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_netdev_dbg(struct _ddebug *arg0, const struct net_device *arg1, co
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--airo_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--airo_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--mwifiex--mwifiex_pcie_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int __dynamic_pr_debug(struct _ddebug *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_nortel.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_plx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--orinoco--orinoco_tmd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl1251--wl1251_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl1251--wl1251_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __netdev_alloc_skb
 // with type: struct sk_buff *__netdev_alloc_skb(struct net_device *, unsigned int, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--parport--parport_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--parport--parport_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--hotplug--cpcihp_generic_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--hotplug--cpcihp_generic_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--ioapic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--ioapic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -50,6 +50,13 @@ int acpi_unregister_ioapic(acpi_handle arg0, u32 arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--pci-stub_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pci--pci-stub_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_printk(const char *arg0, const struct device *arg1, const char *arg2, ..
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--asus-nb-wmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--asus-nb-wmi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void asus_wmi_unregister_driver(struct asus_wmi_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ void input_unregister_device(struct input_dev *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--intel_menlow.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--intel_menlow.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -91,6 +91,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--mxm-wmi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--mxm-wmi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -55,6 +55,13 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: backlight_device_register
 // with type: struct backlight_device *backlight_device_register(const char *, struct device *, void *, const struct backlight_ops *, const struct backlight_properties *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ void input_unregister_device(struct input_dev *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--toshiba_bluetooth.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--toshiba_bluetooth.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void acpi_bus_unregister_driver(struct acpi_driver *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: acpi_device_hid
 // with type: const char *acpi_device_hid(struct acpi_device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--max8903_charger_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--max8903_charger_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--test_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--wm831x_backup_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--wm831x_backup_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--power--wm831x_power.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pps--clients--pps-ktimer_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pps--clients--pps-ktimer_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ void init_timer_key(struct timer_list *arg0, const char *arg1, struct lock_class
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pps--clients--pps-ldisc_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--pps--clients--pps-ldisc_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--gpio-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--gpio-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max1586.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max1586.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -30,6 +30,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max8649.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max8649.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--userspace-consumer.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-dcdc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-dcdc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1390.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1390.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1672_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1672_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3232.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3232.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-em3027_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-em3027_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int i2c_transfer(struct i2c_adapter *arg0, struct i2c_msg *arg1, int arg2) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -45,6 +45,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-mc13xxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-mc13xxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-pcf2123.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-pcf2123.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -79,6 +79,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,6 +54,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-rs5c348.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-rs5c348.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,6 +54,13 @@ int dev_warn(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-v3020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-v3020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ unsigned char bin2bcd(unsigned int arg0) {
   // Simple type
   return __VERIFIER_nondet_uchar();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--iscsi_boot_sysfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--iscsi_boot_sysfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,6 +20,13 @@ bool capable(int arg0) {
   // Simple type
   return __VERIFIER_nondet_bool();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kasprintf
 // with type: char *kasprintf(gfp_t , const char *, ...)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--pcmcia--sym53c500_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--pcmcia--sym53c500_cs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -50,6 +50,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--qlogicfas408_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--qlogicfas408_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--scsi_wait_scan_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--scsi--scsi_wait_scan_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--spi--spi-tle62x0.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--spi--spi-tle62x0.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -35,6 +35,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_class_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_class_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -38,6 +38,13 @@ bool cancel_work_sync(struct work_struct *arg0) {
   // Simple type
   return __VERIFIER_nondet_bool();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--addac--adt7316-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--addac--adt7316-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -27,6 +27,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad5930.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad5930.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9850.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9850.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9852.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9852.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9910.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9910.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--dds--ad9951.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--iio_dummy_evgen_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--iio_dummy_evgen_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -93,6 +93,13 @@ int irq_set_chip(unsigned int arg0, struct irq_chip *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--kfifo_buf_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--kfifo_buf_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -62,6 +62,13 @@ void iio_buffer_init(struct iio_buffer *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--meter--ade7854-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--iio--meter--ade7854-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int ade7854_probe(struct iio_dev *arg0, struct device *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--phison--phison.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--phison--phison.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int ata_std_prereset(struct ata_link *arg0, unsigned long arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_acntsa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_acntsa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_dummy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_dummy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_ltlk.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_ltlk.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_soft.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_soft.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void finish_wait(wait_queue_head_t *arg0, wait_queue_t *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_spkout.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_spkout.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_txprt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--speakup--speakup_txprt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--telephony--ixj_pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--telephony--ixj_pcmcia.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ixj_pcmcia_probe
 // with type: IXJ *ixj_pcmcia_probe(unsigned long, unsigned long)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--vme--boards--vme_vmivme7805.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--vme--boards--vme_vmivme7805.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ unsigned int ioread32(void *arg0) {
   // Simple type
   return __VERIFIER_nondet_uint();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t , unsigned long)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--altera_jtaguart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--altera_jtaguart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -33,6 +33,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t , unsigned long)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--altera_uart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--altera_uart.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int del_timer_sync(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--mfd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--mfd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -53,6 +53,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--uartlite_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--uartlite_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--xilinx_uartps.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--tty--serial--xilinx_uartps.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_aec.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -37,6 +37,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_pci_generic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_pci_generic.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_sercos3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uio--uio_sercos3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -59,6 +59,13 @@ void _raw_spin_unlock_irq(raw_spinlock_t *arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--atm--xusbatm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--atm--xusbatm.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--dwc3--dwc3-pci_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--dwc3--dwc3-pci_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: devm_kzalloc
 // with type: void *devm_kzalloc(struct device *, size_t , gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--misc--cypress_cy7c63.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--misc--trancevibrator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,6 +19,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--otg--ab8500-usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--otg--ab8500-usb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -101,6 +101,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--otg--nop-usb-xceiv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--otg--nop-usb-xceiv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--empeg_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--empeg_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--funsoft_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--funsoft_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ipaq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ipaq.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ipw_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ipw_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--metro-usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--metro-usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--moto_modem_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--moto_modem_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--siemens_mpi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--siemens_mpi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ssu100_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--ssu100_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -51,6 +51,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--usb_debug_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--vivopay-serial_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--vivopay-serial_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--zio_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--serial--zio_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--storage--ums-cypress.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--storage--ums-cypress.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--usb--storage--ums-freecom.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __const_udelay(unsigned long arg0) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--uwb--i1480--i1480-est.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ili9320_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ili9320_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -44,6 +44,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -61,6 +61,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lcd_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lcd_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -79,6 +79,13 @@ int fb_unregister_client(struct notifier_block *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -34,6 +34,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--vgg2432a4.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--matrox--i2c-matroxfb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--matrox--i2c-matroxfb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,6 +36,13 @@ int i2c_del_adapter(struct i2c_adapter *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: i2c_new_probed_device
 // with type: struct i2c_client *i2c_new_probed_device(struct i2c_adapter *, struct i2c_board_info *, const unsigned short *, int (*)(struct i2c_adapter *, unsigned short))

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--n411_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--n411_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int __request_module(bool arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--vfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--vfb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--masters--matrox_w1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--masters--matrox_w1.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,6 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--masters--w1-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--masters--w1-gpio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __gpio_set_value(unsigned int arg0, int arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_bq27000.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2408.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2423.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -38,6 +38,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2431.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -10,6 +10,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2433.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,6 +21,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Skip function: kfree
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2760.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2780.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_ds2781.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--w1--slaves--w1_smem.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--acquirewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--acquirewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--advantechwdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--advantechwdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--cpu5wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--cpu5wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--f71808e_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--f71808e_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -26,6 +26,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--geodewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--geodewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2)
   // Simple type
   return __VERIFIER_nondet_ulong();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: cs5535_mfgpt_alloc_timer
 // with type: struct cs5535_mfgpt_timer *cs5535_mfgpt_alloc_timer(int, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--iTCO_vendor_support_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--iTCO_vendor_support_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,3 +1,10 @@
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 // Skip function: __VERIFIER_error
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ib700wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ib700wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ibmasr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ibmasr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--it8712f_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--it8712f_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--machzwd_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--machzwd_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--pc87413_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--pc87413_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc60xxwdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc60xxwdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc8360_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc8360_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc_epx_c3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sbc_epx_c3.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sc520_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sc520_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -51,6 +51,13 @@ int del_timer(struct timer_list *arg0) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: ioremap_nocache
 // with type: void *ioremap_nocache(resource_size_t , unsigned long)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sch311x_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sch311x_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--smsc37b787_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--smsc37b787_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -25,6 +25,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--softdog_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--softdog_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void emergency_restart() {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83697hf_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83697hf_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83697ug_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83697ug_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83877f_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83877f_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83977f_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--w83977f_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -17,6 +17,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wafer5823wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wafer5823wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -9,6 +9,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: __request_region
 // with type: struct resource *__request_region(struct resource *, resource_size_t , resource_size_t , const char *, int)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wdt_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wdt_pci.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -67,6 +67,13 @@ void free_irq(unsigned int arg0, void *arg1) {
   // Void type
   return;
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: kmem_cache_alloc
 // with type: void *kmem_cache_alloc(struct kmem_cache *, gfp_t )

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wm831x_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--wm831x_wdt.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
   // Simple type
   return __VERIFIER_nondet_int();
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: dev_get_drvdata
 // with type: void *dev_get_drvdata(const struct device *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--xen--xenfs--xenfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--xen--xenfs--xenfs.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ struct timespec current_kernel_time() {
   // Composite type
   return *(struct timespec *)ldv_xmalloc(sizeof(struct timespec));
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: d_alloc_name
 // with type: struct dentry *d_alloc_name(struct dentry *, const char *)

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--xen--xenfs--xenfs_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--xen--xenfs--xenfs_false-termination.ko-ldv_main1_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -18,6 +18,13 @@ struct timespec current_kernel_time() {
   // Composite type
   return *(struct timespec *)ldv_xmalloc(sizeof(struct timespec));
 }
+extern _Bool __VERIFIER_nondet_bool(void) ;
+extern void *malloc(size_t) ;
+void *ldv_malloc(size_t size )
+{
+  if(__VERIFIER_nondet_bool()) return 0;
+  return malloc(size);
+}
 
 // Function: d_alloc_name
 // with type: struct dentry *d_alloc_name(struct dentry *, const char *)


### PR DESCRIPTION
This is a fix-up to 79df7e73cf8ecc223fbd5d39cb2e3a53c17cfc91, which
added the changes to the preprocessed files only. The original comment
was:
In cddc3e6515cfc2f, calls to ldv_malloc were added to files that didn't
necessarily have a definition of ldv_malloc. This commit adds a definition such
that either a null pointer or malloc-allocated memory is returned.

The changes were done using the following command:
```
for f in c/ldv-*/model/*.[ci]
do
  grep -q 'ldv_malloc(' $f || continue
  grep -q '^void \?\* \?ldv_malloc(.*)[^;]*$' $f && continue
  dn=$(dirname $f)
  bn=$(basename $f _true-unreach-call.cil.out.env.c)
  bn=$(basename $bn _false-unreach-call.cil.out.env.c)
  sf=$dn/../$bn.cil.out.c
  if [ ! -e $sf ]
  then
    sf=$(grep -l "model/$(basename $f)" $dn/../*.c)
  fi
  if [ "x$sf" = "x" ] || [ ! -e $sf ]
  then
    echo "Unused model: $f"
    continue
  fi
  grep -q '^void \?\* \?ldv_malloc(.*)[^;]*$' $sf && continue
  perl -lne '/^typedef\s+.*\s+size_t;\s*$/ and exit(1)' $sf
  export t=$?
perl -i -e \
  '$s = 0; $d = 0; $b = 0; $m = 0; $t = $ENV{t}; $body = "";

   while(<>) {
     if(/^void \*ldv_malloc\(size_t size \) ;$/) {
       next if($d == 2);
     }
     if(/^(extern\s+)?(_Bool|bool)\s+__VERIFIER_nondet_bool(void) ?;\s*$/) {
       next if($b == 2);
       $b = 1;
     }
     if(/^(extern\s+)?void \*malloc\(size_t(\s+size)?\s*\) ;$/) {
       next if($m == 2);
       $m = 1;
     }
     if(/^typedef\s+.*\s+size_t;\s*$/) {
       next if($t == 2);
       $t = 1;
     }
     if($s == 2 || ($s == 0 && !/^\{/ && (/[;\}]\s*$/ || /^#/))) {
       print $body;
       $body = "";
       print;
     }
     else {
       $body .= $_;
       if($s == 1 && /^\}$/) {
         print $body;
         $body = "";
         $s = 0;
       }
       elsif($s == 0 && /\{/) { $s = 1; }
       elsif($s == 1) {
         if(/ldv_malloc\(.*\);\s*/) {
           if($b == 0) {
             print "extern _Bool __VERIFIER_nondet_bool(void) ;\n";
             $b = 2;
           }
           if($t == 0) {
             print "typedef unsigned long size_t;\n";
             $t = 2;
           }
           if($m == 0) {
             print "extern void *malloc(size_t) ;\n";
             $m = 2;
           }
           print "void *ldv_malloc(size_t size )\n";
           print "{\n";
           print "  if(__VERIFIER_nondet_bool()) return 0;\n";
           print "  return malloc(size);\n";
           print "}\n";
           $d = 2;
           print $body;
           $body = "";
           $s = 2;
         }
       }
     }
   }' \
  $f
done
```


