### PR TITLE
Option 'data_model' is only for 'C' programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,20 +133,20 @@ currently, there are verification tasks for the ILP32 (32-bit) and the LP64 (64-
 In order to obtain verification tasks from the programs and specifications in the repository,
 a simple task-definition mechanism is used.
 For each program, the repository contains a .yml file that specifies the following items:
-  - `format_version`: the version of the format (a version string. One of `1.0`, `2.0`)
+  - `format_version`: the version of the format (a version string, one of `1.0`, `2.0`)
   - `input_files`: the subject program files or directories
     (a file or directory name, or a list of files or directory names, that the program consists of)
   - `properties`: the properties that constitute the specification of the program,
     each consisting of the following items:
     - `property_file`: file that contains a property definition
       (cf. common property files [for C][C-props] and [for Java][Java-props])
-    - `expected_verdict`: the intended verification result (`true` or `false`, optional for coverage properties)
+    - `expected_verdict`: the intended verification result (`true` or `false`, only for non-coverage properties)
     - `subproperty` (optional): a subproperty of the property that is violated
       in cases where the property is a conjunction of subproperties (for verdict `false`)
   - `options`: parameters that are relevant for verification or give extra information:
     - `language`: programming language that the program is written in (`C` or `Java`)
     - `data_model` data model of the computer architecture
-      (`ILP32`, `LP64`, see http://www.unix.org/whitepapers/64bit.html)
+      (`ILP32`, `LP64`, see http://www.unix.org/whitepapers/64bit.html, only for `C` programs)
 
 Optional items are explicitly marked as optional, all other items are mandatory.
 The dictionary `options` can contain additional data that are not mentioned above.


### PR DESCRIPTION
PR #1112 reveals that option 'data_model' is only for 'C' programs.