### PR TITLE
Add remaining data-model declarations

### DIFF
--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--atm--fore_200e.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--mtip32xx--mtip32xx.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--nvme.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--nvme.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--paride--pf.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--paride--pf.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--rsxx--rsxx.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--skd.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--skd.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--virtio_blk.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--block--xen-blkfront.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--char--ipmi--ipmi_msghandler.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--firewire--firewire-core.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--gpu--drm--ast--ast.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--gpu--drm--qxl--qxl.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: unknown
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--hid--hid-wiimote.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--hid--usbhid--usbhid.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--hwmon--applesmc.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--hwmon--nct6775.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--ide--ide-core.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--ide--ide-core.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--iio--accel--kxcjk-1013.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--infiniband--ulp--srp--ib_srp.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--input--misc--ims-pcu.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--input--touchscreen--elants_i2c.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--md--raid456.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--md--raid456.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--dvb-core--dvb-core.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--usb--dvb-usb-v2--dvb-usb-mxl111sf.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--usb--ttusb-budget--dvb-ttusb-budget.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--memstick--core--ms_block.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--memstick--core--mspro_block.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--misc--mic--host--mic_host.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--misc--sgi-gru--gru.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--mmc--card--mmc_test.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--mtd--sm_ftl.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--mtd--ubi--ubi.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: unknown
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--can--janz-ican3.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--8390--pcnet_cs.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--amd--amd8111e.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--atheros--alx--alx.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--atheros--atl1e--atl1e.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--broadcom--tg3.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: unknown
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--cisco--enic--enic.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--dec--tulip--dmfe.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--ethoc.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--icplus--ipg.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--intel--i40evf--i40evf.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--intel--igbvf--igbvf.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--qlogic--netxen--netxen_nic.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--qlogic--qlge--qlge.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ethernet--smsc--smc91c92_cs.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--ppp--ppp_generic.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--team--team.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--team--team.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--usb--kaweth.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--wireless--ath--ar5523--ar5523.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--wireless--rtl818x--rtl8180--rtl818x_pci.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--net--wireless--rtlwifi--rtl8192de--rtl8192de.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--nfc--port100.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--nfc--port100.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--BusLogic.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--aacraid--aacraid.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--advansys.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--advansys.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--be2iscsi--be2iscsi.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--esas2r--esas2r.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--hpsa.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--mvsas--mvsas.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--pm8001--pm80xx.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--qla4xxx--qla4xxx.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: unknown
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--scsi--sg.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--scsi--sg.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--staging--dgnc--dgnc.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--staging--ozwpan--ozwpan.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--class--cdc-wdm.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--gadget--udc--net2272.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--gadget--udc--pch_udc.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--host--isp116x-hcd.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--host--u132-hcd.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--misc--iowarrior.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: unknown
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--misc--legousbtower.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--misc--uss720.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--misc--yurex.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--usb--musb--musb_hdrc.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--video--fbdev--core--fb.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--video--fbdev--s3fb.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--video--fbdev--udlfb.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--vme--bridges--vme_ca91cx42.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---drivers--xen--xen-pciback--xen-pciback.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---fs--ncpfs--ncpfs.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---fs--nfs--nfsv2.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---fs--squashfs--squashfs.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---kernel--locking--locktorture.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---kernel--locking--locktorture.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---net--netfilter--nf_tables.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---net--netfilter--nfnetlink_log.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---net--rose--rose.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---net--rose--rose.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---sound--core--seq--oss--snd-seq-oss.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---sound--drivers--vx--snd-vx-lib.ko.cil.c.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.yml
+++ b/c/ldv-multiproperty/linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'linux-4.0-rc1---sound--pci--ice1712--snd-ice1724.ko.cil.c'
 
@@ -65,3 +65,7 @@ properties:
     expected_verdict: true
   - property_file: properties/unreach-call-usb_coherent.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: LP64

--- a/c/ldv-races/race-1_2b-join.yml
+++ b/c/ldv-races/race-1_2b-join.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 # old file name: race-1_2-join_false-unreach-call.i
 input_files: 'race-1_2b-join.i'
@@ -6,3 +6,7 @@ input_files: 'race-1_2b-join.i'
 properties:
   - property_file: ../properties/no-data-race.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/ldv-races/race-1_3b-join.yml
+++ b/c/ldv-races/race-1_3b-join.yml
@@ -1,4 +1,4 @@
-format_version: '1.0'
+format_version: '2.0'
 
 # old file name: race-1_3-join_false-unreach-call.i
 input_files: 'race-1_3b-join.i'
@@ -6,3 +6,7 @@ input_files: 'race-1_3b-join.i'
 properties:
   - property_file: ../properties/no-data-race.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-005.yml
+++ b/c/xcsp/AllInterval-005.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-005.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-006.yml
+++ b/c/xcsp/AllInterval-006.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-006.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-007.yml
+++ b/c/xcsp/AllInterval-007.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-007.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-008.yml
+++ b/c/xcsp/AllInterval-008.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-008.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-009.yml
+++ b/c/xcsp/AllInterval-009.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-009.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-010.yml
+++ b/c/xcsp/AllInterval-010.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-010.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-011.yml
+++ b/c/xcsp/AllInterval-011.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-011.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-012.yml
+++ b/c/xcsp/AllInterval-012.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-012.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-013.yml
+++ b/c/xcsp/AllInterval-013.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-013.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-014.yml
+++ b/c/xcsp/AllInterval-014.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-014.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-015.yml
+++ b/c/xcsp/AllInterval-015.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-015.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-016.yml
+++ b/c/xcsp/AllInterval-016.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-016.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-017.yml
+++ b/c/xcsp/AllInterval-017.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-017.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-018.yml
+++ b/c/xcsp/AllInterval-018.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-018.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-019.yml
+++ b/c/xcsp/AllInterval-019.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-019.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-020.yml
+++ b/c/xcsp/AllInterval-020.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-020.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-025.yml
+++ b/c/xcsp/AllInterval-025.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-025.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-030.yml
+++ b/c/xcsp/AllInterval-030.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-030.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/AllInterval-035.yml
+++ b/c/xcsp/AllInterval-035.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'AllInterval-035.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-10.yml
+++ b/c/xcsp/CostasArray-10.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-11.yml
+++ b/c/xcsp/CostasArray-11.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-11.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-12.yml
+++ b/c/xcsp/CostasArray-12.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-12.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-13.yml
+++ b/c/xcsp/CostasArray-13.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-13.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-14.yml
+++ b/c/xcsp/CostasArray-14.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-14.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-15.yml
+++ b/c/xcsp/CostasArray-15.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-15.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-16.yml
+++ b/c/xcsp/CostasArray-16.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-16.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/CostasArray-17.yml
+++ b/c/xcsp/CostasArray-17.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'CostasArray-17.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-015.yml
+++ b/c/xcsp/Dubois-015.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-015.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-016.yml
+++ b/c/xcsp/Dubois-016.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-016.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-017.yml
+++ b/c/xcsp/Dubois-017.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-017.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-018.yml
+++ b/c/xcsp/Dubois-018.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-018.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-019.yml
+++ b/c/xcsp/Dubois-019.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-019.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-020.yml
+++ b/c/xcsp/Dubois-020.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-020.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-021.yml
+++ b/c/xcsp/Dubois-021.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-021.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-022.yml
+++ b/c/xcsp/Dubois-022.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-022.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-023.yml
+++ b/c/xcsp/Dubois-023.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-023.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-024.yml
+++ b/c/xcsp/Dubois-024.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-024.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-025.yml
+++ b/c/xcsp/Dubois-025.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-025.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-026.yml
+++ b/c/xcsp/Dubois-026.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-026.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-027.yml
+++ b/c/xcsp/Dubois-027.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-027.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-028.yml
+++ b/c/xcsp/Dubois-028.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-028.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-029.yml
+++ b/c/xcsp/Dubois-029.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-029.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-030.yml
+++ b/c/xcsp/Dubois-030.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-030.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-035.yml
+++ b/c/xcsp/Dubois-035.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-035.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-040.yml
+++ b/c/xcsp/Dubois-040.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-040.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-045.yml
+++ b/c/xcsp/Dubois-045.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-045.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-050.yml
+++ b/c/xcsp/Dubois-050.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-050.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-055.yml
+++ b/c/xcsp/Dubois-055.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-055.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-060.yml
+++ b/c/xcsp/Dubois-060.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-060.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-065.yml
+++ b/c/xcsp/Dubois-065.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-065.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-070.yml
+++ b/c/xcsp/Dubois-070.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-070.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-075.yml
+++ b/c/xcsp/Dubois-075.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-075.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-080.yml
+++ b/c/xcsp/Dubois-080.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-080.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-085.yml
+++ b/c/xcsp/Dubois-085.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-085.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-090.yml
+++ b/c/xcsp/Dubois-090.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-090.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-095.yml
+++ b/c/xcsp/Dubois-095.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-095.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Dubois-100.yml
+++ b/c/xcsp/Dubois-100.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Dubois-100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-06.yml
+++ b/c/xcsp/Haystacks-06.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-06.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-07.yml
+++ b/c/xcsp/Haystacks-07.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-07.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-08.yml
+++ b/c/xcsp/Haystacks-08.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-08.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-09.yml
+++ b/c/xcsp/Haystacks-09.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-09.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-10.yml
+++ b/c/xcsp/Haystacks-10.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-11.yml
+++ b/c/xcsp/Haystacks-11.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-11.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-12.yml
+++ b/c/xcsp/Haystacks-12.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-12.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-13.yml
+++ b/c/xcsp/Haystacks-13.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-13.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-14.yml
+++ b/c/xcsp/Haystacks-14.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-14.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-15.yml
+++ b/c/xcsp/Haystacks-15.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-15.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-16.yml
+++ b/c/xcsp/Haystacks-16.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-16.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-17.yml
+++ b/c/xcsp/Haystacks-17.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-17.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-18.yml
+++ b/c/xcsp/Haystacks-18.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-18.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/Haystacks-19.yml
+++ b/c/xcsp/Haystacks-19.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'Haystacks-19.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-sat-1.yml
+++ b/c/xcsp/aim-100-1-6-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-sat-2.yml
+++ b/c/xcsp/aim-100-1-6-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-sat-3.yml
+++ b/c/xcsp/aim-100-1-6-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-sat-4.yml
+++ b/c/xcsp/aim-100-1-6-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-unsat-1.yml
+++ b/c/xcsp/aim-100-1-6-unsat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-unsat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-unsat-2.yml
+++ b/c/xcsp/aim-100-1-6-unsat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-unsat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-unsat-3.yml
+++ b/c/xcsp/aim-100-1-6-unsat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-unsat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-1-6-unsat-4.yml
+++ b/c/xcsp/aim-100-1-6-unsat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-1-6-unsat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-sat-1.yml
+++ b/c/xcsp/aim-100-2-0-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-sat-2.yml
+++ b/c/xcsp/aim-100-2-0-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-sat-3.yml
+++ b/c/xcsp/aim-100-2-0-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-sat-4.yml
+++ b/c/xcsp/aim-100-2-0-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-unsat-1.yml
+++ b/c/xcsp/aim-100-2-0-unsat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-unsat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-unsat-2.yml
+++ b/c/xcsp/aim-100-2-0-unsat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-unsat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-unsat-3.yml
+++ b/c/xcsp/aim-100-2-0-unsat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-unsat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-2-0-unsat-4.yml
+++ b/c/xcsp/aim-100-2-0-unsat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-2-0-unsat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-3-4-sat-1.yml
+++ b/c/xcsp/aim-100-3-4-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-3-4-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-3-4-sat-2.yml
+++ b/c/xcsp/aim-100-3-4-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-3-4-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-3-4-sat-3.yml
+++ b/c/xcsp/aim-100-3-4-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-3-4-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-3-4-sat-4.yml
+++ b/c/xcsp/aim-100-3-4-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-3-4-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-6-0-sat-1.yml
+++ b/c/xcsp/aim-100-6-0-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-6-0-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-6-0-sat-2.yml
+++ b/c/xcsp/aim-100-6-0-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-6-0-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-6-0-sat-3.yml
+++ b/c/xcsp/aim-100-6-0-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-6-0-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-100-6-0-sat-4.yml
+++ b/c/xcsp/aim-100-6-0-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-100-6-0-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-sat-1.yml
+++ b/c/xcsp/aim-200-1-6-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-sat-2.yml
+++ b/c/xcsp/aim-200-1-6-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-sat-3.yml
+++ b/c/xcsp/aim-200-1-6-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-sat-4.yml
+++ b/c/xcsp/aim-200-1-6-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-unsat-1.yml
+++ b/c/xcsp/aim-200-1-6-unsat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-unsat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-unsat-2.yml
+++ b/c/xcsp/aim-200-1-6-unsat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-unsat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-unsat-3.yml
+++ b/c/xcsp/aim-200-1-6-unsat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-unsat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-1-6-unsat-4.yml
+++ b/c/xcsp/aim-200-1-6-unsat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-1-6-unsat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-sat-1.yml
+++ b/c/xcsp/aim-200-2-0-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-sat-2.yml
+++ b/c/xcsp/aim-200-2-0-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-sat-3.yml
+++ b/c/xcsp/aim-200-2-0-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-sat-4.yml
+++ b/c/xcsp/aim-200-2-0-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-unsat-1.yml
+++ b/c/xcsp/aim-200-2-0-unsat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-unsat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-unsat-2.yml
+++ b/c/xcsp/aim-200-2-0-unsat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-unsat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-unsat-3.yml
+++ b/c/xcsp/aim-200-2-0-unsat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-unsat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-2-0-unsat-4.yml
+++ b/c/xcsp/aim-200-2-0-unsat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-2-0-unsat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-3-4-sat-1.yml
+++ b/c/xcsp/aim-200-3-4-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-3-4-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-3-4-sat-2.yml
+++ b/c/xcsp/aim-200-3-4-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-3-4-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-3-4-sat-3.yml
+++ b/c/xcsp/aim-200-3-4-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-3-4-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-3-4-sat-4.yml
+++ b/c/xcsp/aim-200-3-4-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-3-4-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-6-0-sat-1.yml
+++ b/c/xcsp/aim-200-6-0-sat-1.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-6-0-sat-1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-6-0-sat-2.yml
+++ b/c/xcsp/aim-200-6-0-sat-2.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-6-0-sat-2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-6-0-sat-3.yml
+++ b/c/xcsp/aim-200-6-0-sat-3.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-6-0-sat-3.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/xcsp/aim-200-6-0-sat-4.yml
+++ b/c/xcsp/aim-200-6-0-sat-4.yml
@@ -1,6 +1,10 @@
-format_version: '1.0'
+format_version: '2.0'
 
 input_files: 'aim-200-6-0-sat-4.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32


### PR DESCRIPTION
There were still some task-definition files with format version 1.0 and no data model. This PR fills this gap.

I have already written a corresponding check for `check.py`, I will add a new PR with it as part of more `check.py` improvements after this PR is merged (easier to review this way).