### PR TITLE
Resolving conflicting definitions of assert macro

### DIFF
--- a/c/aws-c-common/prelude.h
+++ b/c/aws-c-common/prelude.h
@@ -23,6 +23,7 @@ void __VERIFIER_assert(_Bool cond) {
 
 #define __CPROVER_size_t unsigned long
 
+#undef assert
 #define assert(cond) \
     __VERIFIER_assert(cond)
 

--- a/c/pthread-atomic/dekker.c
+++ b/c/pthread-atomic/dekker.c
@@ -11,6 +11,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int flag1 = 0, flag2 = 0; // boolean flags

--- a/c/pthread-atomic/lamport.c
+++ b/c/pthread-atomic/lamport.c
@@ -7,6 +7,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int x, y;

--- a/c/pthread-atomic/peterson.c
+++ b/c/pthread-atomic/peterson.c
@@ -7,6 +7,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int flag1 = 0, flag2 = 0; // boolean flags

--- a/c/pthread-atomic/qrcu-1.c
+++ b/c/pthread-atomic/qrcu-1.c
@@ -16,6 +16,7 @@ extern int __VERIFIER_nondet_int();
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int idx=0; // boolean to control which of the two elements will be used by readers

--- a/c/pthread-atomic/qrcu-2.c
+++ b/c/pthread-atomic/qrcu-2.c
@@ -16,6 +16,7 @@ extern int __VERIFIER_nondet_int();
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int idx=0; // boolean to control which of the two elements will be used by readers

--- a/c/pthread-atomic/read_write_lock-1.c
+++ b/c/pthread-atomic/read_write_lock-1.c
@@ -15,6 +15,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int w=0, r=0, x, y;

--- a/c/pthread-atomic/read_write_lock-2.c
+++ b/c/pthread-atomic/read_write_lock-2.c
@@ -15,6 +15,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int w=0, r=0, x, y;

--- a/c/pthread-atomic/scull.c
+++ b/c/pthread-atomic/scull.c
@@ -83,6 +83,7 @@ extern int __VERIFIER_nondet_int();
 
 
 
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 inode i;

--- a/c/pthread-atomic/szymanski.c
+++ b/c/pthread-atomic/szymanski.c
@@ -7,6 +7,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int flag1 = 0, flag2 = 0; // integer flags 

--- a/c/pthread-atomic/time_var_mutex.c
+++ b/c/pthread-atomic/time_var_mutex.c
@@ -15,6 +15,7 @@ void reach_error() { assert(0); }
 */
 
 #include <pthread.h>
+#undef assert
 #define assert(e) if (!(e)) ERROR: reach_error()
 
 int block;

--- a/c/pthread-complex/safestack_relacy.c
+++ b/c/pthread-complex/safestack_relacy.c
@@ -7,6 +7,7 @@ extern void abort(void);
 void reach_error() { assert(0); }
 extern void __VERIFIER_atomic_begin(void);
 extern void __VERIFIER_atomic_end(void);
+#undef assert
 #define assert(X) if(!(X)) reach_error()
 
 #include <stdio.h>

--- a/c/pthread-complex/workstealqueue_mutex-1.c
+++ b/c/pthread-complex/workstealqueue_mutex-1.c
@@ -9,6 +9,7 @@ extern void abort(void);
 void reach_error() { assert(0); }
 extern void __VERIFIER_atomic_begin(void);
 extern void __VERIFIER_atomic_end(void);
+#undef assert
 #define assert(X) if(!(X)) reach_error()
 
 #include <stdio.h>

--- a/c/pthread-complex/workstealqueue_mutex-2.c
+++ b/c/pthread-complex/workstealqueue_mutex-2.c
@@ -9,6 +9,7 @@ extern void abort(void);
 void reach_error() { assert(0); }
 extern void __VERIFIER_atomic_begin(void);
 extern void __VERIFIER_atomic_end(void);
+#undef assert
 #define assert(X) if(!(X)) reach_error()
 
 #include <stdio.h>

--- a/c/pthread-ext/01_inc.c
+++ b/c/pthread-ext/01_inc.c
@@ -12,6 +12,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 volatile unsigned value, m = 0;

--- a/c/pthread-ext/02_inc_cas.c
+++ b/c/pthread-ext/02_inc_cas.c
@@ -7,6 +7,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_CAS(

--- a/c/pthread-ext/03_incdec.c
+++ b/c/pthread-ext/03_incdec.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define atomic_assert(e) {__VERIFIER_atomic_acquire();assert(e);__VERIFIER_atomic_release();}

--- a/c/pthread-ext/04_incdec_cas.c
+++ b/c/pthread-ext/04_incdec_cas.c
@@ -8,6 +8,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_CAS(

--- a/c/pthread-ext/05_tas.c
+++ b/c/pthread-ext/05_tas.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #define locked 1
 volatile int lock = unlocked;
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_TAS(

--- a/c/pthread-ext/06_ticket.c
+++ b/c/pthread-ext/06_ticket.c
@@ -16,6 +16,7 @@ extern void __VERIFIER_atomic_end();
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 volatile unsigned next_ticket = 0;

--- a/c/pthread-ext/07_rand.c
+++ b/c/pthread-ext/07_rand.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int m = 0;

--- a/c/pthread-ext/08_rand_cas.c
+++ b/c/pthread-ext/08_rand_cas.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 inline int calculateNext(int s2){ 

--- a/c/pthread-ext/09_fmaxsym.c
+++ b/c/pthread-ext/09_fmaxsym.c
@@ -10,6 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define WORKPERTHREAD 2

--- a/c/pthread-ext/10_fmaxsym_cas.c
+++ b/c/pthread-ext/10_fmaxsym_cas.c
@@ -10,6 +10,7 @@ extern int __VERIFIER_nondet_int();
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define WORKPERTHREAD 2

--- a/c/pthread-ext/11_fmaxsymopt.c
+++ b/c/pthread-ext/11_fmaxsymopt.c
@@ -11,6 +11,7 @@ extern int __VERIFIER_nondet_int();
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define WORKPERTHREAD 2

--- a/c/pthread-ext/12_fmaxsymopt_cas.c
+++ b/c/pthread-ext/12_fmaxsymopt_cas.c
@@ -11,6 +11,7 @@ extern int __VERIFIER_nondet_int();
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_CAS(

--- a/c/pthread-ext/13_unverif.c
+++ b/c/pthread-ext/13_unverif.c
@@ -11,6 +11,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 unsigned int r = 0;

--- a/c/pthread-ext/14_spin2003.c
+++ b/c/pthread-ext/14_spin2003.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int x=1, m=0;

--- a/c/pthread-ext/15_dekker.c
+++ b/c/pthread-ext/15_dekker.c
@@ -4,6 +4,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int flag1 = 0, flag2 = 0; // N boolean flags 

--- a/c/pthread-ext/16_peterson.c
+++ b/c/pthread-ext/16_peterson.c
@@ -4,6 +4,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int turn; // integer variable to hold the ID of the thread whose turn is it

--- a/c/pthread-ext/17_szymanski.c
+++ b/c/pthread-ext/17_szymanski.c
@@ -4,6 +4,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int flag1 = 0, flag2 = 0; // N integer flags 

--- a/c/pthread-ext/18_read_write_lock.c
+++ b/c/pthread-ext/18_read_write_lock.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int w=0, r=0, x, y;

--- a/c/pthread-ext/19_time_var_mutex.c
+++ b/c/pthread-ext/19_time_var_mutex.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/20_lamport.c
+++ b/c/pthread-ext/20_lamport.c
@@ -4,6 +4,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int x;

--- a/c/pthread-ext/23_lu-fig2.fixed.c
+++ b/c/pthread-ext/23_lu-fig2.fixed.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int mThread=0;

--- a/c/pthread-ext/25_stack.c
+++ b/c/pthread-ext/25_stack.c
@@ -14,6 +14,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/25_stack_longer-1.c
+++ b/c/pthread-ext/25_stack_longer-1.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/25_stack_longer-2.c
+++ b/c/pthread-ext/25_stack_longer-2.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/25_stack_longest-1.c
+++ b/c/pthread-ext/25_stack_longest-1.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/25_stack_longest-2.c
+++ b/c/pthread-ext/25_stack_longest-2.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/26_stack_cas.c
+++ b/c/pthread-ext/26_stack_cas.c
@@ -14,6 +14,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/26_stack_cas_longer-1.c
+++ b/c/pthread-ext/26_stack_cas_longer-1.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/26_stack_cas_longer-2.c
+++ b/c/pthread-ext/26_stack_cas_longer-2.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/26_stack_cas_longest-1.c
+++ b/c/pthread-ext/26_stack_cas_longest-1.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/26_stack_cas_longest-2.c
+++ b/c/pthread-ext/26_stack_cas_longest-2.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();} (void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/27_Boop_simple_vf.c
+++ b/c/pthread-ext/27_Boop_simple_vf.c
@@ -5,6 +5,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int usecount;

--- a/c/pthread-ext/28_buggy_simple_loop1_vf.c
+++ b/c/pthread-ext/28_buggy_simple_loop1_vf.c
@@ -6,6 +6,7 @@ extern unsigned int __VERIFIER_nondet_uint();
 #include <pthread.h>
 
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void* thr1(void* arg){

--- a/c/pthread-ext/29_conditionals_vs.c
+++ b/c/pthread-ext/29_conditionals_vs.c
@@ -11,6 +11,7 @@ void reach_error() { assert(0); }
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int m = 0;

--- a/c/pthread-ext/30_Function_Pointer3_vs.c
+++ b/c/pthread-ext/30_Function_Pointer3_vs.c
@@ -10,6 +10,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int mutex;

--- a/c/pthread-ext/31_simple_loop5_vs.c
+++ b/c/pthread-ext/31_simple_loop5_vs.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int a = 1;

--- a/c/pthread-ext/32_pthread5_vs.c
+++ b/c/pthread-ext/32_pthread5_vs.c
@@ -10,6 +10,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define MONITOR_EQ(x,y) \

--- a/c/pthread-ext/33_double_lock_p1_vs.c
+++ b/c/pthread-ext/33_double_lock_p1_vs.c
@@ -13,6 +13,7 @@ int count = 0;
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/34_double_lock_p2_vs.c
+++ b/c/pthread-ext/34_double_lock_p2_vs.c
@@ -13,6 +13,7 @@ int count = 0;
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/35_double_lock_p3_vs.c
+++ b/c/pthread-ext/35_double_lock_p3_vs.c
@@ -13,6 +13,7 @@ int count = 0;
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_acquire(int * m)

--- a/c/pthread-ext/36_stack_cas_p0_vs_concur.c
+++ b/c/pthread-ext/36_stack_cas_p0_vs_concur.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 void __VERIFIER_atomic_CAS(

--- a/c/pthread-ext/37_stack_lock_p0_vs_concur.c
+++ b/c/pthread-ext/37_stack_lock_p0_vs_concur.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define MEMSIZE (2*32+1) //0 for "NULL"

--- a/c/pthread-ext/38_rand_cas_vs_concur.c
+++ b/c/pthread-ext/38_rand_cas_vs_concur.c
@@ -8,6 +8,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 inline int nC(int s2){ 

--- a/c/pthread-ext/39_rand_lock_p0_vs.c
+++ b/c/pthread-ext/39_rand_lock_p0_vs.c
@@ -13,6 +13,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int m = 0;

--- a/c/pthread-ext/40_barrier_vf.c
+++ b/c/pthread-ext/40_barrier_vf.c
@@ -9,6 +9,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 volatile unsigned int count = 0; //shared

--- a/c/pthread-ext/41_FreeBSD_abd_kbd_sliced.c
+++ b/c/pthread-ext/41_FreeBSD_abd_kbd_sliced.c
@@ -15,6 +15,7 @@ to correctly model the cv_broadcast(COND) statement "b1_COND := 1;" must be manu
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define cv_wait(c,m){ \

--- a/c/pthread-ext/42_FreeBSD_rdma_addr_sliced.c
+++ b/c/pthread-ext/42_FreeBSD_rdma_addr_sliced.c
@@ -15,6 +15,7 @@ to correctly model the cv_broadcast(COND) statement "b1_COND := 1;" must be manu
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define cv_wait(c,m){ \

--- a/c/pthread-ext/43_NetBSD_sysmon_power_sliced.c
+++ b/c/pthread-ext/43_NetBSD_sysmon_power_sliced.c
@@ -15,6 +15,7 @@ to correctly model the cv_broadcast(COND) statement "b1_COND := 1;" must be manu
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define cv_wait(c,m){ \

--- a/c/pthread-ext/44_Solaris_space_map_sliced.c
+++ b/c/pthread-ext/44_Solaris_space_map_sliced.c
@@ -15,6 +15,7 @@ to correctly model the cv_broadcast(COND) statement "b1_COND := 1;" must be manu
 
 #define assume(e) assume_abort_if_not(e)
 #define assert_nl(e) { if(!(e)) { goto ERROR; } }
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 #define cv_wait(c,m){ \

--- a/c/pthread-ext/45_monabsex1_vs.c
+++ b/c/pthread-ext/45_monabsex1_vs.c
@@ -5,6 +5,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 int s;

--- a/c/pthread-ext/46_monabsex2_vs.c
+++ b/c/pthread-ext/46_monabsex2_vs.c
@@ -4,6 +4,7 @@ void reach_error() { assert(0); }
 
 #include <pthread.h>
 
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 _Bool s = 0;

--- a/c/pthread-ext/47_ticket_lock_hc_backoff_vs.c
+++ b/c/pthread-ext/47_ticket_lock_hc_backoff_vs.c
@@ -15,6 +15,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 volatile unsigned s = 0; //served

--- a/c/pthread-ext/48_ticket_lock_low_contention_vs.c
+++ b/c/pthread-ext/48_ticket_lock_low_contention_vs.c
@@ -10,6 +10,7 @@ void reach_error() { assert(0); }
 #include <pthread.h>
 
 #define assume(e) assume_abort_if_not(e)
+#undef assert
 #define assert(e) { if(!(e)) { ERROR: {reach_error();abort();}(void)0; } }
 
 volatile unsigned s = 0; //served


### PR DESCRIPTION
With the insertion of `assert(0)` into the body of `reach_error` it was
necessary to include the `assert.h` system header. Some tasks, however, already
defined the `assert` macro themselves (expanding to calls to `reach_error()`).
To avoid compiler/preprocessor warnings about conflicting macro definitions,
prefix the local `assert` definitions by `#undef assert` to disable the prior
definition.

The changes were done using the following command:
```
for f in c/aws-c-common/prelude.h c/*/*.c
do
perl -i -e \
  '$p = 0; $e = 0;
   while(<>) {
     if(/^#define\s+assert\(\w+\)/) {
       print "#undef assert\n";
     }
     print;
   }' \
  $f
done
```