### PR TITLE
Add .set and .cfg file for new (demo) category on data races

### DIFF
--- a/c/NoDataRace-Main.cfg
+++ b/c/NoDataRace-Main.cfg
@@ -1,0 +1,2 @@
+Description: Contains problems regarding the detection of data races.
+Architecture: 32 bit

--- a/c/NoDataRace-Main.set
+++ b/c/NoDataRace-Main.set
@@ -1,1 +1,5 @@
 ldv-races/*.yml
+pthread/*.yml
+pthread-atomic/*.yml
+pthread-ext/*.yml
+pthread-lit/*.yml

--- a/c/NoDataRace-Main.set
+++ b/c/NoDataRace-Main.set
@@ -1,0 +1,1 @@
+ldv-races/*.yml


### PR DESCRIPTION
This PR adds a first set file for the planned demo category on detecting data races.

There are already some tasks that were merged with https://github.com/sosy-lab/sv-benchmarks/pull/1107,
but of course we need more tasks, please contribute (and extend NoDataRace-Main.set to include your tasks)!

I also added a `cfg` file just to be consistent, but this will probably be deleted soon anyway now since we have #1111 merged.