### PR TITLE
Passing size of 0 to malloc leads to assertion violation

### DIFF
--- a/c/aws-c-common/aws_string_eq_byte_buf_harness.i
+++ b/c/aws-c-common/aws_string_eq_byte_buf_harness.i
@@ -6860,7 +6860,7 @@ struct aws_string *ensure_string_is_allocated_nondet_length() {
 
 struct aws_string *ensure_string_is_allocated_bounded_length(size_t max_size) {
     size_t len = nondet_uint64_t();
-    assume_abort_if_not(len < max_size);
+    assume_abort_if_not(0 < len && len < max_size);
     return ensure_string_is_allocated(len);
 }
 

--- a/c/aws-c-common/aws_string_new_from_array_harness.i
+++ b/c/aws-c-common/aws_string_new_from_array_harness.i
@@ -9460,10 +9460,11 @@ struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, co
 }
 void aws_string_new_from_array_harness() {
 
-    size_t alloc_size;
+    size_t alloc_size = nondet_size_t();
+    assume_abort_if_not(alloc_size > 0);
     uint8_t *array = bounded_malloc(alloc_size);
     struct aws_allocator *allocator = can_fail_allocator();
-    size_t reported_size;
+    size_t reported_size = nondet_size_t();
 
 
     assume_abort_if_not(reported_size <= alloc_size);


### PR DESCRIPTION
This commit avoids the situation where size of 0 can be
passed to malloc. I think it does not alter the spirit
of the benchmark.

This is related to the unresolved mailing list discussion with the subject line "Can malloc return 0 when 0 is passed as size?".
As I wrote there, if we assume that malloc(0) can return NULL, which C standard allows, then these two benchmarks have an interesting (in my opinion) corner case bug. However, since we have not resolved the discussion, and in my opinion the current SVCOMP spec for malloc does not adequately cover this corner case, I am disabling 0 being passed to malloc.

If we decide that malloc(0) can return NULL, I will create buggy versions of these benchmarks.
