### PR TITLE
fix build errors

### DIFF
--- a/c/NoDataRace-Main.cfg
+++ b/c/NoDataRace-Main.cfg
@@ -1,0 +1,2 @@
+Description: Contains problems regarding the detection of data races.
+Architecture: 32 bit

--- a/c/NoDataRace-Main.set
+++ b/c/NoDataRace-Main.set
@@ -1,1 +1,5 @@
 ldv-races/*.yml
+pthread/*.yml
+pthread-atomic/*.yml
+pthread-ext/*.yml
+pthread-lit/*.yml

--- a/c/NoDataRace-Main.set
+++ b/c/NoDataRace-Main.set
@@ -1,0 +1,1 @@
+ldv-races/*.yml

--- a/c/aws-c-common/prelude.h
+++ b/c/aws-c-common/prelude.h
@@ -3,7 +3,7 @@
 typedef _Bool bool;
 
 extern void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 extern void abort(void); 
 void assume_abort_if_not(_Bool cond) { 
   if(!cond) {abort();}

--- a/c/busybox-1.22.0-todo/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cal_false-unreach-call_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/cat_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/cat_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cat_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/chmod_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/chmod_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chmod_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/cp-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/cp-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cp-incomplete_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/dos2unix_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/dos2unix_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "dos2unix_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "expr_false-unreach-call_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0-todo/id-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/id-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "id-incomplete_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/ln_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/ln_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ln_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/mv-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/mv-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mv-incomplete_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/pwd_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/pwd_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "pwd_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/rmdir_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/rmdir_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "rmdir_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/tail_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/tail_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tail_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/tty_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/tty_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tty_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0-todo/uuencode_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/uuencode_true-no-overflow_true-valid-memsafety.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uuencode_true-no-overflow_true-valid-memsafety.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/basename-1.i
+++ b/c/busybox-1.22.0/basename-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "basename-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/basename-2.i
+++ b/c/busybox-1.22.0/basename-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "basename-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/busybox_sv_comp.h
+++ b/c/busybox-1.22.0/busybox_sv_comp.h
@@ -9,4 +9,4 @@ void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
 }
 extern void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }

--- a/c/busybox-1.22.0/chgrp-incomplete-1.i
+++ b/c/busybox-1.22.0/chgrp-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chgrp-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/chgrp-incomplete-2.i
+++ b/c/busybox-1.22.0/chgrp-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chgrp-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/chroot-incomplete-1.i
+++ b/c/busybox-1.22.0/chroot-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chroot-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/chroot-incomplete-2.i
+++ b/c/busybox-1.22.0/chroot-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "chroot-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/cut-1.i
+++ b/c/busybox-1.22.0/cut-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cut-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/cut-2.i
+++ b/c/busybox-1.22.0/cut-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cut-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/date-1.i
+++ b/c/busybox-1.22.0/date-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "date-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/date-2.i
+++ b/c/busybox-1.22.0/date-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "date-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/dirname-1.i
+++ b/c/busybox-1.22.0/dirname-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "dirname-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/du-1.i
+++ b/c/busybox-1.22.0/du-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "du-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/du-2.i
+++ b/c/busybox-1.22.0/du-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "du-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/echo-1.i
+++ b/c/busybox-1.22.0/echo-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "echo-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/echo-2.i
+++ b/c/busybox-1.22.0/echo-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "echo-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/expand-1.i
+++ b/c/busybox-1.22.0/expand-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "expand-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/expand-2.i
+++ b/c/busybox-1.22.0/expand-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "expand-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/fold-1.i
+++ b/c/busybox-1.22.0/fold-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fold-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/fold-2.i
+++ b/c/busybox-1.22.0/fold-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fold-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/head-1.i
+++ b/c/busybox-1.22.0/head-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "head-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/head-2.i
+++ b/c/busybox-1.22.0/head-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "head-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/head-3.i
+++ b/c/busybox-1.22.0/head-3.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "head-3.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/hostid.i
+++ b/c/busybox-1.22.0/hostid.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "hostid.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/logname-1.i
+++ b/c/busybox-1.22.0/logname-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "logname-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/logname-2.i
+++ b/c/busybox-1.22.0/logname-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "logname-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/ls-incomplete-1.i
+++ b/c/busybox-1.22.0/ls-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ls-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/ls-incomplete-2.i
+++ b/c/busybox-1.22.0/ls-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ls-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/mkdir-1.i
+++ b/c/busybox-1.22.0/mkdir-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mkdir-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/mkdir-2.i
+++ b/c/busybox-1.22.0/mkdir-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mkdir-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/mkfifo-incomplete-1.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mkfifo-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/mkfifo-incomplete-2.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mkfifo-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/od-1.i
+++ b/c/busybox-1.22.0/od-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "od-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/od-2.i
+++ b/c/busybox-1.22.0/od-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "od-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/printf-1.i
+++ b/c/busybox-1.22.0/printf-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "printf-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/printf-2.i
+++ b/c/busybox-1.22.0/printf-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "printf-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/readlink-1.i
+++ b/c/busybox-1.22.0/readlink-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "readlink-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/readlink-2.i
+++ b/c/busybox-1.22.0/readlink-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "readlink-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/realpath-1.i
+++ b/c/busybox-1.22.0/realpath-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "realpath-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/realpath-2.i
+++ b/c/busybox-1.22.0/realpath-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "realpath-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/rm-1.i
+++ b/c/busybox-1.22.0/rm-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "rm-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/rm-2.i
+++ b/c/busybox-1.22.0/rm-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "rm-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/seq-1.i
+++ b/c/busybox-1.22.0/seq-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "seq-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/seq-2.i
+++ b/c/busybox-1.22.0/seq-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "seq-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/sleep-1.i
+++ b/c/busybox-1.22.0/sleep-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sleep-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/sleep-2.i
+++ b/c/busybox-1.22.0/sleep-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sleep-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/sleep-3.i
+++ b/c/busybox-1.22.0/sleep-3.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sleep-3.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/stty-1.i
+++ b/c/busybox-1.22.0/stty-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "stty-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/stty-2.i
+++ b/c/busybox-1.22.0/stty-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "stty-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/sync-1.i
+++ b/c/busybox-1.22.0/sync-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sync-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/sync-2.i
+++ b/c/busybox-1.22.0/sync-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sync-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/tac-1.i
+++ b/c/busybox-1.22.0/tac-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tac-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/tac-2.i
+++ b/c/busybox-1.22.0/tac-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tac-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/tee-1.i
+++ b/c/busybox-1.22.0/tee-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tee-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/tee-2.i
+++ b/c/busybox-1.22.0/tee-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tee-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/test-incomplete-1.i
+++ b/c/busybox-1.22.0/test-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/test-incomplete-2.i
+++ b/c/busybox-1.22.0/test-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/touch-1.i
+++ b/c/busybox-1.22.0/touch-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "touch-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/touch-2.i
+++ b/c/busybox-1.22.0/touch-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "touch-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/uname-1.i
+++ b/c/busybox-1.22.0/uname-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uname-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/uname-2.i
+++ b/c/busybox-1.22.0/uname-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uname-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/uniq-1.i
+++ b/c/busybox-1.22.0/uniq-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uniq-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/uniq-2.i
+++ b/c/busybox-1.22.0/uniq-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uniq-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/usleep-1.i
+++ b/c/busybox-1.22.0/usleep-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "usleep-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/usleep-2.i
+++ b/c/busybox-1.22.0/usleep-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "usleep-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/uudecode-1.i
+++ b/c/busybox-1.22.0/uudecode-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uudecode-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/uudecode-2.i
+++ b/c/busybox-1.22.0/uudecode-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "uudecode-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/wc-1.i
+++ b/c/busybox-1.22.0/wc-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "wc-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/wc-2.i
+++ b/c/busybox-1.22.0/wc-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "wc-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/who-1.i
+++ b/c/busybox-1.22.0/who-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "who-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/who-2.i
+++ b/c/busybox-1.22.0/who-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "who-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef __builtin_va_list __gnuc_va_list;
 
 extern void closelog (void);

--- a/c/busybox-1.22.0/whoami-incomplete-1.i
+++ b/c/busybox-1.22.0/whoami-incomplete-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "whoami-incomplete-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/whoami-incomplete-2.i
+++ b/c/busybox-1.22.0/whoami-incomplete-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "whoami-incomplete-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/yes-1.i
+++ b/c/busybox-1.22.0/yes-1.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "yes-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/busybox-1.22.0/yes-2.i
+++ b/c/busybox-1.22.0/yes-2.i
@@ -19,7 +19,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "yes-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "busybox_sv_comp.h", 12, __extension__ __PRETTY_FUNCTION__); })); }
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/ldv-sets/model/ldv.h
+++ b/c/ldv-sets/model/ldv.h
@@ -1,5 +1,5 @@
 void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/ldv-sets/test_add-1.i
+++ b/c/ldv-sets/test_add-1.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_add-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_add-2.i
+++ b/c/ldv-sets/test_add-2.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_add-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex.i
+++ b/c/ldv-sets/test_mutex.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex_double_lock.i
+++ b/c/ldv-sets/test_mutex_double_lock.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex_double_lock.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex_double_unlock.i
+++ b/c/ldv-sets/test_mutex_double_unlock.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex_double_unlock.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex_unbounded-1.i
+++ b/c/ldv-sets/test_mutex_unbounded-1.i
@@ -563,7 +563,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex_unbounded-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex_unbounded-2.i
+++ b/c/ldv-sets/test_mutex_unbounded-2.i
@@ -563,7 +563,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex_unbounded-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/ldv-sets/test_mutex_unlock_at_exit.i
+++ b/c/ldv-sets/test_mutex_unlock_at_exit.i
@@ -559,7 +559,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "test_mutex_unlock_at_exit.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ldv.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/MADWiFi-encode_ie_ok.i
+++ b/c/loop-invgen/MADWiFi-encode_ie_ok.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "MADWiFi-encode_ie_ok.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/NetBSD_loop.i
+++ b/c/loop-invgen/NetBSD_loop.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "NetBSD_loop.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/SpamAssassin-loop.i
+++ b/c/loop-invgen/SpamAssassin-loop.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "SpamAssassin-loop.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/apache-escape-absolute.i
+++ b/c/loop-invgen/apache-escape-absolute.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "apache-escape-absolute.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/apache-get-tag.i
+++ b/c/loop-invgen/apache-get-tag.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "apache-get-tag.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/assert.h
+++ b/c/loop-invgen/assert.h
@@ -1,5 +1,5 @@
 extern void abort(void); 
-void reach_error(){}                                             
+void reach_error() { assert(0); }                                             
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/loop-invgen/down.i
+++ b/c/loop-invgen/down.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "down.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/fragtest_simple.i
+++ b/c/loop-invgen/fragtest_simple.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fragtest_simple.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/half_2.i
+++ b/c/loop-invgen/half_2.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "half_2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/heapsort.i
+++ b/c/loop-invgen/heapsort.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "heapsort.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/id_build.i
+++ b/c/loop-invgen/id_build.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "id_build.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/id_trans.i
+++ b/c/loop-invgen/id_trans.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "id_trans.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/large_const.i
+++ b/c/loop-invgen/large_const.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "large_const.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/nest-if3.i
+++ b/c/loop-invgen/nest-if3.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nest-if3.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/nested6.i
+++ b/c/loop-invgen/nested6.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nested6.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/nested9.i
+++ b/c/loop-invgen/nested9.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nested9.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/sendmail-close-angle.i
+++ b/c/loop-invgen/sendmail-close-angle.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sendmail-close-angle.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/seq-3.i
+++ b/c/loop-invgen/seq-3.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "seq-3.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/string_concat-noarr.i
+++ b/c/loop-invgen/string_concat-noarr.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "string_concat-noarr.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-invgen/up.i
+++ b/c/loop-invgen/up.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "up.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/afnp2014.i
+++ b/c/loop-lit/afnp2014.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "afnp2014.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/assert.h
+++ b/c/loop-lit/assert.h
@@ -1,5 +1,5 @@
 extern void abort(void); 
-void reach_error(){}                                             
+void reach_error() { assert(0); }                                             
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/loop-lit/bhmr2007.i
+++ b/c/loop-lit/bhmr2007.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "bhmr2007.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/cggmp2005.i
+++ b/c/loop-lit/cggmp2005.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cggmp2005.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/cggmp2005_variant.i
+++ b/c/loop-lit/cggmp2005_variant.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cggmp2005_variant.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/cggmp2005b.i
+++ b/c/loop-lit/cggmp2005b.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "cggmp2005b.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/css2003.i
+++ b/c/loop-lit/css2003.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "css2003.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/ddlm2013.i
+++ b/c/loop-lit/ddlm2013.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ddlm2013.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/gcnr2008.i
+++ b/c/loop-lit/gcnr2008.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gcnr2008.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/gj2007.i
+++ b/c/loop-lit/gj2007.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gj2007.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/gj2007b.i
+++ b/c/loop-lit/gj2007b.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gj2007b.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/gr2006.i
+++ b/c/loop-lit/gr2006.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gr2006.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/gsv2008.i
+++ b/c/loop-lit/gsv2008.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gsv2008.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/hhk2008.i
+++ b/c/loop-lit/hhk2008.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "hhk2008.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/jm2006.i
+++ b/c/loop-lit/jm2006.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "jm2006.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/jm2006_variant.i
+++ b/c/loop-lit/jm2006_variant.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "jm2006_variant.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-lit/mcmillan2006.i
+++ b/c/loop-lit/mcmillan2006.i
@@ -10,7 +10,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mcmillan2006.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/assert.h
+++ b/c/loop-new/assert.h
@@ -1,5 +1,5 @@
 extern void abort(void); 
-void reach_error(){}                                             
+void reach_error() { assert(0); }                                             
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/loop-new/count_by_1.i
+++ b/c/loop-new/count_by_1.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "count_by_1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/count_by_1_variant.i
+++ b/c/loop-new/count_by_1_variant.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "count_by_1_variant.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/count_by_2.i
+++ b/c/loop-new/count_by_2.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "count_by_2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/count_by_k.i
+++ b/c/loop-new/count_by_k.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "count_by_k.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/count_by_nondet.i
+++ b/c/loop-new/count_by_nondet.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "count_by_nondet.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/gauss_sum.i
+++ b/c/loop-new/gauss_sum.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "gauss_sum.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/half.i
+++ b/c/loop-new/half.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "half.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/loop-new/nested-1.i
+++ b/c/loop-new/nested-1.i
@@ -9,7 +9,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nested-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/openbsd-6.2/if_etherip-double-free.i
+++ b/c/openbsd-6.2/if_etherip-double-free.i
@@ -188,8 +188,6 @@ extern void __assert_fail (const char *__assertion, const char *__file,
 extern void __assert_perror_fail (int __errnum, const char *__file,
       unsigned int __line, const char *__function)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sv_comp.h", 4, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);

--- a/c/openbsd-6.2/if_etherip-double-free.i
+++ b/c/openbsd-6.2/if_etherip-double-free.i
@@ -191,7 +191,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "if_etherip-double-free.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sv_comp.h", 4, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/openbsd-6.2/if_etherip-fixed-double-free.i
+++ b/c/openbsd-6.2/if_etherip-fixed-double-free.i
@@ -191,7 +191,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "if_etherip-fixed-double-free.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sv_comp.h", 4, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/openbsd-6.2/if_etherip-fixed-double-free.i
+++ b/c/openbsd-6.2/if_etherip-fixed-double-free.i
@@ -188,8 +188,6 @@ extern void __assert_fail (const char *__assertion, const char *__file,
 extern void __assert_perror_fail (int __errnum, const char *__file,
       unsigned int __line, const char *__function)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sv_comp.h", 4, __extension__ __PRETTY_FUNCTION__); })); }
 void abort(void);

--- a/c/openbsd-6.2/sources/stubs/sv_comp.h
+++ b/c/openbsd-6.2/sources/stubs/sv_comp.h
@@ -1,7 +1,7 @@
 #include "sys/types.h"
 
 void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/pthread-divine/barrier_2t.i
+++ b/c/pthread-divine/barrier_2t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "barrier_2t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/barrier_3t.i
+++ b/c/pthread-divine/barrier_3t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "barrier_3t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/condvar.i
+++ b/c/pthread-divine/condvar.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "condvar.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 pthread_mutex_t lock;
 pthread_cond_t cond;
 int x;

--- a/c/pthread-divine/condvar_spurious_wakeup.i
+++ b/c/pthread-divine/condvar_spurious_wakeup.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "condvar_spurious_wakeup.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 pthread_mutex_t lock;
 pthread_cond_t cond;
 int x;

--- a/c/pthread-divine/divinefifo-bug_1w1r.i
+++ b/c/pthread-divine/divinefifo-bug_1w1r.i
@@ -990,7 +990,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divinefifo-bug_1w1r.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 struct FifoNode_ {
     int *read;
     int buffer[ 2 ];

--- a/c/pthread-divine/divinefifo_1w1r.i
+++ b/c/pthread-divine/divinefifo_1w1r.i
@@ -990,7 +990,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divinefifo_1w1r.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 struct FifoNode_ {
     int *read;
     int buffer[ 2 ];

--- a/c/pthread-divine/one_time_barrier_2t.i
+++ b/c/pthread-divine/one_time_barrier_2t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "one_time_barrier_2t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/one_time_barrier_3t.i
+++ b/c/pthread-divine/one_time_barrier_3t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "one_time_barrier_3t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/one_time_barrier_twice_2t.i
+++ b/c/pthread-divine/one_time_barrier_twice_2t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "one_time_barrier_twice_2t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/one_time_barrier_twice_3t.i
+++ b/c/pthread-divine/one_time_barrier_twice_3t.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "one_time_barrier_twice_3t.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _barrier {
     int thread_count;
     int seen;

--- a/c/pthread-divine/ring_1w1r-1.i
+++ b/c/pthread-divine/ring_1w1r-1.i
@@ -800,7 +800,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ring_1w1r-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _ring {
     volatile long reader;
     long q[ 4 ];

--- a/c/pthread-divine/ring_1w1r-2.i
+++ b/c/pthread-divine/ring_1w1r-2.i
@@ -800,7 +800,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ring_1w1r-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _ring {
     volatile long reader;
     long q[ 4 ];

--- a/c/pthread-divine/ring_2w1r-1.i
+++ b/c/pthread-divine/ring_2w1r-1.i
@@ -800,7 +800,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ring_2w1r-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _ring {
     volatile long reader;
     long q[ 4 ];

--- a/c/pthread-divine/ring_2w1r-2.i
+++ b/c/pthread-divine/ring_2w1r-2.i
@@ -800,7 +800,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "ring_2w1r-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 typedef struct _ring {
     volatile long reader;
     long q[ 4 ];

--- a/c/pthread-divine/svc.h
+++ b/c/pthread-divine/svc.h
@@ -2,7 +2,7 @@
 #define SVC_H
 
 void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 
 #undef assert
 #define assert( X ) (!(X) ? reach_error() : (void)0)

--- a/c/pthread-divine/tls_basic.i
+++ b/c/pthread-divine/tls_basic.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tls_basic.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 void *worker( void *k ) {
     pthread_key_t *key = k;
     long val = (long)pthread_getspecific( *key );

--- a/c/pthread-divine/tls_destructor_worker.i
+++ b/c/pthread-divine/tls_destructor_worker.i
@@ -693,7 +693,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "tls_destructor_worker.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svc.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 void dtor( void *v ) {
     long val = (long)v;
     (!(val != 42) ? reach_error() : (void)0);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_nvram_llseek_read_nvram.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_nvram_llseek_write_nvram.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_nvram_unlocked_ioctl_write_nvram.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_read_nvram_nvram_unlocked_ioctl.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_generic_nvram_read_nvram_write_nvram.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set.i
@@ -164,7 +164,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "svcomp.h", 23, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-driver-races/model/svcomp.h
+++ b/c/pthread-driver-races/model/svcomp.h
@@ -20,7 +20,7 @@ extern void __VERIFIER_atomic_begin(void);
 extern void __VERIFIER_atomic_end(void);
 
 extern void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 

--- a/c/pthread-lit/assert.h
+++ b/c/pthread-lit/assert.h
@@ -2,7 +2,7 @@
 #define SVC_ASSERT_H
 
 extern void abort(void); 
-void reach_error(){}                                             
+void reach_error() { assert(0); }                                             
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 
   if(!cond) {abort();}

--- a/c/pthread-lit/fkp2013-1.i
+++ b/c/pthread-lit/fkp2013-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fkp2013-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/fkp2013-2.i
+++ b/c/pthread-lit/fkp2013-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fkp2013-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/fkp2013_variant-1.i
+++ b/c/pthread-lit/fkp2013_variant-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fkp2013_variant-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/fkp2013_variant-2.i
+++ b/c/pthread-lit/fkp2013_variant-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fkp2013_variant-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/fkp2014.i
+++ b/c/pthread-lit/fkp2014.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "fkp2014.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/qw2004-1.i
+++ b/c/pthread-lit/qw2004-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "qw2004-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/qw2004-2.i
+++ b/c/pthread-lit/qw2004-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "qw2004-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/qw2004_variant.i
+++ b/c/pthread-lit/qw2004_variant.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "qw2004_variant.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/sssc12.i
+++ b/c/pthread-lit/sssc12.i
@@ -988,7 +988,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sssc12.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-lit/sssc12_variant.i
+++ b/c/pthread-lit/sssc12_variant.i
@@ -988,7 +988,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "sssc12_variant.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 5, __extension__ __PRETTY_FUNCTION__); })); }
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread-nondet/assert.h
+++ b/c/pthread-nondet/assert.h
@@ -1,5 +1,5 @@
 extern void abort(void); 
-void reach_error(){}
+void reach_error() { assert(0); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void); 
 void assume_abort_if_not(int cond) { 

--- a/c/pthread-nondet/nondet-array-1.i
+++ b/c/pthread-nondet/nondet-array-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-array-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {

--- a/c/pthread-nondet/nondet-array-2.i
+++ b/c/pthread-nondet/nondet-array-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-array-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {

--- a/c/pthread-nondet/nondet-loop-bound-1.i
+++ b/c/pthread-nondet/nondet-loop-bound-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-loop-bound-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {

--- a/c/pthread-nondet/nondet-loop-bound-2.i
+++ b/c/pthread-nondet/nondet-loop-bound-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-loop-bound-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {

--- a/c/pthread-nondet/nondet-loop-bound-variant-1.i
+++ b/c/pthread-nondet/nondet-loop-bound-variant-1.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-loop-bound-variant-1.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {

--- a/c/pthread-nondet/nondet-loop-bound-variant-2.i
+++ b/c/pthread-nondet/nondet-loop-bound-variant-2.i
@@ -680,7 +680,7 @@ extern void __assert_perror_fail (int __errnum, const char *__file,
 extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "nondet-loop-bound-variant-2.c", , __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "assert.h", 2, __extension__ __PRETTY_FUNCTION__); })); }
 unsigned int __VERIFIER_nondet_uint();
 extern void abort(void);
 void assume_abort_if_not(int cond) {


### PR DESCRIPTION
Attempt to apply the first option of a possible solution as discussed in #1135 

Still has 2 issue:
1. Preprocessing fails for busybox
2. build fails for openbsd openbsd-6.2 because of clashing declaration of `__assert` 

Not sure if this is the best way forward.

fixes #1135 