### PR TITLE
Fix wrong reference to the software system BusyBox

### DIFF
--- a/c/SoftwareSystems-uthash-MemSafety.set
+++ b/c/SoftwareSystems-uthash-MemSafety.set
@@ -1,2 +1,2 @@
-# Contains problems from the software system BusyBox.
+# Contains problems from the uthash hashing library.
 uthash-2.0.2/*.yml

--- a/c/SoftwareSystems-uthash-NoOverflows.set
+++ b/c/SoftwareSystems-uthash-NoOverflows.set
@@ -1,2 +1,2 @@
-# Contains problems from the software system BusyBox.
+# Contains problems from the uthash hashing library.
 uthash-2.0.2/*.yml

--- a/c/SoftwareSystems-uthash-ReachSafety.set
+++ b/c/SoftwareSystems-uthash-ReachSafety.set
@@ -1,2 +1,2 @@
-# Contains problems from the software system BusyBox.
+# Contains problems from the uthash hashing library.
 uthash-2.0.2/*.yml


### PR DESCRIPTION
I overlooked this mistake when reviewing.