### PR TITLE
fix diff build

### DIFF
--- a/c/diff_ci.sh
+++ b/c/diff_ci.sh
@@ -32,7 +32,7 @@ find_parent_with_Makefile() {
 relevant_diff=`git diff --name-only --diff-filter=d origin/master... -- './*.i' './*.c' './*.h'`
 [ -z "$relevant_diff" ] && echo "Found nothing to build!!" && exit
 # dirs is the list of directories from the changed files
-dirs=`echo $relevant_diff | xargs dirname | cut -d/ -f2- | sort | uniq`
+dirs=`echo $relevant_diff | xargs dirname | cut -d/ -f2- -s | sort | uniq`
 
 printf "Selected following directories for diff build: \n$dirs \n"
 for d in $dirs


### PR DESCRIPTION
This PR adds "-s" flag to the cut command.

without this flag the changes if the dir `c` is found in the diff it will be included.
This is causing the script to hang later.

e.g., in the PR #1099 the file `Makefile-detect-compiler.c` was changed and this put the directory `c` to be in the list of directories to be built. We don't build this directory. We iteratively build the directories in `c`