### PR TITLE
Fix verdicts for nla-digbench-scaling

### DIFF
--- a/c/nla-digbench-scaling/bresenham_unwindbound1.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound1.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound10.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound10.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound100.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound100.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound2.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound2.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound20.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound20.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound5.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound5.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_unwindbound50.c
+++ b/c/nla-digbench-scaling/bresenham_unwindbound50.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound1.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound1.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound1.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound10.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound10.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound10.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound100.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound100.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound100.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound2.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound2.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound2.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound20.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound20.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound20.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound5.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound5.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound5.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/bresenham_valuebound50.c
+++ b/c/nla-digbench-scaling/bresenham_valuebound50.c
@@ -3,8 +3,7 @@
   from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "bresenham.c", 7, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/bresenham_valuebound50.yml
+++ b/c/nla-digbench-scaling/bresenham_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'bresenham_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_unwindbound1.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound1.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound10.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound10.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound100.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound100.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound2.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound2.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound20.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound20.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound5.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound5.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_unwindbound50.c
+++ b/c/nla-digbench-scaling/cohencu_unwindbound50.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound1.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound1.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound1.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound10.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound10.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound10.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound100.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound100.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound100.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound2.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound2.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound2.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound20.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound20.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound20.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound5.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound5.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound5.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohencu_valuebound50.c
+++ b/c/nla-digbench-scaling/cohencu_valuebound50.c
@@ -4,8 +4,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohencu.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohencu_valuebound50.yml
+++ b/c/nla-digbench-scaling/cohencu_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohencu_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound1.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound1.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound1.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound10.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound10.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound10.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound100.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound100.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound100.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound2.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound2.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound2.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound20.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound20.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound20.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound5.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound5.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound5.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_unwindbound50.c
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound50.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_unwindbound50.yml
+++ b/c/nla-digbench-scaling/cohendiv_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound1.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound1.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound1.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound10.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound10.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound10.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound100.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound100.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound100.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound2.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound2.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound2.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound20.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound20.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound20.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound5.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound5.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound5.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/cohendiv_valuebound50.c
+++ b/c/nla-digbench-scaling/cohendiv_valuebound50.c
@@ -4,8 +4,7 @@
   http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohendiv.htm
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "cohendiv.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-	{reach_error();abort();}
+	{reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/cohendiv_valuebound50.yml
+++ b/c/nla-digbench-scaling/cohendiv_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'cohendiv_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound1.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound1.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound1.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound10.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound10.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound10.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound100.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound100.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound100.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound2.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound2.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound2.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound20.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound20.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound20.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound5.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound5.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound5.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_unwindbound50.c
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound50.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_unwindbound50.yml
+++ b/c/nla-digbench-scaling/dijkstra_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound1.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound1.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound1.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound10.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound10.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound10.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound100.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound100.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound100.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound2.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound2.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound2.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound20.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound20.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound20.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound5.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound5.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound5.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/dijkstra_valuebound50.c
+++ b/c/nla-digbench-scaling/dijkstra_valuebound50.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "dijkstra.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/dijkstra_valuebound50.yml
+++ b/c/nla-digbench-scaling/dijkstra_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'dijkstra_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound1.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound1.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound1.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound1.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound10.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound10.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound10.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound10.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound100.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound100.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound100.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound100.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound2.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound2.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound2.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound2.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound20.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound20.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound20.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound20.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound5.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound5.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound5.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound5.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_unwindbound50.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound50.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound50.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_unwindbound50.yml
+++ b/c/nla-digbench-scaling/divbin2_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_unwindbound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound1.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound1.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound1.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound1.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound10.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound10.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound10.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound10.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound100.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound100.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound100.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound100.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound2.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound2.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound2.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound2.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound20.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound20.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound20.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound20.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound5.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound5.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound5.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound5.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin2_valuebound50.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound50.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound50.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin2_valuebound50.yml
+++ b/c/nla-digbench-scaling/divbin2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin2_valuebound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound1.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound1.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound1.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound1.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound10.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound10.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound10.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound100.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound100.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound100.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound2.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound2.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound2.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound2.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound20.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound20.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound20.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound5.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound5.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound5.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound5.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_unwindbound50.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound50.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_unwindbound50.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound1.c
+++ b/c/nla-digbench-scaling/divbin_valuebound1.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound1.i
+++ b/c/nla-digbench-scaling/divbin_valuebound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound1.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound10.c
+++ b/c/nla-digbench-scaling/divbin_valuebound10.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound10.i
+++ b/c/nla-digbench-scaling/divbin_valuebound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound10.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound100.c
+++ b/c/nla-digbench-scaling/divbin_valuebound100.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound100.i
+++ b/c/nla-digbench-scaling/divbin_valuebound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound100.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound2.c
+++ b/c/nla-digbench-scaling/divbin_valuebound2.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound2.i
+++ b/c/nla-digbench-scaling/divbin_valuebound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound2.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound20.c
+++ b/c/nla-digbench-scaling/divbin_valuebound20.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound20.i
+++ b/c/nla-digbench-scaling/divbin_valuebound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound20.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound5.c
+++ b/c/nla-digbench-scaling/divbin_valuebound5.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound5.i
+++ b/c/nla-digbench-scaling/divbin_valuebound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound5.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/divbin_valuebound50.c
+++ b/c/nla-digbench-scaling/divbin_valuebound50.c
@@ -6,8 +6,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound50.i
+++ b/c/nla-digbench-scaling/divbin_valuebound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/divbin_valuebound50.yml
+++ b/c/nla-digbench-scaling/divbin_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_valuebound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_unwindbound1.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound10.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound100.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound2.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound20.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound5.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_unwindbound50.c
+++ b/c/nla-digbench-scaling/egcd2_unwindbound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound1.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound1.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound10.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound10.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound100.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound100.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound2.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound2.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound20.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound20.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound5.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound5.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd2_valuebound50.c
+++ b/c/nla-digbench-scaling/egcd2_valuebound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd2.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd2_valuebound50.yml
+++ b/c/nla-digbench-scaling/egcd2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_unwindbound1.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound10.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound100.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound2.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound20.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound5.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_unwindbound50.c
+++ b/c/nla-digbench-scaling/egcd3_unwindbound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound1.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound1.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound10.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound10.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound100.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound100.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound2.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound2.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound20.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound20.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound5.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound5.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd3_valuebound50.c
+++ b/c/nla-digbench-scaling/egcd3_valuebound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd3.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd3_valuebound50.yml
+++ b/c/nla-digbench-scaling/egcd3_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd3_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound1.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound1.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound10.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound10.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound100.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound100.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound2.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound2.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound20.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound20.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound5.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound5.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_unwindbound50.c
+++ b/c/nla-digbench-scaling/egcd_unwindbound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_unwindbound50.yml
+++ b/c/nla-digbench-scaling/egcd_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound1.c
+++ b/c/nla-digbench-scaling/egcd_valuebound1.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound1.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound10.c
+++ b/c/nla-digbench-scaling/egcd_valuebound10.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound10.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound100.c
+++ b/c/nla-digbench-scaling/egcd_valuebound100.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound100.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound2.c
+++ b/c/nla-digbench-scaling/egcd_valuebound2.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound2.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound20.c
+++ b/c/nla-digbench-scaling/egcd_valuebound20.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound20.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound5.c
+++ b/c/nla-digbench-scaling/egcd_valuebound5.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound5.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/egcd_valuebound50.c
+++ b/c/nla-digbench-scaling/egcd_valuebound50.c
@@ -1,7 +1,6 @@
 /* extended Euclid's algorithm */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "egcd.c", 4, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -10,7 +9,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/egcd_valuebound50.yml
+++ b/c/nla-digbench-scaling/egcd_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'egcd_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound1.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound1.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound1.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound10.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound10.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound10.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound100.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound100.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound100.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound2.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound2.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound2.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound20.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound20.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound20.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound5.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound5.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound5.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_unwindbound50.c
+++ b/c/nla-digbench-scaling/fermat1_unwindbound50.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_unwindbound50.yml
+++ b/c/nla-digbench-scaling/fermat1_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound1.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound1.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound1.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound10.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound10.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound10.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound100.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound100.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound100.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound2.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound2.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound2.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound20.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound20.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound20.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound5.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound5.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound5.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat1_valuebound50.c
+++ b/c/nla-digbench-scaling/fermat1_valuebound50.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat1.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat1_valuebound50.yml
+++ b/c/nla-digbench-scaling/fermat1_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat1_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound1.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound1.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound1.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound10.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound10.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound10.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound100.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound100.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound100.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound2.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound2.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound2.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound20.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound20.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound20.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound5.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound5.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound5.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_unwindbound50.c
+++ b/c/nla-digbench-scaling/fermat2_unwindbound50.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_unwindbound50.yml
+++ b/c/nla-digbench-scaling/fermat2_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound1.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound1.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound1.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound10.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound10.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound10.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound100.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound100.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound100.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound2.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound2.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound2.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound20.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound20.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound20.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound5.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound5.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound5.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/fermat2_valuebound50.c
+++ b/c/nla-digbench-scaling/fermat2_valuebound50.c
@@ -1,8 +1,7 @@
 /* program computing a divisor for factorisation, by Bressoud */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "fermat2.c", 5, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/fermat2_valuebound50.yml
+++ b/c/nla-digbench-scaling/fermat2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'fermat2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/freire1_unwindbound1.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound1.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound10.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound10.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound100.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound100.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound2.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound2.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound20.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound20.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound5.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound5.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_unwindbound50.c
+++ b/c/nla-digbench-scaling/freire1_unwindbound50.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound1.c
+++ b/c/nla-digbench-scaling/freire1_valuebound1.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound10.c
+++ b/c/nla-digbench-scaling/freire1_valuebound10.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound100.c
+++ b/c/nla-digbench-scaling/freire1_valuebound100.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound2.c
+++ b/c/nla-digbench-scaling/freire1_valuebound2.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound20.c
+++ b/c/nla-digbench-scaling/freire1_valuebound20.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound5.c
+++ b/c/nla-digbench-scaling/freire1_valuebound5.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire1_valuebound50.c
+++ b/c/nla-digbench-scaling/freire1_valuebound50.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire1.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound1.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound1.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound10.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound10.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound100.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound100.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound2.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound2.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound20.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound20.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound5.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound5.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_unwindbound50.c
+++ b/c/nla-digbench-scaling/freire2_unwindbound50.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound1.c
+++ b/c/nla-digbench-scaling/freire2_valuebound1.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound10.c
+++ b/c/nla-digbench-scaling/freire2_valuebound10.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound100.c
+++ b/c/nla-digbench-scaling/freire2_valuebound100.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound2.c
+++ b/c/nla-digbench-scaling/freire2_valuebound2.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound20.c
+++ b/c/nla-digbench-scaling/freire2_valuebound20.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound5.c
+++ b/c/nla-digbench-scaling/freire2_valuebound5.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/freire2_valuebound50.c
+++ b/c/nla-digbench-scaling/freire2_valuebound50.c
@@ -6,8 +6,7 @@ cpa.sh -kInduction -setprop solver.solver=z3 freire2.c
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "freire2.c", 10, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -16,7 +15,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/generate.py
+++ b/c/nla-digbench-scaling/generate.py
@@ -39,10 +39,30 @@ def valuetemplate(f):
 
 
 nladir = "../nla-digbench"
+
+# task where the expected result should become true if the values are restricted:
+healed_by_valuebound = ["divbin.c", "hard.c"]
+# tasks where the expected result should become true if the number of iterations is restricted:
+healed_by_unwindbound = ["divbin.c"]
+# tasks where the expected result should become false if the number of iterations is restricted:
+broken_by_unwindbound = [
+    "hard2.c",
+    "bresenham.c",
+    "cohencu.c",
+    "egcd1.c",
+    "egcd2.c",
+    "egcd3.c",
+    "hard2.c",
+    "mannadiv.c",
+    "ps4.c",
+    "ps5.c",
+    "ps6.c",
+]
+
 cfiles = [f for f in listdir(nladir) if isfile(join(nladir, f)) and ".c" in f]
 for file in cfiles:
     fullpath = join(nladir, file)
-    fullpathToPreprocessed = fullpath[:-2]+".i"
+    fullpathToPreprocessed = fullpath[:-2] + ".i"
     iFileExists = isfile(fullpathToPreprocessed)
     for (templatefun, name) in [
         (looptemplate, "_unwindbound"),
@@ -51,9 +71,17 @@ for file in cfiles:
         template = templatefun(fullpath)
         abort = False
         ymlcontent = open(join(nladir, file[:-2] + ".yml"), "r").read()
-        ymlcontent = re.sub(
-            "expected_verdict: true", "expected_verdict: false", ymlcontent
-        )
+
+        if (file in healed_by_valuebound and name == "_valuebound") or (
+            file in healed_by_unwindbound and name == "_unwindbound"
+        ):
+            ymlcontent = re.sub(
+                "expected_verdict: false", "expected_verdict: true", ymlcontent
+            )
+        if file in broken_by_unwindbound and name == "_unwindbound":
+            ymlcontent = re.sub(
+                "expected_verdict: true", "expected_verdict: false", ymlcontent
+            )
         for m in re.findall("property_file: (.*)", ymlcontent):
             if not "unreach-call" in m:
                 print("WARNING, additional property found in %s: %s" % (file, m))
@@ -62,18 +90,22 @@ for file in cfiles:
             break
         for i in [1, 2, 5, 10, 20, 50, 100]:
             content = re.sub("__BOUND", str(i), template)
-            filename_in_yml = file if not iFileExists else file[:-2]+".i"
+            filename_in_yml = file if not iFileExists else file[:-2] + ".i"
             new_filename_in_yml = file[:-2] + name + str(i) + filename_in_yml[-2:]
             ymlname = new_filename_in_yml[:-2] + ".yml"
             if iFileExists:
-                iFileContent = re.sub("__BOUND", str(i), templatefun(fullpathToPreprocessed))
+                iFileContent = re.sub(
+                    "__BOUND", str(i), templatefun(fullpathToPreprocessed)
+                )
                 new_c_filename = file[:-2] + name + str(i) + ".c"
                 print("Writing file: %s" % new_c_filename)
-                open(new_c_filename,"w").write(content)
+                open(new_c_filename, "w").write(content)
                 print("Writing file: %s" % new_filename_in_yml)
-                open(new_filename_in_yml,"w").write(iFileContent)
+                open(new_filename_in_yml, "w").write(iFileContent)
             else:
                 print("Writing file: %s" % new_filename_in_yml)
                 open(new_filename_in_yml, "w").write(content)
             print("Writing file: %s" % ymlname)
-            open(ymlname, "w").write(re.sub(filename_in_yml, new_filename_in_yml, ymlcontent))
+            open(ymlname, "w").write(
+                re.sub(filename_in_yml, new_filename_in_yml, ymlcontent)
+            )

--- a/c/nla-digbench-scaling/geo1_unwindbound1.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound1.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound1.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound10.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound10.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound10.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound100.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound100.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound100.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound2.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound2.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound2.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound20.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound20.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound20.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound5.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound5.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound5.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_unwindbound50.c
+++ b/c/nla-digbench-scaling/geo1_unwindbound50.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_unwindbound50.yml
+++ b/c/nla-digbench-scaling/geo1_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound1.c
+++ b/c/nla-digbench-scaling/geo1_valuebound1.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound1.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound10.c
+++ b/c/nla-digbench-scaling/geo1_valuebound10.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound10.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound100.c
+++ b/c/nla-digbench-scaling/geo1_valuebound100.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound100.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound2.c
+++ b/c/nla-digbench-scaling/geo1_valuebound2.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound2.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound20.c
+++ b/c/nla-digbench-scaling/geo1_valuebound20.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound20.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound5.c
+++ b/c/nla-digbench-scaling/geo1_valuebound5.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound5.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo1_valuebound50.c
+++ b/c/nla-digbench-scaling/geo1_valuebound50.c
@@ -5,8 +5,7 @@ returns 1+x-y == 0
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo1.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo1_valuebound50.yml
+++ b/c/nla-digbench-scaling/geo1_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo1_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound1.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound1.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound1.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound10.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound10.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound10.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound100.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound100.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound100.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound2.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound2.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound2.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound20.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound20.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound20.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound5.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound5.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound5.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_unwindbound50.c
+++ b/c/nla-digbench-scaling/geo2_unwindbound50.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_unwindbound50.yml
+++ b/c/nla-digbench-scaling/geo2_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound1.c
+++ b/c/nla-digbench-scaling/geo2_valuebound1.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound1.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound10.c
+++ b/c/nla-digbench-scaling/geo2_valuebound10.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound10.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound100.c
+++ b/c/nla-digbench-scaling/geo2_valuebound100.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound100.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound2.c
+++ b/c/nla-digbench-scaling/geo2_valuebound2.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound2.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound20.c
+++ b/c/nla-digbench-scaling/geo2_valuebound20.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound20.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound5.c
+++ b/c/nla-digbench-scaling/geo2_valuebound5.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound5.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo2_valuebound50.c
+++ b/c/nla-digbench-scaling/geo2_valuebound50.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo2_valuebound50.yml
+++ b/c/nla-digbench-scaling/geo2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound1.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound1.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound1.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound10.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound10.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound10.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound100.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound100.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound100.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound2.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound2.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound2.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound20.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound20.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound20.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound5.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound5.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound5.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_unwindbound50.c
+++ b/c/nla-digbench-scaling/geo3_unwindbound50.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_unwindbound50.yml
+++ b/c/nla-digbench-scaling/geo3_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound1.c
+++ b/c/nla-digbench-scaling/geo3_valuebound1.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound1.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound10.c
+++ b/c/nla-digbench-scaling/geo3_valuebound10.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound10.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound100.c
+++ b/c/nla-digbench-scaling/geo3_valuebound100.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound100.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound2.c
+++ b/c/nla-digbench-scaling/geo3_valuebound2.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound2.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound20.c
+++ b/c/nla-digbench-scaling/geo3_valuebound20.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound20.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound5.c
+++ b/c/nla-digbench-scaling/geo3_valuebound5.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound5.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/geo3_valuebound50.c
+++ b/c/nla-digbench-scaling/geo3_valuebound50.c
@@ -4,8 +4,7 @@ computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "geo3.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/geo3_valuebound50.yml
+++ b/c/nla-digbench-scaling/geo3_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'geo3_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_unwindbound1.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound1.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound10.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound10.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound100.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound100.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound2.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound2.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound20.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound20.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound5.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound5.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_unwindbound50.c
+++ b/c/nla-digbench-scaling/hard2_unwindbound50.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound1.c
+++ b/c/nla-digbench-scaling/hard2_valuebound1.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound1.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound10.c
+++ b/c/nla-digbench-scaling/hard2_valuebound10.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound10.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound100.c
+++ b/c/nla-digbench-scaling/hard2_valuebound100.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound100.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound2.c
+++ b/c/nla-digbench-scaling/hard2_valuebound2.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound2.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound20.c
+++ b/c/nla-digbench-scaling/hard2_valuebound20.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound20.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound5.c
+++ b/c/nla-digbench-scaling/hard2_valuebound5.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound5.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard2_valuebound50.c
+++ b/c/nla-digbench-scaling/hard2_valuebound50.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard2_valuebound50.yml
+++ b/c/nla-digbench-scaling/hard2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_unwindbound1.c
+++ b/c/nla-digbench-scaling/hard_unwindbound1.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound10.c
+++ b/c/nla-digbench-scaling/hard_unwindbound10.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound100.c
+++ b/c/nla-digbench-scaling/hard_unwindbound100.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound2.c
+++ b/c/nla-digbench-scaling/hard_unwindbound2.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound20.c
+++ b/c/nla-digbench-scaling/hard_unwindbound20.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound5.c
+++ b/c/nla-digbench-scaling/hard_unwindbound5.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_unwindbound50.c
+++ b/c/nla-digbench-scaling/hard_unwindbound50.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound1.c
+++ b/c/nla-digbench-scaling/hard_valuebound1.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound1.yml
+++ b/c/nla-digbench-scaling/hard_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound10.c
+++ b/c/nla-digbench-scaling/hard_valuebound10.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound10.yml
+++ b/c/nla-digbench-scaling/hard_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound100.c
+++ b/c/nla-digbench-scaling/hard_valuebound100.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound100.yml
+++ b/c/nla-digbench-scaling/hard_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound2.c
+++ b/c/nla-digbench-scaling/hard_valuebound2.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound2.yml
+++ b/c/nla-digbench-scaling/hard_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound20.c
+++ b/c/nla-digbench-scaling/hard_valuebound20.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound20.yml
+++ b/c/nla-digbench-scaling/hard_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound5.c
+++ b/c/nla-digbench-scaling/hard_valuebound5.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound5.yml
+++ b/c/nla-digbench-scaling/hard_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/hard_valuebound50.c
+++ b/c/nla-digbench-scaling/hard_valuebound50.c
@@ -4,8 +4,7 @@
   */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "hard.c", 8, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/hard_valuebound50.yml
+++ b/c/nla-digbench-scaling/hard_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'hard_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound1.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound1.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound1.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound1.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound10.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound10.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound10.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound10.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound100.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound100.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound100.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound100.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound2.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound2.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound2.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound2.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound20.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound20.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound20.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound20.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound5.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound5.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound5.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound5.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_unwindbound50.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound50.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound50.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_unwindbound50.yml
+++ b/c/nla-digbench-scaling/knuth_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_unwindbound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound1.c
+++ b/c/nla-digbench-scaling/knuth_valuebound1.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound1.i
+++ b/c/nla-digbench-scaling/knuth_valuebound1.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound1.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound1.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound10.c
+++ b/c/nla-digbench-scaling/knuth_valuebound10.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound10.i
+++ b/c/nla-digbench-scaling/knuth_valuebound10.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound10.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound100.c
+++ b/c/nla-digbench-scaling/knuth_valuebound100.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound100.i
+++ b/c/nla-digbench-scaling/knuth_valuebound100.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound100.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound2.c
+++ b/c/nla-digbench-scaling/knuth_valuebound2.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound2.i
+++ b/c/nla-digbench-scaling/knuth_valuebound2.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound2.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound20.c
+++ b/c/nla-digbench-scaling/knuth_valuebound20.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound20.i
+++ b/c/nla-digbench-scaling/knuth_valuebound20.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound20.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound5.c
+++ b/c/nla-digbench-scaling/knuth_valuebound5.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound5.i
+++ b/c/nla-digbench-scaling/knuth_valuebound5.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound5.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound5.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/knuth_valuebound50.c
+++ b/c/nla-digbench-scaling/knuth_valuebound50.c
@@ -3,8 +3,7 @@
 #include <limits.h>
 
 extern void abort(void);
-#include <assert.h>
-void reach_error() { assert(0); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -13,7 +12,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound50.i
+++ b/c/nla-digbench-scaling/knuth_valuebound50.i
@@ -1,15 +1,5 @@
 extern void abort(void);
-
-extern void __assert_fail (const char *__assertion, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert_perror_fail (int __errnum, const char *__file,
-      unsigned int __line, const char *__function)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-extern void __assert (const char *__assertion, const char *__file, int __line)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -18,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/knuth_valuebound50.yml
+++ b/c/nla-digbench-scaling/knuth_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'knuth_valuebound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound1.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound1.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound1.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound10.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound10.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound10.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound100.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound100.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound100.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound2.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound2.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound2.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound20.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound20.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound20.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound5.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound5.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound5.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_unwindbound50.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound50.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_unwindbound50.yml
+++ b/c/nla-digbench-scaling/lcm1_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound1.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound1.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound1.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound10.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound10.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound10.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound100.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound100.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound100.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound2.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound2.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound2.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound20.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound20.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound20.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound5.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound5.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound5.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm1_valuebound50.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound50.c
@@ -4,8 +4,7 @@
  */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -14,7 +13,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm1_valuebound50.yml
+++ b/c/nla-digbench-scaling/lcm1_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm1_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound1.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound1.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound1.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound10.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound10.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound10.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound100.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound100.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound100.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound2.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound2.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound2.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound20.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound20.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound20.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound5.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound5.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound5.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_unwindbound50.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound50.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_unwindbound50.yml
+++ b/c/nla-digbench-scaling/lcm2_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound1.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound1.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound1.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound10.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound10.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound10.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound100.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound100.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound100.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound2.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound2.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound2.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound20.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound20.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound20.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound5.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound5.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound5.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/lcm2_valuebound50.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound50.c
@@ -1,8 +1,7 @@
 /* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
+void reach_error(){}
 extern unsigned __VERIFIER_nondet_unsigned_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/lcm2_valuebound50.yml
+++ b/c/nla-digbench-scaling/lcm2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'lcm2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false    
+    expected_verdict: true    
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_unwindbound1.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound1.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound10.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound10.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound100.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound100.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound2.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound2.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound20.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound20.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound5.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound5.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_unwindbound50.c
+++ b/c/nla-digbench-scaling/mannadiv_unwindbound50.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound1.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound1.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound1.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound10.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound10.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound10.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound100.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound100.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound100.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound2.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound2.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound2.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound20.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound20.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound20.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound5.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound5.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound5.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/mannadiv_valuebound50.c
+++ b/c/nla-digbench-scaling/mannadiv_valuebound50.c
@@ -5,8 +5,7 @@
 */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "mannadiv.c", 9, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -15,7 +14,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/mannadiv_valuebound50.yml
+++ b/c/nla-digbench-scaling/mannadiv_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'mannadiv_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound1.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound1.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound1.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound10.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound10.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound10.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound100.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound100.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound100.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound2.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound2.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound2.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound20.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound20.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound20.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound5.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound5.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound5.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_unwindbound50.c
+++ b/c/nla-digbench-scaling/prod4br_unwindbound50.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_unwindbound50.yml
+++ b/c/nla-digbench-scaling/prod4br_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound1.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound1.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound1.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound10.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound10.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound10.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound100.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound100.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound100.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound2.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound2.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound2.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound20.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound20.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound20.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound5.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound5.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound5.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prod4br_valuebound50.c
+++ b/c/nla-digbench-scaling/prod4br_valuebound50.c
@@ -1,8 +1,7 @@
 /* algorithm for computing the product of two natural numbers */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prod4br.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prod4br_valuebound50.yml
+++ b/c/nla-digbench-scaling/prod4br_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prod4br_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound1.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound1.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound1.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound10.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound10.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound10.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound100.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound100.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound100.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound2.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound2.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound2.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound20.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound20.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound20.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound5.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound5.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound5.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_unwindbound50.c
+++ b/c/nla-digbench-scaling/prodbin_unwindbound50.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_unwindbound50.yml
+++ b/c/nla-digbench-scaling/prodbin_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound1.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound1.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound1.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound10.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound10.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound10.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound100.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound100.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound100.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound2.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound2.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound2.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound20.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound20.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound20.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound5.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound5.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound5.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/prodbin_valuebound50.c
+++ b/c/nla-digbench-scaling/prodbin_valuebound50.c
@@ -2,8 +2,7 @@
    product of two natural numbers
 */
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "prodbin.c", 6, "reach_error"); }
+void reach_error(){}
 extern double __VERIFIER_nondet_double(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -12,7 +11,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/prodbin_valuebound50.yml
+++ b/c/nla-digbench-scaling/prodbin_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'prodbin_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound1.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound1.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound10.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound10.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound100.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound100.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound2.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound2.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound20.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound20.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound5.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound5.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_unwindbound50.c
+++ b/c/nla-digbench-scaling/ps2_unwindbound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_unwindbound50.yml
+++ b/c/nla-digbench-scaling/ps2_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound1.c
+++ b/c/nla-digbench-scaling/ps2_valuebound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound1.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound10.c
+++ b/c/nla-digbench-scaling/ps2_valuebound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound10.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound100.c
+++ b/c/nla-digbench-scaling/ps2_valuebound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound100.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound2.c
+++ b/c/nla-digbench-scaling/ps2_valuebound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound2.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound20.c
+++ b/c/nla-digbench-scaling/ps2_valuebound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound20.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound5.c
+++ b/c/nla-digbench-scaling/ps2_valuebound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound5.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps2_valuebound50.c
+++ b/c/nla-digbench-scaling/ps2_valuebound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps2.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps2_valuebound50.yml
+++ b/c/nla-digbench-scaling/ps2_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps2_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound1.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound1.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound10.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound10.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound100.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound100.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound2.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound2.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound20.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound20.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound5.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound5.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_unwindbound50.c
+++ b/c/nla-digbench-scaling/ps3_unwindbound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_unwindbound50.yml
+++ b/c/nla-digbench-scaling/ps3_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound1.c
+++ b/c/nla-digbench-scaling/ps3_valuebound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound1.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound10.c
+++ b/c/nla-digbench-scaling/ps3_valuebound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound10.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound100.c
+++ b/c/nla-digbench-scaling/ps3_valuebound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound100.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound2.c
+++ b/c/nla-digbench-scaling/ps3_valuebound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound2.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound20.c
+++ b/c/nla-digbench-scaling/ps3_valuebound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound20.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound5.c
+++ b/c/nla-digbench-scaling/ps3_valuebound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound5.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps3_valuebound50.c
+++ b/c/nla-digbench-scaling/ps3_valuebound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps3.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps3_valuebound50.yml
+++ b/c/nla-digbench-scaling/ps3_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps3_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_unwindbound1.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound10.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound100.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound2.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound20.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound5.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_unwindbound50.c
+++ b/c/nla-digbench-scaling/ps4_unwindbound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound1.c
+++ b/c/nla-digbench-scaling/ps4_valuebound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound1.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound10.c
+++ b/c/nla-digbench-scaling/ps4_valuebound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound10.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound100.c
+++ b/c/nla-digbench-scaling/ps4_valuebound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound100.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound2.c
+++ b/c/nla-digbench-scaling/ps4_valuebound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound2.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound20.c
+++ b/c/nla-digbench-scaling/ps4_valuebound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound20.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound5.c
+++ b/c/nla-digbench-scaling/ps4_valuebound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound5.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps4_valuebound50.c
+++ b/c/nla-digbench-scaling/ps4_valuebound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps4.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps4_valuebound50.yml
+++ b/c/nla-digbench-scaling/ps4_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps4_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_unwindbound1.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound10.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound100.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound2.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound20.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound5.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_unwindbound50.c
+++ b/c/nla-digbench-scaling/ps5_unwindbound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound1.c
+++ b/c/nla-digbench-scaling/ps5_valuebound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound1.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound10.c
+++ b/c/nla-digbench-scaling/ps5_valuebound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound10.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound100.c
+++ b/c/nla-digbench-scaling/ps5_valuebound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound100.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound2.c
+++ b/c/nla-digbench-scaling/ps5_valuebound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound2.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound20.c
+++ b/c/nla-digbench-scaling/ps5_valuebound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound20.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound5.c
+++ b/c/nla-digbench-scaling/ps5_valuebound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound5.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps5_valuebound50.c
+++ b/c/nla-digbench-scaling/ps5_valuebound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps5.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps5_valuebound50.yml
+++ b/c/nla-digbench-scaling/ps5_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps5_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_unwindbound1.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound10.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound100.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound2.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound20.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound5.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_unwindbound50.c
+++ b/c/nla-digbench-scaling/ps6_unwindbound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound1.c
+++ b/c/nla-digbench-scaling/ps6_valuebound1.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound1.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound10.c
+++ b/c/nla-digbench-scaling/ps6_valuebound10.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound10.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound100.c
+++ b/c/nla-digbench-scaling/ps6_valuebound100.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound100.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound2.c
+++ b/c/nla-digbench-scaling/ps6_valuebound2.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound2.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound20.c
+++ b/c/nla-digbench-scaling/ps6_valuebound20.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound20.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound5.c
+++ b/c/nla-digbench-scaling/ps6_valuebound5.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound5.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/ps6_valuebound50.c
+++ b/c/nla-digbench-scaling/ps6_valuebound50.c
@@ -1,6 +1,5 @@
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "ps6.c", 3, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -9,7 +8,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/ps6_valuebound50.yml
+++ b/c/nla-digbench-scaling/ps6_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'ps6_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound1.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound1.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound1.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound10.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound10.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound10.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound100.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound100.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound100.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound2.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound2.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound2.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound20.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound20.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound20.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound5.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound5.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound5.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_unwindbound50.c
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound50.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_unwindbound50.yml
+++ b/c/nla-digbench-scaling/sqrt1_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_unwindbound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound1.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound1.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound1.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound10.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound10.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound10.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound100.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound100.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound100.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound2.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound2.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound2.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound20.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound20.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound20.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound5.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound5.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound5.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench-scaling/sqrt1_valuebound50.c
+++ b/c/nla-digbench-scaling/sqrt1_valuebound50.c
@@ -1,8 +1,7 @@
 /* Compute the floor of the square root of a natural number */
 
 extern void abort(void);
-extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-void reach_error() { __assert_fail("0", "sqrt1.c", 5, "reach_error"); }
+void reach_error(){}
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
@@ -11,7 +10,7 @@ void assume_abort_if_not(int cond) {
 void __VERIFIER_assert(int cond) {
     if (!(cond)) {
     ERROR:
-        {reach_error();abort();}
+        {reach_error();}
     }
     return;
 }

--- a/c/nla-digbench-scaling/sqrt1_valuebound50.yml
+++ b/c/nla-digbench-scaling/sqrt1_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'sqrt1_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: C


### PR DESCRIPTION
The verdicts are adapted to represent the results of the first
tool executions on these tasks. This was expected to happen, verdicts
could still be wrong on a few tasks, the verifiers will hopefully find
this! Also this commit reverts some changes that were still left over
from reverting PR #1119, such that once the fixed PR comes we have a
consistent state.