### PR TITLE
Restore original benchmark semantics

### DIFF
--- a/c/ldv-races/race-2_2-container_of.c
+++ b/c/ldv-races/race-2_2-container_of.c
@@ -45,7 +45,10 @@ void *my_callback(void *arg) {
      data->shared.a = 1;
      __VERIFIER_atomic_end();
      __VERIFIER_atomic_begin();
-     data->shared.b = data->shared.b + 1;
+     int lb = data->shared.b;
+     __VERIFIER_atomic_end();
+     __VERIFIER_atomic_begin();
+     data->shared.b = lb + 1;
      __VERIFIER_atomic_end();
     //pthread_mutex_unlock (&data->lock);
 	return 0;

--- a/c/ldv-races/race-2_2-container_of.i
+++ b/c/ldv-races/race-2_2-container_of.i
@@ -1693,7 +1693,10 @@ void *my_callback(void *arg) {
      data->shared.a = 1;
      __VERIFIER_atomic_end();
      __VERIFIER_atomic_begin();
-     data->shared.b = data->shared.b + 1;
+     int lb = data->shared.b;
+     __VERIFIER_atomic_end();
+     __VERIFIER_atomic_begin();
+     data->shared.b = lb + 1;
      __VERIFIER_atomic_end();
  return 0;
 }

--- a/c/ldv-races/race-2_5-container_of.c
+++ b/c/ldv-races/race-2_5-container_of.c
@@ -44,7 +44,10 @@ void *my_callback(void *arg) {
 	data->shared.a = 1;
     __VERIFIER_atomic_end();
     __VERIFIER_atomic_begin();
-	data->shared.b = data->shared.b + 1;
+    int lb = data->shared.b;
+    __VERIFIER_atomic_end();
+    __VERIFIER_atomic_begin();
+    data->shared.b = lb + 1;
     __VERIFIER_atomic_end();
 	pthread_mutex_unlock (&data->lock);
 	return 0;

--- a/c/ldv-races/race-2_5-container_of.i
+++ b/c/ldv-races/race-2_5-container_of.i
@@ -1694,7 +1694,10 @@ void *my_callback(void *arg) {
  data->shared.a = 1;
     __VERIFIER_atomic_end();
     __VERIFIER_atomic_begin();
- data->shared.b = data->shared.b + 1;
+    int lb = data->shared.b;
+    __VERIFIER_atomic_end();
+    __VERIFIER_atomic_begin();
+    data->shared.b = lb + 1;
     __VERIFIER_atomic_end();
  pthread_mutex_unlock (&data->lock);
  return 0;


### PR DESCRIPTION
Changes made by me in #1157 and #1177 changed the semantics of two benchmarks which changed the result of the verification.
In both cases the problem was the same. The original code
```
data->shared.a = 1;
data->shared.b = data->shared.b + 1;
```
was changed to 
```
__VERIFIER_atomic_begin();
data->shared.a = 1;
__VERIFIER_atomic_end();
__VERIFIER_atomic_begin();
data->shared.b = data->shared.b + 1;
__VERIFIER_atomic_end();
```
This clearly changes the semantics of the program since in the original case there can be a context switch between the read and the write of `data->shared.b`. This is not possible in the benchmarks after my changes.

This PR fix these while still providing a solution for the data races (which was the intention of #1157 and #1177).