### PR TITLE
Shrink Juliet MemSafety integration

### DIFF
--- a/c/MemSafety-Juliet.set
+++ b/c/MemSafety-Juliet.set
@@ -1,3 +1,10 @@
 # Contains tasks for checking memory safety of programs from Juliet Test Suite.
-Juliet_Test/*.yml
+
+#CWE415_Double_Free
+Juliet_Test/CWE415*.yml
+
+#CWE476_NULL_Pointer_Dereference
+Juliet_Test/CWE476*_int*.yml
+Juliet_Test/CWE476*_long*.yml
+Juliet_Test/CWE476*_struct*.yml
 

--- a/c/Unused_Juliet.set
+++ b/c/Unused_Juliet.set
@@ -1,0 +1,21 @@
+# Contains tasks from Juliet Test Suite.
+# Those tasks are currently not used in any benchmark.
+
+Juliet_Test/CWE121*.yml
+Juliet_Test/CWE122*.yml
+Juliet_Test/CWE124*.yml
+Juliet_Test/CWE126*.yml
+Juliet_Test/CWE127*.yml
+Juliet_Test/CWE401*.yml
+
+Juliet_Test/CWE416*.yml
+
+Juliet_Test/CWE476*_binary_*.yml
+Juliet_Test/CWE476*_char_*.yml
+Juliet_Test/CWE476*_null_check_*.yml
+Juliet_Test/CWE476*_deref_after_check_*.yml
+
+Juliet_Test/CWE590*.yml
+Juliet_Test/CWE690*.yml
+Juliet_Test/CWE761*.yml
+Juliet_Test/CWE789*.yml


### PR DESCRIPTION
Many CWE IDs of the preprocessed files in Juliet_Test folder can not be mapped on our MemSafety property.
This PR restricts the MemSafety-Juliet.set to two CWEs:
- CWE415_Double_Free
- CWE476_NULL_Pointer_Dereference
The PR includes 668 Juliet Tasks.
