### PR TITLE
Fix diff_ci.sh, run CI on folders with Makefile

### DIFF
--- a/c/diff_ci.sh
+++ b/c/diff_ci.sh
@@ -37,9 +37,13 @@ dirs=`echo $relevant_diff | xargs dirname | cut -d/ -f2- | sort | uniq`
 printf "Selected following directories for diff build: \n$dirs \n"
 for d in $dirs
 do
-  parent_with_Makefile=$d
-  find_parent_with_Makefile
-  # Execute the command only if the directory is not present in dirs.
-  # Assumes that directory names do not have spaces.
-  [[ " ${dirs[@]} " =~ " $parent_with_Makefile " ]] || $cmdToExecute $parent_with_Makefile
+  if [ -e "$d/Makefile" ]; then
+    $cmdToExecute $d
+  else
+    parent_with_Makefile=$d
+    find_parent_with_Makefile
+    # Execute the command only if the directory is not present in dirs.
+    # Assumes that directory names do not have spaces.
+    [[ " ${dirs[@]} " =~ " $parent_with_Makefile " ]] || $cmdToExecute $parent_with_Makefile
+  fi
 done


### PR DESCRIPTION
While the script worked correctly if a folder where things were changed
contains NO Makefile, it was broken in cases where it actually contained
a Makefile. Then no command was executed for that directory.