### PR TITLE
Fixes for Integer Overflows

### DIFF
--- a/c/array-cav19/array_tiling_poly6.c
+++ b/c/array-cav19/array_tiling_poly6.c
@@ -11,8 +11,8 @@ int main()
 {
   int S=__VERIFIER_nondet_int();
   assume_abort_if_not(S>1);
-  int i;
-  int a[S];
+  long long i;
+  long long a[S];
 
   for(i=0;i<S;i++)
     a[i]=((i-1)*(i+1));

--- a/c/array-cav19/array_tiling_tcpy.c
+++ b/c/array-cav19/array_tiling_tcpy.c
@@ -11,6 +11,7 @@ int main()
 {
   int S=__VERIFIER_nondet_int();
   assume_abort_if_not(S>1);
+  assume_abort_if_not(S < 1073741823);
   int i;
   int a[2*S];
   int acopy[2*S];


### PR DESCRIPTION
Added the fixes for integer overflow issues raised in #1173, for the benchmarks submitted in PR #835 

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [ ] [data model](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#data-model) present in task-definition file
- [ ] original (ideally not preprocessed) sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
