### PR TITLE
fix crash of check-script when called with `python3 check.py`.

### DIFF
--- a/c/check.py
+++ b/c/check.py
@@ -660,7 +660,7 @@ def main(num_processes):
         logging.warning("Missing python-yaml, not all checks can be executed")
 
 
-    main_directory = os.path.relpath(os.path.dirname(__file__))
+    main_directory = os.path.relpath(os.path.dirname(__file__) or '.')
     _check_known_errors_consistent(main_directory)
     entries = sorted(os.listdir(main_directory))
     all_patterns_re = (


### PR DESCRIPTION
This is a quite small PR: just a few chars are added.

An empty dirname crashes the script. The fix uses '.' instead of empty string ''.