### PR TITLE
Remove cfg files for categories, update scripts and documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -15,7 +15,7 @@
 - [ ] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)
 
 <!-- For C programs: -->
-- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
+- [ ] [data model](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#data-model) present in task-definition file
 - [ ] original sources present
 - [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
 - [ ] preprocessed files generated with correct architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,12 @@ but for real-world programs GNU C is also acceptable.
 #### Task Definition
 
 For each verification problem,
-a separate [task definiton](https://github.com/sosy-lab/sv-benchmarks/blob/master/README.md#task-definitions)
+a separate [task definition](https://github.com/sosy-lab/sv-benchmarks/blob/master/README.md#task-definitions)
 in form of a `.yml` file is required that contains the file name of the verification task and
 the expected result for at least one [property](README.md#specifications).
 The `.yml` file should be named just like the original verification problem (except file ending).
 The task definition can contain additional information.
+For example, it needs to define the language (C or Java).
 
 
 #### Category
@@ -89,20 +90,17 @@ In order to be effectively used by people (e.g., in SV-COMP),
 the verification tasks need to be part of some category.
 Thus, please choose an appropriate category of [SV-COMP](https://sv-comp.sosy-lab.org/2017/benchmarks.php)
 and make sure that your programs are
-- matched by the `.set` file of the category by adding appropriate patterns,
-- are made to be verified against the specification in the `.prp` file of the category, and
-- are compatible to the parameters in the `.cfg` file of the category.
+- matched by the `.set` file of the category by adding appropriate patterns and
+- are made to be verified against the specification used by this category.
 
 Programs can also be part of several categories if more than one property is present.
 If a task does not fit in any existing category, you may propose a new category.
 
-#### Architecture
+#### Data Model
 
-Each category specifies an architecture (32-bit or 64-bit Linux systems) in its `.cfg` file,
-and all verification tasks of a category need to be valid
-assuming a system with the respective architecture.
+For C programs, the data model (`ILP32` or `LP64`)
+needs to be specified in the task-definition file.
 This mostly affects sizes of data types.
-Please check that the architecture of the category matches the one of your programs.
 
 #### Preprocessing
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ For some programs, this information is given in the header of the program as com
 The verification tasks for C programs are grouped into (sub-)categories
 as defined by [SV-COMP](https://sv-comp.sosy-lab.org/2017/benchmarks.php).
 
-A (sub-)category `<category>` is defined by the following three files:
-- `<category>.set` contains patterns that specify the set of programs,
-- `<category>.prp` contains the specification, and
-- `<category>.cfg` contains the parameters (and a description of the (sub-)category).
+A (sub-)category `<category>` is defined by a file named `<category>.set`
+that contains patterns that specify the set of programs.
 
 
 ## Definitions
@@ -72,8 +70,7 @@ A *verification task* consists of
 A *category* is a set of verification tasks.
 
 A *sub-category* is a set of verification tasks that consist of the same
-specification and the same parameters
-as specified in the corresponding `.cfg` and `.prp` files.
+specification.
 
 A *verification run* is
 - a non-interactive execution
@@ -122,7 +119,7 @@ explains those specifications.
 
 ### Parameters
 
-The paramaters of a verification task are needed to make additional information 
+The parameters of a verification task are needed to make additional information
 about the verification task available to the verification run.
 The most prominent parameter is the machine model;
 currently, there are verification tasks for the ILP32 (32-bit) and the LP64 (64-bit) architecture
@@ -132,8 +129,10 @@ currently, there are verification tasks for the ILP32 (32-bit) and the LP64 (64-
 
 In order to obtain verification tasks from the programs and specifications in the repository,
 a simple task-definition mechanism is used.
+We use [version 2.0 of this format](https://gitlab.com/sosy-lab/software/task-definition-format/-/tree/2.0)
+with some additional requirements.
 For each program, the repository contains a .yml file that specifies the following items:
-  - `format_version`: the version of the format (a version string, one of `1.0`, `2.0`)
+  - `format_version`: the version of the format (the version string `2.0`)
   - `input_files`: the subject program files or directories
     (a file or directory name, or a list of files or directory names, that the program consists of)
   - `properties`: the properties that constitute the specification of the program,

--- a/c/ConcurrencySafety-Main.cfg
+++ b/c/ConcurrencySafety-Main.cfg
@@ -1,3 +1,0 @@
-Description: Contains concurrency problems.
-Architecture: 32 bit
-

--- a/c/ConcurrencySafety-Main.set
+++ b/c/ConcurrencySafety-Main.set
@@ -1,3 +1,4 @@
+# Contains concurrency problems.
 pthread/*.yml
 pthread-atomic/*.yml
 pthread-ext/*.yml

--- a/c/DefinedBehavior-Arrays.cfg
+++ b/c/DefinedBehavior-Arrays.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking whether the program might run into undefined behavior.
-Architecture: 32 bit
-

--- a/c/DefinedBehavior-Arrays.set
+++ b/c/DefinedBehavior-Arrays.set
@@ -1,2 +1,3 @@
+# Contains tasks for checking whether the program might run into undefined behavior.
 array-examples/*.yml
 reducercommutativity/*.yml

--- a/c/DefinedBehavior-TerminCrafted.cfg
+++ b/c/DefinedBehavior-TerminCrafted.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking whether the program might run into undefined behavior.
-Architecture: 64 bit
-

--- a/c/DefinedBehavior-TerminCrafted.set
+++ b/c/DefinedBehavior-TerminCrafted.set
@@ -1,1 +1,2 @@
+# Contains tasks for checking whether the program might run into undefined behavior.
 termination-crafted/*.yml

--- a/c/Juliet_Test.cfg
+++ b/c/Juliet_Test.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of programs from Juliet Test Suite.
-Architecture: 64 bit
-

--- a/c/Juliet_Test.set
+++ b/c/Juliet_Test.set
@@ -1,2 +1,3 @@
+# Contains tasks for checking memory safety of programs from Juliet Test Suite.
 Juliet_Test/*.yml
 

--- a/c/MemSafety-Arrays.cfg
+++ b/c/MemSafety-Arrays.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of array-based programs.
-Architecture: 32 bit
-

--- a/c/MemSafety-Arrays.set
+++ b/c/MemSafety-Arrays.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking memory safety of array-based programs.
 array-memsafety/*.yml
 array-examples/*.yml
 array-memsafety-realloc/*.yml

--- a/c/MemSafety-Heap.cfg
+++ b/c/MemSafety-Heap.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of programs.
-Architecture: 32 bit
-

--- a/c/MemSafety-Heap.set
+++ b/c/MemSafety-Heap.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking memory safety of programs.
 memsafety/*.yml
 memsafety-ext/*.yml
 memsafety-ext2/*.yml

--- a/c/MemSafety-LinkedLists.cfg
+++ b/c/MemSafety-LinkedLists.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of programs.
-Architecture: 32 bit
-

--- a/c/MemSafety-LinkedLists.set
+++ b/c/MemSafety-LinkedLists.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking memory safety of programs.
 heap-manipulation/*.yml
 forester-heap/*.yml
 list-properties/*.yml

--- a/c/MemSafety-MemCleanup.cfg
+++ b/c/MemSafety-MemCleanup.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of programs.
-Architecture: 32 bit
-

--- a/c/MemSafety-MemCleanup.set
+++ b/c/MemSafety-MemCleanup.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking memory safety of programs.
 list-ext-properties/*.yml
 heap-manipulation/*.yml
 forester-heap/*.yml

--- a/c/MemSafety-Other.cfg
+++ b/c/MemSafety-Other.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of programs.
-Architecture: 32 bit
-

--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking memory safety of programs.
 loops/*.yml
 loop-acceleration/*.yml
 ntdrivers/*.yml

--- a/c/MemSafety-TerminCrafted.cfg
+++ b/c/MemSafety-TerminCrafted.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking memory safety of array-based programs.
-Architecture: 64 bit
-

--- a/c/MemSafety-TerminCrafted.set
+++ b/c/MemSafety-TerminCrafted.set
@@ -1,1 +1,2 @@
+# Contains tasks for checking memory safety of array-based programs.
 termination-crafted/*.yml

--- a/c/NoDataRace-Main.cfg
+++ b/c/NoDataRace-Main.cfg
@@ -1,2 +1,0 @@
-Description: Contains problems regarding the detection of data races.
-Architecture: 32 bit

--- a/c/NoDataRace-Main.set
+++ b/c/NoDataRace-Main.set
@@ -1,3 +1,4 @@
+# Contains problems regarding the detection of data races.
 ldv-races/*.yml
 pthread/*.yml
 pthread-atomic/*.yml

--- a/c/NoOverflows-BitVectors.cfg
+++ b/c/NoOverflows-BitVectors.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking if variables of type signed integers overflow.
-Architecture: 64 bit
-

--- a/c/NoOverflows-BitVectors.set
+++ b/c/NoOverflows-BitVectors.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking if variables of type signed integers overflow.
 signedintegeroverflow-regression/*.yml
 termination-crafted/*.yml
 termination-crafted-lit/*.yml

--- a/c/NoOverflows-Other.cfg
+++ b/c/NoOverflows-Other.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking if variables of type signed integers overflow.
-Architecture: 32 bit
-

--- a/c/NoOverflows-Other.set
+++ b/c/NoOverflows-Other.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking if variables of type signed integers overflow.
 recursive/*.yml
 recursive-simple/*.yml
 bitvector/*.yml

--- a/c/ReachSafety-Arrays.cfg
+++ b/c/ReachSafety-Arrays.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for which treatment of arrays is necessary in order to determine reachability.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Arrays.set
+++ b/c/ReachSafety-Arrays.set
@@ -1,3 +1,4 @@
+# Contains tasks for which treatment of arrays is necessary in order to determine reachability.
 array-examples/*.yml
 array-industry-pattern/*.yml
 reducercommutativity/*.yml

--- a/c/ReachSafety-BitVectors.cfg
+++ b/c/ReachSafety-BitVectors.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for which treatment of bit-operations is necessary.
-Architecture: 32 bit
-

--- a/c/ReachSafety-BitVectors.set
+++ b/c/ReachSafety-BitVectors.set
@@ -1,3 +1,4 @@
+# Contains tasks for which treatment of bit-operations is necessary.
 bitvector/*.yml
 bitvector-regression/*.yml
 bitvector-loops/*.yml

--- a/c/ReachSafety-ControlFlow.cfg
+++ b/c/ReachSafety-ControlFlow.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs for which the correctness depends mostly on the control-flow structure and integer variables. There is no particular focus on pointers, data structures, and concurrency.
-Architecture: 32 bit
-

--- a/c/ReachSafety-ControlFlow.set
+++ b/c/ReachSafety-ControlFlow.set
@@ -1,3 +1,4 @@
+# Contains programs for which the correctness depends mostly on the control-flow structure and integer variables. There is no particular focus on pointers, data structures, and concurrency.
 ntdrivers-simplified/*.yml
 openssl-simplified/*.yml
 locks/*.yml

--- a/c/ReachSafety-ECA.cfg
+++ b/c/ReachSafety-ECA.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs that represent event-condition-action systems.
-Architecture: 32 bit
-

--- a/c/ReachSafety-ECA.set
+++ b/c/ReachSafety-ECA.set
@@ -1,3 +1,4 @@
+# Contains programs that represent event-condition-action systems.
 eca-rers2012/*.yml
 eca-rers2018/*.yml
 psyco/*.yml

--- a/c/ReachSafety-Floats.cfg
+++ b/c/ReachSafety-Floats.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for checking programs with floating-point arithmetics.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Floats.set
+++ b/c/ReachSafety-Floats.set
@@ -1,3 +1,4 @@
+# Contains tasks for checking programs with floating-point arithmetics.
 floats-cdfpl/*.yml
 floats-cbmc-regression/*.yml
 float-benchs/*.yml

--- a/c/ReachSafety-Heap.cfg
+++ b/c/ReachSafety-Heap.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks that require the analysis of data structures on the heap, pointer aliases, and function pointers.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Heap.set
+++ b/c/ReachSafety-Heap.set
@@ -1,3 +1,4 @@
+# Contains tasks that require the analysis of data structures on the heap, pointer aliases, and function pointers.
 heap-manipulation/*.yml
 list-properties/*.yml
 ldv-regression/*.yml

--- a/c/ReachSafety-Loops.cfg
+++ b/c/ReachSafety-Loops.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for which loop analysis is necessary.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Loops.set
+++ b/c/ReachSafety-Loops.set
@@ -1,3 +1,4 @@
+# Contains tasks for which loop analysis is necessary.
 loops/*.yml
 loop-acceleration/*.yml
 loop-crafted/*.yml

--- a/c/ReachSafety-ProductLines.cfg
+++ b/c/ReachSafety-ProductLines.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs that represents 'products' and 'product simulators' that are derived using different configurations of product lines.
-Architecture: 32 bit
-

--- a/c/ReachSafety-ProductLines.set
+++ b/c/ReachSafety-ProductLines.set
@@ -1,1 +1,2 @@
+# Contains programs that represents 'products' and 'product simulators' that are derived using different configurations of product lines.
 product-lines/*.yml

--- a/c/ReachSafety-Recursive.cfg
+++ b/c/ReachSafety-Recursive.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks for which recursive analysis is necessary.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Recursive.set
+++ b/c/ReachSafety-Recursive.set
@@ -1,3 +1,4 @@
+# Contains tasks for which recursive analysis is necessary.
 recursive/*.yml
 recursive-simple/*.yml
 recursive-with-pointer/*.yml

--- a/c/ReachSafety-Sequentialized.cfg
+++ b/c/ReachSafety-Sequentialized.cfg
@@ -1,3 +1,0 @@
-Description: Contains sequentialized concurrent programs that were derived from SystemC programs. The programs were transformed to pure C programs by incorporating the scheduler into the C code.
-Architecture: 32 bit
-

--- a/c/ReachSafety-Sequentialized.set
+++ b/c/ReachSafety-Sequentialized.set
@@ -1,3 +1,4 @@
+# Contains sequentialized concurrent programs that were derived from SystemC programs. The programs were transformed to pure C programs by incorporating the scheduler into the C code.
 systemc/*.yml
 seq-mthreaded/*.yml
 seq-mthreaded-reduced/*.yml

--- a/c/ReachSafety-XCSP.cfg
+++ b/c/ReachSafety-XCSP.cfg
@@ -1,3 +1,0 @@
-Description: Contains tasks from the XCSP_to_C tool benchmark set.
-Architecture: 32 bit
-

--- a/c/ReachSafety-XCSP.set
+++ b/c/ReachSafety-XCSP.set
@@ -1,1 +1,2 @@
+# Contains tasks from the XCSP_to_C tool benchmark set.
 xcsp/*.yml

--- a/c/SoftwareSystems-AWS-C-Common-ReachSafety.cfg
+++ b/c/SoftwareSystems-AWS-C-Common-ReachSafety.cfg
@@ -1,2 +1,0 @@
-Description: Contains programs from the AWS C commons library
-Architecture: 64 bit

--- a/c/SoftwareSystems-AWS-C-Common-ReachSafety.set
+++ b/c/SoftwareSystems-AWS-C-Common-ReachSafety.set
@@ -1,1 +1,2 @@
+# Contains programs from the AWS C commons library
 aws-c-common/*.yml

--- a/c/SoftwareSystems-BusyBox-MemSafety.cfg
+++ b/c/SoftwareSystems-BusyBox-MemSafety.cfg
@@ -1,4 +1,0 @@
-Description: Contains problems from the software system BusyBox.
-Architecture: 64 bit
-
-

--- a/c/SoftwareSystems-BusyBox-MemSafety.set
+++ b/c/SoftwareSystems-BusyBox-MemSafety.set
@@ -1,1 +1,2 @@
+# Contains problems from the software system BusyBox.
 busybox-1.22.0/*.yml

--- a/c/SoftwareSystems-BusyBox-NoOverflows.cfg
+++ b/c/SoftwareSystems-BusyBox-NoOverflows.cfg
@@ -1,4 +1,0 @@
-Description: Contains problems from the software system BusyBox.
-Architecture: 64 bit
-
-

--- a/c/SoftwareSystems-BusyBox-NoOverflows.set
+++ b/c/SoftwareSystems-BusyBox-NoOverflows.set
@@ -1,1 +1,2 @@
+# Contains problems from the software system BusyBox.
 busybox-1.22.0/*.yml

--- a/c/SoftwareSystems-DeviceDriversLinux64-ConcurrencySafety.cfg
+++ b/c/SoftwareSystems-DeviceDriversLinux64-ConcurrencySafety.cfg
@@ -1,2 +1,0 @@
-Description: Contains problems that require the concurrency analysis
-Architecture: 64 bit

--- a/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.cfg
+++ b/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.cfg
@@ -1,4 +1,0 @@
-Description: Contains problems that require the analysis of pointer aliases and function pointers.
-Architecture: 64 bit
-
-

--- a/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set
+++ b/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set
@@ -1,3 +1,4 @@
+# Contains problems that require the analysis of pointer aliases and function pointers.
 ldv-linux-3.0/*.yml
 ldv-linux-3.4-simple/*.yml
 ldv-linux-3.7.3/*.yml

--- a/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.cfg
+++ b/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.cfg
@@ -1,4 +1,0 @@
-Description: Contains large tasks from the DeviceDrivers64 category (from the LDV project).
-Architecture: 64 bit
-
-

--- a/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set
+++ b/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set
@@ -1,3 +1,4 @@
+# Contains large tasks from the DeviceDrivers64 category (from the LDV project).
 
 
 ldv-challenges/linux-3.14_complex_emg_linux-alloc-spinlock_drivers-net-ethernet-sfc-sfc.cil.yml

--- a/c/SoftwareSystems-OpenBSD-MemSafety.cfg
+++ b/c/SoftwareSystems-OpenBSD-MemSafety.cfg
@@ -1,2 +1,0 @@
-Description: Contains problems that require the analysis of memory safety.
-Architecture: 64 bit

--- a/c/SoftwareSystems-OpenBSD-MemSafety.set
+++ b/c/SoftwareSystems-OpenBSD-MemSafety.set
@@ -1,1 +1,2 @@
+# Contains problems that require the analysis of memory safety.
 openbsd-6.2/*.yml

--- a/c/SoftwareSystems-SQLite-MemSafety.cfg
+++ b/c/SoftwareSystems-SQLite-MemSafety.cfg
@@ -1,4 +1,0 @@
-Description: Contains problems from the software SQLite
-Architecture: 64 bit
-
-

--- a/c/SoftwareSystems-SQLite-MemSafety.set
+++ b/c/SoftwareSystems-SQLite-MemSafety.set
@@ -1,1 +1,2 @@
+# Contains problems from the software SQLite
 sqlite/*.yml

--- a/c/Termination-MainControlFlow.cfg
+++ b/c/Termination-MainControlFlow.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs for which termination should be decided.
-Architecture: 64 bit
-

--- a/c/Termination-MainControlFlow.set
+++ b/c/Termination-MainControlFlow.set
@@ -1,3 +1,4 @@
+# Contains programs for which termination should be decided.
 termination-crafted/*.yml
 termination-crafted-lit/*.yml
 termination-numeric/*.yml

--- a/c/Termination-MainHeap.cfg
+++ b/c/Termination-MainHeap.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs for which termination should be decided.
-Architecture: 64 bit
-

--- a/c/Termination-MainHeap.set
+++ b/c/Termination-MainHeap.set
@@ -1,3 +1,4 @@
+# Contains programs for which termination should be decided.
 termination-dietlibc/*.yml
 termination-memory-alloca/*.yml
 termination-memory-linkedlists/*.yml

--- a/c/Termination-Other.cfg
+++ b/c/Termination-Other.cfg
@@ -1,3 +1,0 @@
-Description: Contains programs for which termination should be decided.
-Architecture: 32 bit
-

--- a/c/Termination-Other.set
+++ b/c/Termination-Other.set
@@ -1,3 +1,4 @@
+# Contains programs for which termination should be decided.
 array-examples/*.yml
 array-industry-pattern/*.yml
 bitvector/*.yml

--- a/c/check.py
+++ b/c/check.py
@@ -73,6 +73,8 @@ PROPERTIES |= {
     "unreach-call-usb_urb",
 }
 
+DATA_MODELS = {"ILP32": 32, "LP64": 64}
+
 # Ignore regression
 # as long as no yml-task definitions exist for the tasks in these directories
 IGNORED_DIRECTORIES = set(["properties", "regression"])
@@ -353,6 +355,38 @@ class TaskDefinitionFileChecks(FileChecks):
             name=self.name,
         ).run()
 
+    def check_language(self):
+        if not self.content:
+            return
+        language = self.content.get("options", {}).get("language")
+        if language != "C":
+            self.error("unexpected language %s", language)
+
+    def check_data_model(self):
+        if not self.content:
+            return
+        data_model = self.content.get("options", {}).get("data_model")
+        if not data_model:
+            self.error("missing declaration of data_model")
+            return
+        if not data_model in DATA_MODELS:
+            self.error("unknown data_model %s", data_model)
+            return
+
+        makefile_path = os.path.join(self.directory, "Makefile")
+        if os.path.exists(makefile_path):
+            archs = self._get_architecture_from_makefile(makefile_path)
+            if len(archs) > 1:
+                self.error("multiple architecture declarations in %s", makefile_path)
+            arch = int(next(iter(archs), "32"))
+            if DATA_MODELS.get(data_model) != arch:
+                self.error(
+                    "Makefile of directory %s declares %d bit, but task has data model %s",
+                    self.directory,
+                    arch,
+                    data_model,
+                )
+
 
     def _get_input_files(self) -> list:
         if 'input_files' not in self.content:
@@ -398,6 +432,14 @@ class TaskDefinitionFileChecks(FileChecks):
                 prop = prop_def["subproperty"]
             prop_and_verdict.append((prop, verdict))
         return prop_and_verdict
+
+
+    @classmethod
+    @functools.lru_cache()  # avoid opening Makefile for each task
+    def _get_architecture_from_makefile(cls, makefile_path):
+        with open(makefile_path) as makefile:
+            archs = [line.split(" ")[-1] for line in makefile if "CC.Arch" in line]
+        return archs
 
 
 class PropertiesChecks(Checks):

--- a/c/check.py
+++ b/c/check.py
@@ -554,7 +554,6 @@ class SetFileChecks(Checks):
         self.patterns = list(read_set_file(path))
         self.matched_files = [file for pattern in self.patterns
                               for file in glob.iglob(os.path.join(self.base_path, pattern))]
-        self.cfg_file = os.path.join(self.base_path, self.category + ".cfg")
 
     def check_all_patterns_match_files(self):
         for pattern in self.patterns:
@@ -567,53 +566,6 @@ class SetFileChecks(Checks):
             file for file in self.matched_files if not BENCHMARK_PATTERN.match(os.path.basename(file))]
         if unexpected_files:
             self.error("includes files %s that do have unexpected file names", unexpected_files)
-
-    def check_declared_architecture_of_benchmarks(self):
-        cfg = self._load_config()
-        expected_arch = int(cfg["Architecture"].split(" ")[0]) if cfg else None
-        directories = set(os.path.dirname(file) for file in self.matched_files)
-        for directory in directories:
-            makefile_path = os.path.join(directory, "Makefile")
-            if os.path.exists(makefile_path):
-                with open(makefile_path) as makefile:
-                    archs = [line for line in makefile if "CC.Arch" in line]
-                if len(archs) > 1:
-                    self.error("multiple architecture declarations in %s", makefile_path)
-                arch = int(next(iter(archs), "32").split(" ")[-1])
-                if expected_arch and arch != expected_arch:
-                    self.error(
-                        "%d bit category contains %d bit benchmarks in %s",
-                        expected_arch,
-                        arch,
-                        os.path.basename(directory))
-
-    def check_has_config_file(self):
-        if not os.path.isfile(self.cfg_file):
-            self.error("missing configuration file")
-
-    def _load_config(self):
-        if not yaml:
-            return None
-        if not os.path.isfile(self.cfg_file):
-            return None
-        with open(self.cfg_file) as f:
-            return yaml.safe_load(f)
-
-    def check_config_file(self):
-        cfg = self._load_config()
-        if not cfg:
-            return
-        unknown_keys = set(cfg.keys()).difference(CONFIG_KEYS)
-        missing_keys = CONFIG_KEYS.difference(cfg.keys())
-        if unknown_keys:
-            self.error("unexpected config entries <%s>", ">, <".join(unknown_keys))
-        if missing_keys:
-            self.error("missing config entries <%s>", ">, <".join(missing_keys))
-        if not cfg.get("Description", "dummy"):
-            self.error("missing description")
-        if cfg.get("Architecture", "32 bit") not in ["32 bit", "64 bit"]:
-            self.error("invalid architecture <%s>", cfg.get("Architecture"))
-
 
 def read_set_file(path):
     with open(path) as f:

--- a/c/compare.py
+++ b/c/compare.py
@@ -40,6 +40,8 @@ TASKS_ONLY_PREPROCESSED = ['ddv-machzwd/', 'aws-c-common/', 'ldv-linux-3.0/', 'l
 
 CBMC_GIT_PATH = "../cbmc.git/"
 
+DATA_MODELS = {"ILP32": "32", "LP64": "64"}
+
 
 def fail(*msg):
   print("CRITICAL ERROR:", *msg)
@@ -48,21 +50,6 @@ def fail(*msg):
 
 def expand(s):
   return sorted(glob.glob(s))
-
-
-def get_architecture(setname):
-  cfgfile = setname + ".cfg"
-  if not os.path.exists(cfgfile):
-    fail("No .cfg file present for category", setname)
-
-  with open(cfgfile, "r") as fp:
-    for line in fp:
-      if line.startswith("Architecture"):
-        bits = line.split()[1]
-        if bits in ["32", "64"]:
-          return bits
-        fail("Invalid bit width in file", setname + ".cfg")
-  fail("Invalid configuration file", cfgFile)
 
 
 def get_tasks_from_set(setFile):
@@ -135,6 +122,15 @@ def get_inputfiles_from_yml(yml, taskfile):
       return [inputFiles] # always wrap as list
 
 
+def get_bits_from_yml(yml, taskfile):
+  data_model = yml.get("options", {}).get("data_model")
+  if not data_model:
+    fail("No data model defined in", taskfile)
+  if not data_model in DATA_MODELS:
+    fail("Unknown data model", data_model, "defined in", taskfile)
+  return DATA_MODELS[data_model]
+
+
 def get_orig_filename(taskfile):
   """ try to find a matching source file (.c) for a preprocessed task """
   if taskfile.endswith('.c.i'):
@@ -185,7 +181,6 @@ for setfile in get_setfiles(args):
     continue
 
   print("Processing category", setname)
-  bits = get_architecture(setname)
 
   i = 0
   for taskfile in get_tasks_from_set(setfile):
@@ -196,6 +191,7 @@ for setfile in get_setfiles(args):
       with open(taskfile, 'r') as yamlfile:
         yml = yaml.safe_load(yamlfile)
         inputFiles = get_inputfiles_from_yml(yml, taskfile)
+        bits = get_bits_from_yml(yml, taskfile)
       if len(inputFiles) == 1:
         taskfile = os.path.join(os.path.dirname(taskfile), inputFiles[0])
       else:

--- a/c/compare.py
+++ b/c/compare.py
@@ -124,18 +124,15 @@ def get_setfiles(args):
       fail("Could not find a matching set file for", setfileWildcard)
 
 
-def get_inputfiles_from_yml(taskfile):
-  with open(taskfile, 'r') as yamlfile:
-    yml = yaml.safe_load(yamlfile)
-
-    # check whether the input_basename exists (nobody should ever use "null" as a filename!)
-    inputFiles = yml['input_files']
-    if not inputFiles:
-      fail("No input files defined in", taskfile)
-    elif isinstance(inputFiles, list):
-        return inputFiles
-    else:
-        return [inputFiles] # always wrap as list
+def get_inputfiles_from_yml(yml, taskfile):
+  # check whether the input_basename exists (nobody should ever use "null" as a filename!)
+  inputFiles = yml['input_files']
+  if not inputFiles:
+    fail("No input files defined in", taskfile)
+  elif isinstance(inputFiles, list):
+      return inputFiles
+  else:
+      return [inputFiles] # always wrap as list
 
 
 def get_orig_filename(taskfile):
@@ -196,7 +193,9 @@ for setfile in get_setfiles(args):
       continue
 
     if taskfile.endswith(".yml"):
-      inputFiles = get_inputfiles_from_yml(taskfile)
+      with open(taskfile, 'r') as yamlfile:
+        yml = yaml.safe_load(yamlfile)
+        inputFiles = get_inputfiles_from_yml(yml, taskfile)
       if len(inputFiles) == 1:
         taskfile = os.path.join(os.path.dirname(taskfile), inputFiles[0])
       else:


### PR DESCRIPTION
As cleanup due to the new task-definition files, this
- removes the `.cfg` files that previously stored the architecture and updates the scripts that needed them (fixes #1134),
- adds the necessary checks to `check.py`, e.g., that `language` and `data_model` are present and that the latter matches the `Makefile` in the respective directory, and
- updates the documentation accordingly (supersedes #1137 and fixes #1130 ).

This is required for #1140.

Note: The `.cfg` files also stored a description of each category and currently this is simply removed. I can add it somewhere as discussed in #1134 if this should be kept, but this would need to be decided first.