### PR TITLE
Add the Jdart regression test to SV-COMP

### DIFF
--- a/java/ReachSafety-Java.set
+++ b/java/ReachSafety-Java.set
@@ -7,3 +7,4 @@ java-ranger-regression/siena_eqchk/*.yml
 MinePump/*.yml
 algorithms/*.yml
 juliet-java/*.yml
+jdart-regression/*.yml

--- a/java/compile.xml
+++ b/java/compile.xml
@@ -40,4 +40,8 @@
   <tasks name="juliet-java">
     <include>juliet-java/*.yml</include>
   </tasks>
+
+  <tasks name="jdart-regression">
+    <include>jdart-regression/*.yml</include>
+  </tasks>
 </benchmark>

--- a/java/jdart-regression/LICENSE-4-clause-BSD.txt
+++ b/java/jdart-regression/LICENSE-4-clause-BSD.txt
@@ -1,0 +1,38 @@
+(C) 2020, Malte Mues, Falk Howar
+Automated Quality Assurance Group, TU Dortmund
+
+All rights reserved. Redistribution and use in source and binary forms, with
+or without modification, are permitted provided that the following
+conditions are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  3. All advertising materials mentioning features or use of this software
+     must display the following acknowledgement:
+
+     This product includes software developed by Daniel Kroening,
+     Edmund Clarke,
+     Computer Science Department, University of Oxford
+     Computer Science Department, Carnegie Mellon University
+
+  4. Neither the name of the University nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/java/jdart-regression/LICENSE-Apache
+++ b/java/jdart-regression/LICENSE-Apache
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/java/jdart-regression/LICENSE-MIT
+++ b/java/jdart-regression/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 TU Dortmund, Falk Howar and Malte Mues
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/java/jdart-regression/OverapproximationString01.yml
+++ b/java/jdart-regression/OverapproximationString01.yml
@@ -1,0 +1,11 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - OverapproximationString01/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+
+options:
+  language: Java

--- a/java/jdart-regression/OverapproximationString01/Main.java
+++ b/java/jdart-regression/OverapproximationString01/Main.java
@@ -1,0 +1,26 @@
+/*
+ * Contributed to SV-COMP by Malte Mues
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main{
+  public void foo(String s){
+    String prefix = "abc";
+    String complete = prefix + s;
+    if(complete.equals("not possible")){
+      assert(true);
+    } else{
+      assert(false);
+    }
+  }
+
+  public static void main(String args[]){
+    Main c = new Main();
+    String input = Verifier.nondetString();
+    c.foo(input);
+  }
+}
+
+

--- a/java/jdart-regression/URLDecoder01.yml
+++ b/java/jdart-regression/URLDecoder01.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - URLDecoder01/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+
+options:
+  language: Java

--- a/java/jdart-regression/URLDecoder01/Main.java
+++ b/java/jdart-regression/URLDecoder01/Main.java
@@ -1,0 +1,23 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    String s1 = "some-url+" + Verifier.nondetString();
+
+    try {
+      String s2 = java.net.URLDecoder.decode(s1, "UTF-8");
+      if ( !s2.startsWith("some") ) {
+        assert false;
+      }
+    } catch (java.io.UnsupportedEncodingException e) {
+    }
+  }
+}

--- a/java/jdart-regression/URLDecoder02.yml
+++ b/java/jdart-regression/URLDecoder02.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - URLDecoder02/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/URLDecoder02/Main.java
+++ b/java/jdart-regression/URLDecoder02/Main.java
@@ -1,0 +1,23 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    String s1 = Verifier.nondetString() + "some-url";
+
+    try {
+      String s2 = java.net.URLDecoder.decode(s1, "UTF-8");
+      if ( !s2.startsWith("some") ) {
+        assert false;
+      }
+    } catch (java.io.UnsupportedEncodingException e) {
+    }
+  }
+}

--- a/java/jdart-regression/addition01.yml
+++ b/java/jdart-regression/addition01.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - addition01/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/addition01/Main.java
+++ b/java/jdart-regression/addition01/Main.java
@@ -1,0 +1,49 @@
+/* Copyright, TU Dortmund 2020 Malte Mues
+ * contributed-by: Malte Mues (mail.mues@gmail.com)
+ *
+ * This benchmark task is a modificaiton of the following original Benchmark:
+ * Origin of the benchmark:
+ *     license: MIT (see /java/jayhorn-recursive/LICENSE)
+ *     repo: https://github.com/jayhorn/cav_experiments.git
+ *     branch: master
+ *     root directory: benchmarks/recursive
+ * The benchmark was taken from the repo: 24 January 2018
+ *
+ * Following the original license model, modifications are as well licensed  under the
+ * MIT license.
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static int addition(int m, int n, int c) {
+    if (n == 0) {
+      return m;
+    }
+
+    if(c >= 150){
+    assert false;
+    }
+
+    if (n > 0) {
+      return addition(m + 1, n - 1, ++c);
+    } else {
+      return addition(m - 1, n + 1, ++c);
+    }
+  }
+
+  public static void main(String[] args) {
+    int m = Verifier.nondetInt();
+    if (m < 0 || m >= 10000) {
+      return;
+    }
+    int n = Verifier.nondetInt();
+    if (n < 0 || n >= 10000) {
+      return;
+    }
+    int c = 0;
+    int result = addition(m, n, c);
+    assert(result == m + n);
+  }
+}

--- a/java/jdart-regression/array-iteration01.yml
+++ b/java/jdart-regression/array-iteration01.yml
@@ -1,0 +1,11 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - array-iteration01/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+
+options:
+  language: Java

--- a/java/jdart-regression/array-iteration01/Main.java
+++ b/java/jdart-regression/array-iteration01/Main.java
@@ -1,0 +1,27 @@
+/* Copyright, TU Dortmund 2020 Malte Mues
+ * contributed-by: Malte Mues (mail.mues@gmail.com)
+ *
+ * Origin of the benchmark:
+ *     license: 4-clause BSD (see /java/jbmc-regression/LICENSE)
+ *     repo: https://github.com/diffblue/cbmc.git
+ *     branch: develop
+ *     directory: regression/cbmc-java/aastore_aaload1
+ * The benchmark was taken from the repo: 24 January 2018
+ *
+ * Following the original license model, modifications are as well licensed  under the
+ * MIT license.
+ */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main{
+
+  public static void main(String[] args){
+    int[] ia = new int[200];
+    int index = Verifier.nondetInt();
+    Verifier.assume(0 <= index && index < ia.length);
+    ia[index] = Verifier.nondetInt();
+    for(int i = 0; i < ia.length; i++){
+      assert ia[i] != 0;
+    }
+  }
+}

--- a/java/jdart-regression/boundcheck100.yml
+++ b/java/jdart-regression/boundcheck100.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - boundcheck100/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/boundcheck100/Main.java
+++ b/java/jdart-regression/boundcheck100/Main.java
@@ -1,0 +1,33 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  private static void recursion(int i) {
+    if (i==0) {
+      return;
+    }
+    if (i>0) {
+      recursion(i-1);
+    }
+    if (i<0) {
+      assert false;
+    }
+  }
+
+  public static void main(String[] args) {
+    int x = Verifier.nondetInt();
+    if (x < 100 || x > 100) {
+      return;
+    }
+
+    recursion(x);
+
+    assert false;
+  }
+}

--- a/java/jdart-regression/boundcheck200.yml
+++ b/java/jdart-regression/boundcheck200.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - boundcheck200/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/boundcheck200/Main.java
+++ b/java/jdart-regression/boundcheck200/Main.java
@@ -1,0 +1,33 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  private static void recursion(int i) {
+    if (i==0) {
+      return;
+    }
+    if (i>0) {
+      recursion(i-1);
+    }
+    if (i<0) {
+      assert false;
+    }
+  }
+
+  public static void main(String[] args) {
+    int x = Verifier.nondetInt();
+    if (x < 200 || x > 200) {
+      return;
+    }
+
+    recursion(x);
+
+    assert false;
+  }
+}

--- a/java/jdart-regression/boundcheck30.yml
+++ b/java/jdart-regression/boundcheck30.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - boundcheck30/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/boundcheck30/Main.java
+++ b/java/jdart-regression/boundcheck30/Main.java
@@ -1,0 +1,33 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  private static void recursion(int i) {
+    if (i==0) {
+      return;
+    }
+    if (i>0) {
+      recursion(i-1);
+    }
+    if (i<0) {
+      assert false;
+    }
+  }
+
+  public static void main(String[] args) {
+    int x = Verifier.nondetInt();
+    if (x < 30 || x > 30) {
+      return;
+    }
+
+    recursion(x);
+
+    assert false;
+  }
+}

--- a/java/jdart-regression/double2long.yml
+++ b/java/jdart-regression/double2long.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - double2long/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/double2long/Main.java
+++ b/java/jdart-regression/double2long/Main.java
@@ -1,0 +1,52 @@
+/*
+ * Origin of the benchmark:
+ *     license: Apache 2.0 (see /java/jdart-regression/LICENSE-Apache)
+ *     repo: https://github.com/psycopaths/jdart
+ *     branch: master
+ *     directory: src/examples/features/double2long
+ * 
+ * The benchmark was taken from the repo: 30 September 2020
+ */
+
+/*
+ * Copyright (C) 2015, United States Government, as represented by the 
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ * 
+ * The PSYCO: A Predicate-based Symbolic Compositional Reasoning environment 
+ * platform is licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. You may obtain a 
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0. 
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * specific language governing permissions and limitations under the License.
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+	public static double bar(long l) {
+		assert l < 100L && l > -100L;
+		return (double)l;
+	}
+	
+	public static double foo(double x) {
+		if(x < 0.0) {
+			x *= 10.0;
+		}
+		else {
+			x /= 10.0;
+		}
+		long l = (long)x;
+		return bar(l);
+	}
+
+	public static void main(String[] args) {
+		System.out.println("-------- In main!");
+		double x = Verifier.nondetDouble();
+		foo(x);
+	}
+}

--- a/java/jdart-regression/float.yml
+++ b/java/jdart-regression/float.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - float/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/float/Main.java
+++ b/java/jdart-regression/float/Main.java
@@ -1,0 +1,16 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+    float a = Verifier.nondetFloat();
+    float b = Verifier.nondetFloat();
+    assert (a + b != a || b == 0.0);
+  }
+}

--- a/java/jdart-regression/list2.yml
+++ b/java/jdart-regression/list2.yml
@@ -1,0 +1,11 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - list2/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+
+
+options:
+  language: Java

--- a/java/jdart-regression/list2/Main.java
+++ b/java/jdart-regression/list2/Main.java
@@ -1,0 +1,111 @@
+/* This is a modified version of the original Benchmark.
+ *
+ * Origin of the original benchmark:
+ *     license: 4-clause BSD (see /java/jbmc-regression/LICENSE)
+ *     repo: https://github.com/diffblue/cbmc.git
+ *     branch: develop
+ *     directory: regression/cbmc-java/list1
+ * The benchmark was taken from the repo: 24 January 2018
+ * Modifications are licensed by 4-clause BSD
+ * Copyright TU Dortmund, Malte Mues
+ */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+class LinkedListEntry {
+  public LinkedListEntry Next;
+  public int Value;
+}
+
+class LinkedList {
+  public LinkedListEntry Head;
+
+  public int size() {
+    int count = 0;
+    for (LinkedListEntry entry = Head; entry != null; entry = entry.Next)
+      ++count;
+    return count;
+  }
+
+  public void add(int index, int e) {
+    LinkedListEntry newEntry = new LinkedListEntry();
+    newEntry.Value = e;
+    if (index == 0) {
+      Head = newEntry;
+      return;
+    }
+    LinkedListEntry entry = Head;
+    for (int i = 1; i < index; ++i)
+      entry = entry.Next;
+    entry.Next = newEntry;
+  }
+
+  public void add(int e) { add(size(), e); }
+
+  public void remove(int index) {
+    LinkedListEntry entry = Head;
+    for (int i = 1; i < index; ++i)
+      entry = entry.Next;
+    entry.Next = entry.Next.Next;
+  }
+
+  public int get(int index) {
+    LinkedListEntry entry = Head;
+    for (int i = 0; i < index; ++i)
+      entry = entry.Next;
+    return entry.Value;
+  }
+}
+
+class Utils_nondet {
+  public static int nondet_int() { return Verifier.nondetInt(); }
+}
+
+class Utils_synthesis {
+  public static int accumulator(int aggregated, int e) {
+      if (aggregated < e)
+        return e;
+    return aggregated;
+  }
+
+  public static boolean predicate(int lhs) { return true; }
+}
+
+public class Main {
+  private static int stream(LinkedList list) {
+    // java.util.stream.Stream.filter(...)
+    int index = 0;
+    for (LinkedListEntry entry = list.Head; entry != null; entry = entry.Next)
+      if (Utils_synthesis.predicate(entry.Value))
+        ++index;
+      else
+        list.remove(index);
+
+    // java.util.stream.Stream.reduce(...)
+    int aggregated = 0;
+    for (LinkedListEntry it = list.Head; it != null; it = it.Next)
+      aggregated = Utils_synthesis.accumulator(aggregated, it.Value);
+
+    return aggregated;
+  }
+
+  public static void main(String[] args) {
+    LinkedList lhs = new LinkedList();
+    LinkedList rhs = new LinkedList();
+    int size = 10;
+    for (int i = 0; i < size; ++i) {
+      int value = Utils_nondet.nondet_int();
+      lhs.add(i, value);
+      rhs.add(i, value);
+    }
+
+    int lhs_result = 0;
+    for (LinkedListEntry it = lhs.Head; it != null; it = it.Next) {
+        if (lhs_result < it.Value)
+          lhs_result = it.Value;
+    }
+
+    int rhs_result = stream(rhs);
+
+    assert(lhs_result == rhs_result);
+  }
+}

--- a/java/jdart-regression/radians.yml
+++ b/java/jdart-regression/radians.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - radians/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/radians/Main.java
+++ b/java/jdart-regression/radians/Main.java
@@ -1,0 +1,44 @@
+/*
+ * Origin of the benchmark:
+ *     license: Apache 2.0 (see /java/jdart-regression/LICENSE-Apache)
+ *     repo: https://github.com/psycopaths/jdart
+ *     branch: master
+ *     directory: src/examples/features/radians
+ * 
+ * The benchmark was taken from the repo: 30 September 2020
+ */
+
+/*
+ * Copyright (C) 2015, United States Government, as represented by the 
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ * 
+ * The PSYCO: A Predicate-based Symbolic Compositional Reasoning environment 
+ * platform is licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. You may obtain a 
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0. 
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    double deg = Verifier.nondetDouble();
+    double rad = java.lang.Math.toRadians(deg);
+    if (rad >= 0) {
+      System.out.println("Radians is positively radiant!");
+    }
+    else {
+      assert false;
+    }
+
+  }
+}

--- a/java/jdart-regression/shifting.yml
+++ b/java/jdart-regression/shifting.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - shifting/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/shifting/Main.java
+++ b/java/jdart-regression/shifting/Main.java
@@ -1,0 +1,24 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    int i = Verifier.nondetInt();
+
+    if ( i < 0 || i > 100) {
+      return;
+    }
+
+    if ( (1L << i) > Integer.MAX_VALUE) {
+      assert false;
+    }
+
+  }
+}

--- a/java/jdart-regression/shifting2.yml
+++ b/java/jdart-regression/shifting2.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - shifting2/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/shifting2/Main.java
+++ b/java/jdart-regression/shifting2/Main.java
@@ -1,0 +1,21 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    int i = Verifier.nondetInt();
+
+    if ( i < 1 || i > 100) {
+      return;
+    }
+
+    assert (( 1 << i) != 1);
+  }
+}

--- a/java/jdart-regression/shifting3.yml
+++ b/java/jdart-regression/shifting3.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - shifting3/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: false
+
+options:
+  language: Java

--- a/java/jdart-regression/shifting3/Main.java
+++ b/java/jdart-regression/shifting3/Main.java
@@ -1,0 +1,21 @@
+/*
+ * Contributed to SV-COMP by Falk Howar
+ * License: MIT (see /java/jdart-regression/LICENSE-MIT)
+ *    
+ */
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+
+    int i = Verifier.nondetInt();
+
+    if ( i < 1 || i > 100) {
+      return;
+    }
+
+    assert (( 1L << i) != 1L);
+  }
+}

--- a/java/jdart-regression/startswith.yml
+++ b/java/jdart-regression/startswith.yml
@@ -1,0 +1,10 @@
+format_version: "2.0"
+input_files:
+  - ../common/
+  - startswith/
+properties:
+  - property_file: ../properties/assert.prp
+    expected_verdict: true
+
+options:
+  language: Java

--- a/java/jdart-regression/startswith/Main.java
+++ b/java/jdart-regression/startswith/Main.java
@@ -1,0 +1,30 @@
+/*
+* Contributed to SV-COMP by Falk Howar
+* License: MIT (see /java/jdart-regression/LICENSE-MIT)
+*
+*/
+
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+import java.io.IOException;
+
+public class Main {
+  public void doPost(String request) throws IOException {
+    String param = "";
+    if (Verifier.nondetString() != null) {
+      param = request;
+    }
+
+    String[] argsEnv = { param };
+
+    if (param.equals("") && argsEnv[0].equals("GOTCHA")) {
+      assert false;
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    String request = Verifier.nondetString();
+    Main b = new Main();
+    b.doPost(request);
+  }
+}


### PR DESCRIPTION
This is joint work with Falk Howar @fhowar

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [ ] [data model](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#data-model) present in task-definition file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
