### PR TITLE
Add license declarations to all files in c/pthread

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -22,7 +22,6 @@ Files:
  c/loops
  c/ntdrivers
  c/ntdrivers-simplified
- c/pthread
  c/pthread-ext
  c/seq-pthread
  c/systemc

--- a/c/pthread/README.md
+++ b/c/pthread/README.md
@@ -1,0 +1,17 @@
+<!--
+This file is part of the SV-Benchmarks collection of verification tasks:
+https://github.com/sosy-lab/sv-benchmarks
+
+SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Various small concurrent programs.
+
+- `bigshot*`, `sigma*`, `singleton*`: Submitted by the CSeq project
+- `triangular*`: Submitted by the CPAchecker project
+- Remainder submitted by the ESBMC project.
+  Some of these are described in https://doi.org/10.1145/1985793.1985839
+  or https://dl.acm.org/doi/10.1145/1639622.1639631 (also cf. https://wiki.cs.byu.edu/vv-lab/concurrency-tool-comparison).
+

--- a/c/pthread/README.txt
+++ b/c/pthread/README.txt
@@ -1,4 +1,0 @@
-Contributed by: ESBMC project
-
-triangular*: contributed by Sosy-Lab (Apache2)
-

--- a/c/pthread/bigshot_p.c
+++ b/c/pthread/bigshot_p.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/bigshot_p.i
+++ b/c/pthread/bigshot_p.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/bigshot_s.c
+++ b/c/pthread/bigshot_s.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/bigshot_s.i
+++ b/c/pthread/bigshot_s.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/bigshot_s2.c
+++ b/c/pthread/bigshot_s2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/bigshot_s2.i
+++ b/c/pthread/bigshot_s2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench-1.c
+++ b/c/pthread/fib_bench-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench-1.i
+++ b/c/pthread/fib_bench-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench-2.c
+++ b/c/pthread/fib_bench-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench-2.i
+++ b/c/pthread/fib_bench-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench_longer-1.c
+++ b/c/pthread/fib_bench_longer-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench_longer-1.i
+++ b/c/pthread/fib_bench_longer-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench_longer-2.c
+++ b/c/pthread/fib_bench_longer-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench_longer-2.i
+++ b/c/pthread/fib_bench_longer-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench_longest-1.c
+++ b/c/pthread/fib_bench_longest-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench_longest-1.i
+++ b/c/pthread/fib_bench_longest-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/fib_bench_longest-2.c
+++ b/c/pthread/fib_bench_longest-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/fib_bench_longest-2.i
+++ b/c/pthread/fib_bench_longest-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/indexer.c
+++ b/c/pthread/indexer.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/indexer.i
+++ b/c/pthread/indexer.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/lazy01.c
+++ b/c/pthread/lazy01.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/lazy01.i
+++ b/c/pthread/lazy01.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/queue.c
+++ b/c/pthread/queue.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue.i
+++ b/c/pthread/queue.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/queue_longer.c
+++ b/c/pthread/queue_longer.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue_longer.i
+++ b/c/pthread/queue_longer.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/queue_longest.c
+++ b/c/pthread/queue_longest.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue_longest.i
+++ b/c/pthread/queue_longest.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/queue_ok.c
+++ b/c/pthread/queue_ok.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue_ok.i
+++ b/c/pthread/queue_ok.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/queue_ok_longer.c
+++ b/c/pthread/queue_ok_longer.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue_ok_longer.i
+++ b/c/pthread/queue_ok_longer.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/queue_ok_longest.c
+++ b/c/pthread/queue_ok_longest.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 #include <assert.h>

--- a/c/pthread/queue_ok_longest.i
+++ b/c/pthread/queue_ok_longest.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern int __VERIFIER_nondet_int(void);
 extern void abort(void);
 

--- a/c/pthread/reorder_2.c
+++ b/c/pthread/reorder_2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/reorder_2.i
+++ b/c/pthread/reorder_2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/reorder_5.c
+++ b/c/pthread/reorder_5.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "reorder_5.c", 3, "reach_error"); }

--- a/c/pthread/reorder_5.i
+++ b/c/pthread/reorder_5.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "reorder_5.c", 3, "reach_error"); }

--- a/c/pthread/sigma.c
+++ b/c/pthread/sigma.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread/sigma.i
+++ b/c/pthread/sigma.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}

--- a/c/pthread/singleton-b.c
+++ b/c/pthread/singleton-b.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/singleton-b.i
+++ b/c/pthread/singleton-b.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/singleton.c
+++ b/c/pthread/singleton.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/singleton.i
+++ b/c/pthread/singleton.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/singleton_with-uninit-problems-b.c
+++ b/c/pthread/singleton_with-uninit-problems-b.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/singleton_with-uninit-problems-b.i
+++ b/c/pthread/singleton_with-uninit-problems-b.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/singleton_with-uninit-problems.c
+++ b/c/pthread/singleton_with-uninit-problems.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/singleton_with-uninit-problems.i
+++ b/c/pthread/singleton_with-uninit-problems.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The CSeq project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack-1.c
+++ b/c/pthread/stack-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack-1.i
+++ b/c/pthread/stack-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack-2.c
+++ b/c/pthread/stack-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack-2.i
+++ b/c/pthread/stack-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack_longer-1.c
+++ b/c/pthread/stack_longer-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack_longer-1.i
+++ b/c/pthread/stack_longer-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack_longer-2.c
+++ b/c/pthread/stack_longer-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack_longer-2.i
+++ b/c/pthread/stack_longer-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack_longest-1.c
+++ b/c/pthread/stack_longest-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack_longest-1.i
+++ b/c/pthread/stack_longest-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stack_longest-2.c
+++ b/c/pthread/stack_longest-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stack_longest-2.i
+++ b/c/pthread/stack_longest-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stateful01-1.c
+++ b/c/pthread/stateful01-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stateful01-1.i
+++ b/c/pthread/stateful01-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/stateful01-2.c
+++ b/c/pthread/stateful01-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/stateful01-2.i
+++ b/c/pthread/stateful01-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/sync01.c
+++ b/c/pthread/sync01.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/sync01.i
+++ b/c/pthread/sync01.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2020 The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,

--- a/c/pthread/triangular-1.c
+++ b/c/pthread/triangular-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-1.i
+++ b/c/pthread/triangular-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-2.c
+++ b/c/pthread/triangular-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-2.i
+++ b/c/pthread/triangular-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-longer-1.c
+++ b/c/pthread/triangular-longer-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-longer-1.i
+++ b/c/pthread/triangular-longer-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-longer-2.c
+++ b/c/pthread/triangular-longer-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-longer-2.i
+++ b/c/pthread/triangular-longer-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-longest-1.c
+++ b/c/pthread/triangular-longest-1.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-longest-1.i
+++ b/c/pthread/triangular-longest-1.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-longest-2.c
+++ b/c/pthread/triangular-longest-2.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pthread.h>
 
 extern void __VERIFIER_atomic_begin();

--- a/c/pthread/triangular-longest-2.i
+++ b/c/pthread/triangular-longest-2.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: 2018 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/twostage_3.c
+++ b/c/pthread/twostage_3.c
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }

--- a/c/pthread/twostage_3.i
+++ b/c/pthread/twostage_3.i
@@ -1,3 +1,11 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
 extern void abort(void);
 
 extern void __assert_fail (const char *__assertion, const char *__file,


### PR DESCRIPTION
There was previously no license declaration (except for a short note referring to a subset of the tasks in the readme), but @dbeyer and me communicated with the original submitters via email and got these confirmed. The commit messages also contain more detailed statements.

Readme also improved.

Part of #165.