### PR TITLE
Update the verdict for the good task

### DIFF
--- a/java/juliet-java/CWE369_Divided_by_Zero__float_connect_tcp_divide_81a_good.yml
+++ b/java/juliet-java/CWE369_Divided_by_Zero__float_connect_tcp_divide_81a_good.yml
@@ -5,7 +5,7 @@ input_files:
   - CWE369_Divide_by_Zero__float_connect_tcp_divide_81a_good/
 properties:
   - property_file: ../properties/assert.prp
-    expected_verdict: false
+    expected_verdict: true
 
 options:
   language: Java


### PR DESCRIPTION
<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

This file originates from the good part of the original benchmark. In this example, there is no assertion violation expected. I made a mistake here.

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (in machine-readable comment at beginning of program as specified by the [REUSE project](https://reuse.software/))
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [ ] [data model](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#data-model) present in task-definition file
- [ ] original (ideally not preprocessed) sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
