### PR TITLE
Add a build script for the Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - images
   - checks
 
 sanity-checks:
@@ -104,3 +105,23 @@ java:
       - "java/results/*.results.Werror.xml*"
       - "java/results/*.html"
     when: always
+
+.build-docker:
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  script:
+    - mkdir -p /root/.docker
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+    - /kaniko/executor --dockerfile $CI_PROJECT_DIR/$DOCKERFILE --destination $CI_REGISTRY_IMAGE/$IMAGE
+  only:
+    - schedules
+    - web
+
+build-docker:java:latest:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: java/.Dockerfile
+    IMAGE: java:latest
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,13 +98,15 @@ java:
   script:
       # unset variables to not leak their content through result files
     - "unset $(compgen -v CI) $(compgen -v GIT)"
-    - "java/check-compile.sh"
+    - "sudo -u benchexec java/check-compile.sh"
   artifacts:
     paths:
       - "java/results/*logfiles*"
       - "java/results/*.results.Werror.xml*"
       - "java/results/*.html"
     when: always
+  tags:
+    - privileged
 
 .build-docker:
   image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,5 +123,5 @@ build-docker:java:latest:
   stage: images
   variables:
     DOCKERFILE: java/.Dockerfile
-    IMAGE: java:latest
+    IMAGE: ci/java:latest
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,34 @@ java:
     - schedules
     - web
 
+build-docker:clang:3.9:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: c/.Dockerfile.clang-3.9
+    IMAGE: ci/clang:3.9
+
+build-docker:gcc:5:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: c/.Dockerfile.gcc-5
+    IMAGE: ci/gcc:5
+
+build-docker:preprocessing-consistency:latest:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: c/.Dockerfile.preprocessing-consistency
+    IMAGE: ci/preprocessing-consistency:latest
+
+build-docker:sanity-checks:latest:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: c/.Dockerfile.sanity-checks
+    IMAGE: ci/sanity-checks:latest
+
 build-docker:java:latest:
   extends: .build-docker
   stage: images

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_install:
   - docker pull registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/${DOCKER_IMAGE}
 
 script:
-  - docker run --tty --volume "$(pwd):$(pwd)" registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/${DOCKER_IMAGE} /bin/sh -c "cd $(pwd); ${COMMAND}"
+  - docker run --privileged --tty --volume "$(pwd):$(pwd)" registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/${DOCKER_IMAGE} /bin/sh -c "cd $(pwd); ${COMMAND}"

--- a/java/.Dockerfile
+++ b/java/.Dockerfile
@@ -8,9 +8,12 @@
 
 FROM ubuntu:bionic
 
+RUN adduser --disabled-login --gecos "" benchexec
+
 RUN apt-get update && apt-get install -y \
   git \
   openjdk-8-jdk-headless \
-  python3-pip
+  python3-pip \
+  sudo
 
 RUN pip3 install git+https://github.com/sosy-lab/benchexec.git

--- a/java/check-compile.sh
+++ b/java/check-compile.sh
@@ -2,7 +2,8 @@
 set -eu
 cd "$(dirname "$0")"
 
-benchexec --no-container -r Werror -N 2 compile.xml
+[ -d bin ] || mkdir bin
+benchexec --read-only-dir / --hidden-dir bin -r Werror -N 2 compile.xml
 
 TABLE_GENERATOR_STATISTICS="$(table-generator results/compile.*.results.Werror.xml.bz2 -f html --dump)"
 echo "$TABLE_GENERATOR_STATISTICS"

--- a/java/compile.xml
+++ b/java/compile.xml
@@ -10,6 +10,7 @@
   </rundefinition>
 
   <option name="-source">1.8</option>
+  <option name="-d">bin</option>
 
   <tasks name="MinePump">
     <include>MinePump/*.yml</include>


### PR DESCRIPTION
Add a build script for the Docker image), so that we can update it via a schedule in GitLab.

Motivation: CI for Java uses an outdated BenchExec and thus, the CI fails for PR #1111. I would like to add a schedule to the CI that builds the Docker image weekly, and where I can press a button for a rebuild.