### PR TITLE
Add uthash to list of directories without license headers

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -140,6 +140,7 @@ Files:
  c/termination-recursive-malloc
  c/termination-restricted-15
  c/termination-restricted-15-todo
+ c/uthash-2.0.2
  c/verifythis
  c/xcsp
  java/MinePump


### PR DESCRIPTION
It was recently added but still has the old License.txt

Fixes current CI after #1171 was merged without REUSE-style headers.