### PR TITLE
Added missing expected result for no-overflow property

### DIFF
--- a/c/nla-digbench/divbin.yml
+++ b/c/nla-digbench/divbin.yml
@@ -3,6 +3,8 @@ input_files: 'divbin.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/divbin2.yml
+++ b/c/nla-digbench/divbin2.yml
@@ -3,6 +3,8 @@ input_files: 'divbin2.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/freire1.yml
+++ b/c/nla-digbench/freire1.yml
@@ -3,6 +3,8 @@ input_files: 'freire1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/freire2.yml
+++ b/c/nla-digbench/freire2.yml
@@ -3,6 +3,8 @@ input_files: 'freire2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/knuth.yml
+++ b/c/nla-digbench/knuth.yml
@@ -3,6 +3,8 @@ input_files: 'knuth.i'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/lcm1.yml
+++ b/c/nla-digbench/lcm1.yml
@@ -3,6 +3,8 @@ input_files: 'lcm1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/lcm2.yml
+++ b/c/nla-digbench/lcm2.yml
@@ -3,6 +3,8 @@ input_files: 'lcm2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true    
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C

--- a/c/nla-digbench/mannadiv.yml
+++ b/c/nla-digbench/mannadiv.yml
@@ -3,6 +3,8 @@ input_files: 'mannadiv.c'
 properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: true
+  - property_file: ../properties/no-overflow.prp
+    expected_verdict: true
 
 options:
   language: C


### PR DESCRIPTION
#1155 fixed several overflows and added the corresponding expected behaviour for the modified files.
However the files that were not modified (because they did not have overflows) did not get an expected behaviour for `no-overflow`.
This PR adds those expected behaviours.