### PR TITLE
Consider IS_ERR in ldv_malloc - fixup models

### DIFF
--- a/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--hwmon--abituguru3.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--hwmon--abituguru3.ko-main.env.c
@@ -11,10 +11,17 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.env.c
@@ -11,10 +11,17 @@ void __const_udelay(unsigned long arg0) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __devm_request_region

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--amc6821.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--amc6821.ko-main.env.c
@@ -38,10 +38,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--asb100.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--asb100.ko-main.env.c
@@ -38,10 +38,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--max16065.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--max16065.ko-main.env.c
@@ -11,10 +11,17 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83781d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83781d.ko-main.env.c
@@ -38,10 +38,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83791d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83791d.ko-main.env.c
@@ -29,10 +29,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83792d.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--hwmon--w83792d.ko-main.env.c
@@ -29,10 +29,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--regulator--isl6271a-regulator.ko-main.env.c
+++ b/c/ldv-consumption/model/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--regulator--isl6271a-regulator.ko-main.env.c
@@ -20,10 +20,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_false-unreach-call.cil.out.env.c
@@ -64,10 +64,17 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __kmalloc

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-drbd-drbd.ko_true-unreach-call.cil.out.env.c
@@ -64,10 +64,17 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __kmalloc

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-loop.ko_false-unreach-call.cil.out.env.c
@@ -19,10 +19,17 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __kmalloc

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-paride-pt.ko_true-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-block-pktcdvd.ko_false-unreach-call.cil.out.env.c
@@ -37,10 +37,17 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, struct lock_class_key *arg1)
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __kmalloc

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-bluetooth-btmrvl_false-termination.ko_true-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-gpu-drm-i915-i915.ko_true-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-hwmon-it87.ko_true-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-ppp_generic.ko_false-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-net-wan-farsync.ko_false-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-usb-core-usbcore.ko_false-unreach-call.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.0/model/module_get_put-drivers-video-aty-aty128fb.ko_true-unreach-call.cil.out.env.c
+++ b/c/ldv-linux-3.0/model/module_get_put-drivers-video-aty-aty128fb.ko_true-unreach-call.cil.out.env.c
@@ -28,10 +28,17 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--mv_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_false-unreach-call_ok_linux-43_1a-drivers--usb--gadget--mv_udc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void ___udelay(unsigned long arg0) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __alloc_workqueue_key

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--acpi--fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -58,10 +58,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: free

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--hw_random--virtio-rng.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,10 +36,17 @@ void hwrng_unregister(struct hwrng *arg0) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: kmem_cache_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--char--ramoops.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--gsmi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--firmware--google--gsmi_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,10 +46,13 @@ int atomic_notifier_chain_unregister(struct atomic_notifier_head *arg0, struct n
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dma_pool_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--ads7871.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -29,10 +29,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: hwmon_device_register

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--asus_atk0110.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--asus_atk0110.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -85,10 +85,13 @@ acpi_status acpi_evaluate_object_typed(acpi_handle arg0, acpi_string arg1, struc
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: acpi_format_exception

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--emc1403.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--emc1403.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--f71805f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--f71805f.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,10 +28,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--gpio-fan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -54,10 +54,13 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--max1111.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,10 +28,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pcf8591.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--pcf8591.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--smsc47b397_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--hwmon--smsc47b397_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -28,10 +28,13 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,13 @@ int del_timer_sync(struct timer_list *arg0) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ad714x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,17 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: ad714x_probe

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--adxl34x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--adxl34x-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,17 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: adxl34x_probe

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--cma3000_d0x_i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--cma3000_d0x_i2c_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--ad7879-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--ad7879-spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: ad7879_probe

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--cyttsp_spi_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,17 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: cyttsp_probe

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-regulator_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--leds--leds-regulator_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -57,10 +57,13 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: kfree

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_bus.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,17 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: get_device

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--message--i2o--i2o_scsi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--tps65217.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,10 +21,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mfd--wm8400-core.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -29,10 +29,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--vmw_balloon_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--misc--vmw_balloon_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -53,10 +53,17 @@ int _cond_resched() {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: alloc_pages_current

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ubi--gluebi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--mtd--ubi--gluebi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: kfree

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl1251--wl1251_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl1251--wl1251_spi.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __netdev_alloc_skb

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--net--wireless--wl12xx--wl12xx_sdio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -12,10 +12,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __netdev_alloc_skb

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--intel_menlow.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--intel_menlow.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -93,10 +93,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: kfree

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -57,10 +57,13 @@ acpi_status acpi_evaluate_object(acpi_handle arg0, acpi_string arg1, struct acpi
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: backlight_device_register

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--gpio-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--gpio-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max1586.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max1586.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -32,10 +32,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max8649.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--max8649.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,10 +21,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--virtual.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -29,10 +29,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-dcdc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-dcdc.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -29,10 +29,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-isink.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,10 +21,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm831x-ldo.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,10 +21,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--regulator--wm8400-regulator.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-da9052.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -12,10 +12,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1390.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1390.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -30,10 +30,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds1553.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3232.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3232.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,10 +46,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-ds3234.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -39,10 +39,17 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: kmem_cache_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t93.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -47,10 +47,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m41t94.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -47,10 +47,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-m48t86.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -39,10 +39,17 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: kmem_cache_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-max6902.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -30,10 +30,17 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: kmem_cache_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-mc13xxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-mc13xxx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -12,10 +12,13 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-pcf2123.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-pcf2123.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -81,10 +81,13 @@ void device_remove_file(struct device *arg0, const struct device_attribute *arg1
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: kfree

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-r9701.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -56,10 +56,17 @@ int dev_set_drvdata(struct device *arg0, void *arg1) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: kmem_cache_alloc

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-rs5c348.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-rs5c348.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -56,10 +56,13 @@ int dev_warn(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Skip function: kfree

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-stk17ta8.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-test.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -12,10 +12,17 @@ int _dev_info(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-v3020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-v3020.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -64,10 +64,13 @@ unsigned char bin2bcd(unsigned int arg0) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--rtc--rtc-wm831x.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -21,10 +21,17 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_class_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--staging--android--switch--switch_class_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,16 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--target--loopback--tcm_loop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -1,9 +1,12 @@
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 // Skip function: __VERIFIER_error
 

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ili9320_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ili9320_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -46,10 +46,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--l4f00242t03.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -63,10 +63,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--lms283gf05.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -36,10 +36,13 @@ int dev_err(const struct device *arg0, const char *arg1, ...) {
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--video--backlight--ltv350qv.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,13 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: dev_get_drvdata

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--acquirewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--acquirewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,10 +19,17 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--advantechwdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--advantechwdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -11,10 +11,17 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--geodewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--geodewdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -20,10 +20,17 @@ unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2)
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: cs5535_mfgpt_alloc_timer

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ib700wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--ib700wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,10 +19,17 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region

--- a/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sch311x_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
+++ b/c/ldv-linux-3.4-simple/model/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--watchdog--sch311x_wdt_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.env.c
@@ -19,10 +19,17 @@ void __release_region(struct resource *arg0, resource_size_t arg1, resource_size
 }
 extern _Bool __VERIFIER_nondet_bool(void) ;
 extern void *malloc(size_t) ;
+__inline static  IS_ERR(void const *ptr ) ;
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
 void *ldv_malloc(size_t size )
 {
   if(__VERIFIER_nondet_bool()) return 0;
-  return malloc(size);
+  void *p = malloc(size);
+  assume_abort_if_not(IS_ERR(p) == 0);
+  return p;
 }
 
 // Function: __request_region


### PR DESCRIPTION
Note: this will be kept in draft status until #1116 is merged, the commit of which currently also is included in this PR.

This is a fix-up to 741de9b81b5269097e1782d1245986ff435f4e8a, which
introduced those changes in preprocessed files. The original comment
was:
The Linux kernel uses addresses near (unsigned long)-1 to indicate
errors. ldv_is_err and IS_ERR catch this, and calls to malloc must not
interfere with this.

The changes were done using the following command:
```
for f in c/ldv-*/model/*.[ci]
do
  dn=$(dirname $f)
  bn=$(basename $f _true-unreach-call.cil.out.env.c)
  bn=$(basename $bn _false-unreach-call.cil.out.env.c)
  [ "$bn" = "common.env.c" ] && continue
  [ "$bn" = "mutex.c" ] && continue
  [ "$bn" = "list-set-impl.c" ] && continue
  sf=$dn/../$bn.cil.out.c
  if [ ! -e $sf ]
  then
    sf=$(grep -l "model/$(basename $f)" $dn/../*.c)
  fi
  if [ "x$sf" = "x" ] || [ ! -e $sf ]
  then
    echo "Unused model: $f"
    continue
  fi
grep -q -w '= IS_ERR' $sf || continue
export is_err_type=$(grep -w IS_ERR -m 1 $f | cut -f3 -d" ")
perl -lne '/^void assume_abort_if_not\(/ and exit(1)' $sf
export a=$?
perl -i -e \
  '$s = 0; $e = 0; $p = ""; $a = $ENV{a};
   while(<>) {
     if(/^long ldv_is_err\(void const \*ptr \) ;\s*$/) {
       $e = 1;
     }
     elsif(/^__inline static (long|bool) IS_ERR\(void( const)? \*ptr \)( ;)?\s*$/) {
       $e = 2;
     }
     elsif(/^static inline long IS_ERR\(const void \*ptr\)\s*$/) {
       $e = 2;
     }
     elsif(/^void \*ldv_(x)?[cmz]alloc\(size_t size \)\s*$/) {
       $p = $_;
       $s = 1;
       next;
     }
     elsif(/^void assume_abort_if_not\($/) {
       $a = 1;
     }
     elsif($s == 1) {
       if(/ldv_is_err/ || /IS_ERR/ || /tmp = ldv_calloc/) {
         $p .= $_;
         print $p;
         $p = "";
         $s = 0;
       }
       elsif(/^  return malloc\(size\);$/) {
         if($e == 0) {
           print "__inline static $ENV{is_err_type} IS_ERR(void const *ptr ) ;\n";
           $e = 2;
         }
         if($a == 0) {
           print "extern void abort(void);\n";
           print "void assume_abort_if_not(int cond) {\n";
           print "  if(!cond) {abort();}\n";
           print "}\n";
           $a = 1;
         }
         print $p;
         $p = "";
         print "  void *p = malloc(size);\n";
         if($e == 1) {
           print "  assume_abort_if_not(ldv_is_err(p) == 0);\n";
         }
         else {
           print "  assume_abort_if_not(IS_ERR(p) == 0);\n";
         }
         print "  return p;\n";
         $s = 0;
       }
       elsif(/^    return \(p\);$/) {
         if($e == 0) {
           print "__inline static $ENV{is_err_type} IS_ERR(void const *ptr ) ;\n";
           $e = 2;
         }
         if($a == 0) {
           print "extern void abort(void);\n";
           print "void assume_abort_if_not(int cond) {\n";
           print "  if(!cond) {abort();}\n";
           print "}\n";
           $a = 1;
         }
         print $p;
         $p = "";
         if($e == 1) {
           print "    assume_abort_if_not(ldv_is_err(p) == 0);\n";
         }
         else {
           print "    assume_abort_if_not(IS_ERR(p) == 0);\n";
         }
         print "    return (p);\n";
         $s = 0;
       }
       elsif(/^  return calloc\(1UL, size\);$/) {
         if($e == 0) {
           print "__inline static $ENV{is_err_type} IS_ERR(void const *ptr ) ;\n";
           $e = 2;
         }
         if($a == 0) {
           print "extern void abort(void);\n";
           print "void assume_abort_if_not(int cond) {\n";
           print "  if(!cond) {abort();}\n";
           print "}\n";
           $a = 1;
         }
         print $p;
         $p = "";
         print "  void *p = calloc(1UL, size);\n";
         if($e == 1) {
           print "  assume_abort_if_not(ldv_is_err(p) == 0);\n";
         }
         else {
           print "  assume_abort_if_not(IS_ERR(p) == 0);\n";
         }
         print "  return p;\n";
         $s = 0;
       }
       elsif(/^\}/) {
         print "e=$e\n";
         $p = "";
         $s = 0;
       }
       else {
         $p .= $_;
       }
       next;
     }
     print;
   }' \
  $f
done
```