### PR TITLE
Cleaned up definitions of memcmp function

### DIFF
--- a/c/aws-c-common/aws_array_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_c_str_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_array_eq_harness.i
+++ b/c/aws-c-common/aws_array_eq_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_array_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_array_eq_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_buf_cat_harness.i
+++ b/c/aws-c-common/aws_byte_buf_cat_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_c_str_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_buf_eq_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_buf_eq_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lexical_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_compare_lookup_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_byte_buf_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_c_str_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_eq_ignore_case_harness.i
@@ -7395,23 +7395,10 @@ int aws_last_error(void) {
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8255,7 +8242,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));

--- a/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_c_str_eq_harness.i
@@ -7379,23 +7379,10 @@ _Bool
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8239,7 +8226,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));
@@ -11154,7 +11141,7 @@ int aws_string_compare(const struct aws_string *a, const struct aws_string *b) {
     size_t len_b = b->len;
     size_t min_len = len_a < len_b ? len_a : len_b;
 
-    int ret = memcmp(aws_string_bytes(a), aws_string_bytes(b), min_len);
+    int ret = memcmp_safe(aws_string_bytes(a), aws_string_bytes(b), min_len);
     __VERIFIER_assert((aws_string_is_valid(a)));
     __VERIFIER_assert((aws_string_is_valid(b)));
     if (ret) {

--- a/c/aws-c-common/aws_hash_callback_string_eq_harness.i
+++ b/c/aws-c-common/aws_hash_callback_string_eq_harness.i
@@ -7379,23 +7379,10 @@ _Bool
 
 
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-
-    int res = 0;
+int memcmp_safe(const void *s1, const void *s2, size_t n) {
     assume_abort_if_not((((n) == 0) || (s1)));
     assume_abort_if_not((((n) == 0) || (s2)));
-
-
-    const unsigned char *sc1 = s1, *sc2 = s2;
-    for (; n != 0; n--) {
-        res = (*sc1++) - (*sc2++);
-        if (res != 0)
-            return res;
-    }
-    return res;
-
-
-
+    return memcmp(s1, s2, n);
 }
  size_t aws_nospec_mask(size_t index, size_t bound);
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
@@ -8239,7 +8226,7 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
         comparison_length = rhs->len;
     }
 
-    int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+    int result = memcmp_safe(lhs->ptr, rhs->ptr, comparison_length);
 
     __VERIFIER_assert((aws_byte_cursor_is_valid(lhs)));
     __VERIFIER_assert((aws_byte_cursor_is_valid(rhs)));
@@ -11154,7 +11141,7 @@ int aws_string_compare(const struct aws_string *a, const struct aws_string *b) {
     size_t len_b = b->len;
     size_t min_len = len_a < len_b ? len_a : len_b;
 
-    int ret = memcmp(aws_string_bytes(a), aws_string_bytes(b), min_len);
+    int ret = memcmp_safe(aws_string_bytes(a), aws_string_bytes(b), min_len);
     __VERIFIER_assert((aws_string_is_valid(a)));
     __VERIFIER_assert((aws_string_is_valid(b)));
     if (ret) {


### PR DESCRIPTION
I renamed the existing definition into memcmp_safe
to match its intentions. Then, this safe definition
invoked the standard memcmp.