### PR TITLE
Added ldv_ prefix to strlen and strerror function definitions

### DIFF
--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.c
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.c
@@ -3838,7 +3838,7 @@ extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , 
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4670,7 +4670,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const   *)ps_name);
+  tmp = ldv_strlen((char const   *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4694,9 +4694,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
     } else {
 
     }
-    tmp___1 = strlen((char const   *)ps_name);
+    tmp___1 = ldv_strlen((char const   *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const   *)ps_name);
+      tmp___0 = ldv_strlen((char const   *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4750,7 +4750,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
   } else {
 
   }
-  tmp = strlen((char const   *)rt);
+  tmp = ldv_strlen((char const   *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4948,7 +4948,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const   *)(& ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4975,7 +4975,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const   *)(& radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5371,7 +5371,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U: 
-  tmp = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
@@ -5379,7 +5379,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___0 = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const   *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5389,7 +5389,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25771;
   case 10160390U: 
-  tmp___1 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
@@ -5397,7 +5397,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___2 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const   *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6434,7 +6434,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.i
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f-1.i
@@ -3841,7 +3841,7 @@ extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 extern char *strncpy(char * , char const * , __kernel_size_t ) ;
 extern size_t strlcpy(char * , char const * , size_t ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4586,7 +4586,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const *)ps_name);
+  tmp = ldv_strlen((char const *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4607,9 +4607,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
       goto ldv_25635;
     } else {
     }
-    tmp___1 = strlen((char const *)ps_name);
+    tmp___1 = ldv_strlen((char const *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const *)ps_name);
+      tmp___0 = ldv_strlen((char const *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4657,7 +4657,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
     goto unlock;
   } else {
   }
-  tmp = strlen((char const *)rt);
+  tmp = ldv_strlen((char const *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4843,7 +4843,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const *)(& ps_name));
+  tmp___0 = ldv_strlen((char const *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4867,7 +4867,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const *)(& radio_text));
+  tmp___2 = ldv_strlen((char const *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5236,14 +5236,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U:
-  tmp = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___0 = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5252,14 +5252,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25771;
   case 10160390U:
-  tmp___1 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___2 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6205,7 +6205,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.c
@@ -3838,7 +3838,7 @@ extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , 
 extern void might_fault(void) ;
 extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4670,7 +4670,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const   *)ps_name);
+  tmp = ldv_strlen((char const   *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4694,9 +4694,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
     } else {
 
     }
-    tmp___1 = strlen((char const   *)ps_name);
+    tmp___1 = ldv_strlen((char const   *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const   *)ps_name);
+      tmp___0 = ldv_strlen((char const   *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4750,7 +4750,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
   } else {
 
   }
-  tmp = strlen((char const   *)rt);
+  tmp = ldv_strlen((char const   *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4948,7 +4948,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const   *)(& ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4975,7 +4975,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const   *)(& radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5371,7 +5371,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U: 
-  tmp = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
@@ -5379,7 +5379,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___0 = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const   *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5389,7 +5389,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25771;
   case 10160390U: 
-  tmp___1 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
@@ -5397,7 +5397,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___2 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const   *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6434,7 +6434,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
+++ b/c/ldv-commit-tester/m0_drivers-media-radio-si4713-i2c-ko--111_1a--064368f.i
@@ -3841,7 +3841,7 @@ extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
 extern void might_fault(void) ;
 extern void *memmove(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 extern char *strncpy(char * , char const * , __kernel_size_t ) ;
 extern size_t strlcpy(char * , char const * , size_t ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4586,7 +4586,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const *)ps_name);
+  tmp = ldv_strlen((char const *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4607,9 +4607,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
       goto ldv_25635;
     } else {
     }
-    tmp___1 = strlen((char const *)ps_name);
+    tmp___1 = ldv_strlen((char const *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const *)ps_name);
+      tmp___0 = ldv_strlen((char const *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4657,7 +4657,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
     goto unlock;
   } else {
   }
-  tmp = strlen((char const *)rt);
+  tmp = ldv_strlen((char const *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4843,7 +4843,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const *)(& ps_name));
+  tmp___0 = ldv_strlen((char const *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4867,7 +4867,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const *)(& radio_text));
+  tmp___2 = ldv_strlen((char const *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5236,14 +5236,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U:
-  tmp = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___0 = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5252,14 +5252,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25771;
   case 10160390U:
-  tmp___1 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___2 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23581.string, (void const *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6205,7 +6205,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_drivers-scsi-gdth-ko--111_1a--5934df9-1.c
+++ b/c/ldv-commit-tester/m0_drivers-scsi-gdth-ko--111_1a--5934df9-1.c
@@ -12838,7 +12838,7 @@ __inline static unsigned long ldv_copy_from_user_5(void *to , void const   *from
   return (tmp);
 }
 }
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void) 
 { 
@@ -12867,7 +12867,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_drivers-scsi-gdth-ko--111_1a--5934df9-1.i
+++ b/c/ldv-commit-tester/m0_drivers-scsi-gdth-ko--111_1a--5934df9-1.i
@@ -12104,7 +12104,7 @@ __inline static unsigned long ldv_copy_from_user_5(void *to , void const *from ,
   return (tmp);
 }
 }
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void)
 {
@@ -12127,7 +12127,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d-1.c
+++ b/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d-1.c
@@ -6323,7 +6323,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const   *from
   return (tmp);
 }
 }
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void) 
 { 
@@ -6352,7 +6352,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d-1.i
+++ b/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d-1.i
@@ -6162,7 +6162,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const *from ,
   return (tmp);
 }
 }
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void)
 {
@@ -6185,7 +6185,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d.c
+++ b/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d.c
@@ -6321,7 +6321,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const   *from
   return (tmp);
 }
 }
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void) 
 { 
@@ -6350,7 +6350,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d.i
+++ b/c/ldv-commit-tester/m0_sound-oss-opl3-ko--111_1a--42f9f8d.i
@@ -6160,7 +6160,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const *from ,
   return (tmp);
 }
 }
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void)
 {
@@ -6183,7 +6183,7 @@ long ldv__builtin_expect(long exp , long c )
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point.cil.out.c
@@ -3842,7 +3842,7 @@ extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , 
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4791,7 +4791,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const   *)ps_name);
+  tmp = ldv_strlen((char const   *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4815,9 +4815,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
     } else {
 
     }
-    tmp___1 = strlen((char const   *)ps_name);
+    tmp___1 = ldv_strlen((char const   *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const   *)ps_name);
+      tmp___0 = ldv_strlen((char const   *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4871,7 +4871,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
   } else {
 
   }
-  tmp = strlen((char const   *)rt);
+  tmp = ldv_strlen((char const   *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -5069,7 +5069,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const   *)(& ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5096,7 +5096,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const   *)(& radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5492,7 +5492,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U: 
-  tmp = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
@@ -5500,7 +5500,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___0 = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23757.string, (void const   *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5510,7 +5510,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25943;
   case 10160390U: 
-  tmp___1 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
@@ -5518,7 +5518,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___2 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23757.string, (void const   *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6848,7 +6848,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point.cil.out.i
@@ -3846,7 +3846,7 @@ extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 extern char *strncpy(char * , char const * , __kernel_size_t ) ;
 extern size_t strlcpy(char * , char const * , size_t ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4698,7 +4698,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const *)ps_name);
+  tmp = ldv_strlen((char const *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4719,9 +4719,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
       goto ldv_25807;
     } else {
     }
-    tmp___1 = strlen((char const *)ps_name);
+    tmp___1 = ldv_strlen((char const *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const *)ps_name);
+      tmp___0 = ldv_strlen((char const *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4769,7 +4769,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
     goto unlock;
   } else {
   }
-  tmp = strlen((char const *)rt);
+  tmp = ldv_strlen((char const *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4955,7 +4955,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const *)(& ps_name));
+  tmp___0 = ldv_strlen((char const *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4979,7 +4979,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const *)(& radio_text));
+  tmp___2 = ldv_strlen((char const *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5348,14 +5348,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U:
-  tmp = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___0 = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->ldv_23757.string, (void const *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5364,14 +5364,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25943;
   case 10160390U:
-  tmp___1 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___2 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->ldv_23757.string, (void const *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6571,7 +6571,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point.cil.out.c
@@ -5644,7 +5644,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const   *from
   return (tmp);
 }
 }
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_stop___0(void) 
 { 
@@ -5656,7 +5656,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point.cil.out.i
@@ -5443,7 +5443,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const *from ,
   return (tmp);
 }
 }
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_stop___0(void)
 {
@@ -5453,7 +5453,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point.cil.out.c
@@ -14221,7 +14221,7 @@ int ldv_del_timer_sync_25(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
-unsigned long strlen(char const   *str ) ;
+unsigned long ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_stop___0(void) 
 { 
@@ -14233,7 +14233,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const   *str ) 
+unsigned long ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.6/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point.cil.out.i
+++ b/c/ldv-validator-v0.6/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point.cil.out.i
@@ -13358,7 +13358,7 @@ int ldv_del_timer_sync_25(struct timer_list *ldv_func_arg1 )
   return (ldv_func_res);
 }
 }
-unsigned long strlen(char const *str ) ;
+unsigned long ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_stop___0(void)
 {
@@ -13368,7 +13368,7 @@ __inline static void ldv_stop___0(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-unsigned long strlen(char const *str )
+unsigned long ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -3842,7 +3842,7 @@ extern void warn_slowpath_fmt(char const   * , int const    , char const   *  , 
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
-size_t strlen(char const   *str ) ;
+size_t ldv_strlen(char const   *str ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4787,7 +4787,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const   *)ps_name);
+  tmp = ldv_strlen((char const   *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4811,9 +4811,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
     } else {
 
     }
-    tmp___1 = strlen((char const   *)ps_name);
+    tmp___1 = ldv_strlen((char const   *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const   *)ps_name);
+      tmp___0 = ldv_strlen((char const   *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4867,7 +4867,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
   } else {
 
   }
-  tmp = strlen((char const   *)rt);
+  tmp = ldv_strlen((char const   *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -5065,7 +5065,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const   *)(& ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5092,7 +5092,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
 
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const   *)(& radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5488,7 +5488,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U: 
-  tmp = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
@@ -5496,7 +5496,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___0 = strlen((char const   *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const   *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->__annonCompField45.string, (void const   *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5506,7 +5506,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25932;
   case 10160390U: 
-  tmp___1 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
@@ -5514,7 +5514,7 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   } else {
 
   }
-  tmp___2 = strlen((char const   *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const   *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->__annonCompField45.string, (void const   *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6845,7 +6845,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const   *str ) 
+size_t ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-064368f-1-111_1a-drivers--media--radio--si4713-i2c.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -3846,7 +3846,7 @@ extern void warn_slowpath_fmt(char const * , int const , char const * , ...) ;
 extern void might_fault(void) ;
 extern void *memcpy(void * , void const * , size_t ) ;
 extern void *memset(void * , int , size_t ) ;
-size_t strlen(char const *str ) ;
+size_t ldv_strlen(char const *str ) ;
 extern char *strncpy(char * , char const * , __kernel_size_t ) ;
 extern size_t strlcpy(char * , char const * , size_t ) ;
 extern void __init_waitqueue_head(wait_queue_head_t * , struct lock_class_key * ) ;
@@ -4696,7 +4696,7 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
   {
   rval = 0;
   len = 0U;
-  tmp = strlen((char const *)ps_name);
+  tmp = ldv_strlen((char const *)ps_name);
   if (tmp == 0UL) {
     memset((void *)ps_name, 0, 97UL);
   } else {
@@ -4717,9 +4717,9 @@ static int si4713_set_rds_ps_name(struct si4713_device *sdev , char *ps_name )
       goto ldv_25796;
     } else {
     }
-    tmp___1 = strlen((char const *)ps_name);
+    tmp___1 = ldv_strlen((char const *)ps_name);
     if (tmp___1 != 0UL) {
-      tmp___0 = strlen((char const *)ps_name);
+      tmp___0 = ldv_strlen((char const *)ps_name);
       len = (unsigned int )((u8 )tmp___0) - 1U;
     } else {
       len = 1U;
@@ -4767,7 +4767,7 @@ static int si4713_set_rds_radio_text(struct si4713_device *sdev , char *rt )
     goto unlock;
   } else {
   }
-  tmp = strlen((char const *)rt);
+  tmp = ldv_strlen((char const *)rt);
   if (tmp == 0UL) {
     goto copy;
   } else {
@@ -4953,7 +4953,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   ps_name[len] = 0;
-  tmp___0 = strlen((char const *)(& ps_name));
+  tmp___0 = ldv_strlen((char const *)(& ps_name));
   if (tmp___0 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -4977,7 +4977,7 @@ static int si4713_write_econtrol_string(struct si4713_device *sdev , struct v4l2
   } else {
   }
   radio_text[len] = 0;
-  tmp___2 = strlen((char const *)(& radio_text));
+  tmp___2 = ldv_strlen((char const *)(& radio_text));
   if (tmp___2 % (size_t )vqc.step != 0UL) {
     rval = -34;
     goto exit;
@@ -5346,14 +5346,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   rval = 0;
   switch (control->id) {
   case 10160389U:
-  tmp = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   if (tmp + 1UL > (size_t )control->size) {
     control->size = 97U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___0 = strlen((char const *)(& sdev->rds_info.ps_name));
+  tmp___0 = ldv_strlen((char const *)(& sdev->rds_info.ps_name));
   rval = copy_to_user((void *)control->__annonCompField45.string, (void const *)(& sdev->rds_info.ps_name),
                       (unsigned int )tmp___0 + 1U);
   if (rval != 0) {
@@ -5362,14 +5362,14 @@ static int si4713_read_econtrol_string(struct si4713_device *sdev , struct v4l2_
   }
   goto ldv_25932;
   case 10160390U:
-  tmp___1 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___1 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   if (tmp___1 + 1UL > (size_t )control->size) {
     control->size = 385U;
     rval = -28;
     goto exit;
   } else {
   }
-  tmp___2 = strlen((char const *)(& sdev->rds_info.radio_text));
+  tmp___2 = ldv_strlen((char const *)(& sdev->rds_info.radio_text));
   rval = copy_to_user((void *)control->__annonCompField45.string, (void const *)(& sdev->rds_info.radio_text),
                       (unsigned int )tmp___2 + 1U);
   if (rval != 0) {
@@ -6570,7 +6570,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const *str )
+size_t ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -5553,7 +5553,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const   *from
   return (tmp);
 }
 }
-size_t strlen(char const   *str ) ;
+size_t ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void) 
 { 
@@ -5565,7 +5565,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const   *str ) 
+size_t ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-42f9f8d-1-111_1a-sound--oss--opl3.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -5354,7 +5354,7 @@ __inline static unsigned long ldv_copy_from_user_7(void *to , void const *from ,
   return (tmp);
 }
 }
-size_t strlen(char const *str ) ;
+size_t ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void)
 {
@@ -5364,7 +5364,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const *str )
+size_t ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -13953,7 +13953,7 @@ void ldv_pci_unregister_driver_27(struct pci_driver *ldv_func_arg1 )
   return;
 }
 }
-size_t strlen(char const   *str ) ;
+size_t ldv_strlen(char const   *str ) ;
 __kernel_size_t strnlen(char const   *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void) 
 { 
@@ -13965,7 +13965,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const   *str ) 
+size_t ldv_strlen(char const   *str ) 
 { 
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-5934df9-1-111_1a-drivers--scsi--gdth.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -13136,7 +13136,7 @@ void ldv_pci_unregister_driver_27(struct pci_driver *ldv_func_arg1 )
   return;
 }
 }
-size_t strlen(char const *str ) ;
+size_t ldv_strlen(char const *str ) ;
 __kernel_size_t strnlen(char const *s , __kernel_size_t count ) ;
 __inline static void ldv_error(void)
 {
@@ -13146,7 +13146,7 @@ __inline static void ldv_error(void)
 }
 }
 void ldv_check_ret_val(int res ) ;
-size_t strlen(char const *str )
+size_t ldv_strlen(char const *str )
 {
   size_t res ;
   int tmp ;

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.c
@@ -5338,7 +5338,7 @@ int select_input(struct usb_device *p , int input , int mode ) ;
 int read_saa(struct usb_device *p , u16 reg0 ) ;
 int start_100(struct usb_device *p ) ;
 int stop_100(struct usb_device *p ) ;
-char const   *strerror(int err ) ;
+char const   *ldv_strerror(int err ) ;
 int easycap_debug  ;
 bool easycap_readback  ;
 struct easycap_standard  const  easycap_standard[21U] ;
@@ -5354,7 +5354,7 @@ static int reset(struct easycap *peasycap ) ;
 static int field2frame(struct easycap *peasycap ) ;
 static int redaub(struct easycap *peasycap , void *pad , void *pex , int much , int more ,
                   u8 mask , u8 margin , bool isuy ) ;
-char const   *strerror(int err ) 
+char const   *ldv_strerror(int err ) 
 { 
 
 
@@ -6141,7 +6141,7 @@ int easycap_video_submit_urbs(struct easycap *peasycap )
       rc = ldv_usb_submit_urb_2(purb, 208U);
       if (rc != 0) {
         isbad = isbad + 1;
-        tmp___0 = strerror(rc);
+        tmp___0 = ldv_strerror(rc);
         printk("<7>easycap::%i%s: OLD_ERROR: usb_submit_urb() failed for urb with rc:-%s\n",
                peasycap->isdongle, "easycap_video_submit_urbs", tmp___0);
         if (rc == -28) {
@@ -8934,7 +8934,7 @@ static void easycap_complete(struct urb *purb )
     if (peasycap->video_isoc_streaming != 0) {
       rc = ldv_usb_submit_urb_5(purb, 32U);
       if (rc != 0) {
-        tmp = strerror(rc);
+        tmp = ldv_strerror(rc);
         printk("<7>easycap::%i%s: %s:%d ENOMEM\n", peasycap->isdongle, "easycap_complete",
                tmp, rc);
         if (rc != -19) {
@@ -8974,7 +8974,7 @@ static void easycap_complete(struct urb *purb )
 
     }
     peasycap->field_buffer[peasycap->field_fill][0].kount = (u16 )((unsigned int )peasycap->field_buffer[peasycap->field_fill][0].kount | 32768U);
-    tmp___0 = strerror(purb->status);
+    tmp___0 = ldv_strerror(purb->status);
     printk("<7>easycap::%i%s: OLD_ERROR: bad urb status -%s: %d\n", peasycap->isdongle,
            "easycap_complete", tmp___0, purb->status);
   } else {
@@ -8983,7 +8983,7 @@ static void easycap_complete(struct urb *purb )
     ldv_33365: ;
     if (purb->iso_frame_desc[i].status != 0) {
       peasycap->field_buffer[peasycap->field_fill][0].kount = (u16 )((unsigned int )peasycap->field_buffer[peasycap->field_fill][0].kount | 32768U);
-      tmp___1 = strerror(purb->iso_frame_desc[i].status);
+      tmp___1 = ldv_strerror(purb->iso_frame_desc[i].status);
       strcpy((char *)(& errbuf), tmp___1);
     } else {
 
@@ -9250,7 +9250,7 @@ static void easycap_complete(struct urb *purb )
   if (peasycap->video_isoc_streaming != 0) {
     rc = ldv_usb_submit_urb_6(purb, 32U);
     if (rc != 0) {
-      tmp___3 = strerror(rc);
+      tmp___3 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: %s: %d\n", peasycap->isdongle, "easycap_complete",
              tmp___3, rc);
       if (rc != -19) {
@@ -17674,7 +17674,7 @@ static int easycap_audio_submit_urbs(struct easycap *peasycap )
     rc = ldv_usb_submit_urb_23(purb, 208U);
     if (rc != 0) {
       isbad = isbad + 1;
-      tmp___0 = strerror(rc);
+      tmp___0 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: OLD_ERROR: usb_submit_urb() failed for urb with rc: -%s: %d\n",
              peasycap->isdongle, "easycap_audio_submit_urbs", tmp___0, rc);
     } else {
@@ -17881,7 +17881,7 @@ void easycap_alsa_complete(struct urb *purb )
     } else {
 
     }
-    tmp___0 = strerror(purb->status);
+    tmp___0 = ldv_strerror(purb->status);
     printk("<7>easycap::%i%s: OLD_ERROR: non-zero urb status: -%s: %d\n", peasycap->isdongle,
            "easycap_alsa_complete", tmp___0, purb->status);
     goto resubmit;
@@ -17893,7 +17893,7 @@ void easycap_alsa_complete(struct urb *purb )
   goto ldv_32588;
   ldv_32587: ;
   if (purb->iso_frame_desc[i].status < 0) {
-    tmp___1 = strerror(purb->iso_frame_desc[i].status);
+    tmp___1 = ldv_strerror(purb->iso_frame_desc[i].status);
     printk("<7>easycap::%i%s: -%s: %d\n", peasycap->isdongle, "easycap_alsa_complete",
            tmp___1, purb->iso_frame_desc[i].status);
   } else {
@@ -18075,7 +18075,7 @@ void easycap_alsa_complete(struct urb *purb )
   rc = ldv_usb_submit_urb_24(purb, 32U);
   if (rc != 0) {
     if (rc != -19 && rc != -2) {
-      tmp___2 = strerror(rc);
+      tmp___2 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: OLD_ERROR: while %i=audio_idle, usb_submit_urb failed with rc: -%s :%d\n",
              peasycap->isdongle, "easycap_alsa_complete", peasycap->audio_idle, tmp___2,
              rc);

--- a/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
+++ b/c/ldv-validator-v0.8/linux-stable-8817633-1-144_2a-drivers--staging--media--easycap--easycap.ko-entry_point_ldv-val-v0.8.cil.out.i
@@ -5288,7 +5288,7 @@ int select_input(struct usb_device *p , int input , int mode ) ;
 int read_saa(struct usb_device *p , u16 reg0 ) ;
 int start_100(struct usb_device *p ) ;
 int stop_100(struct usb_device *p ) ;
-char const *strerror(int err ) ;
+char const *ldv_strerror(int err ) ;
 int easycap_debug ;
 bool easycap_readback ;
 struct easycap_standard const easycap_standard[21U] ;
@@ -5304,7 +5304,7 @@ static int reset(struct easycap *peasycap ) ;
 static int field2frame(struct easycap *peasycap ) ;
 static int redaub(struct easycap *peasycap , void *pad , void *pex , int much , int more ,
                   u8 mask , u8 margin , bool isuy ) ;
-char const *strerror(int err )
+char const *ldv_strerror(int err )
 {
   {
   switch (err) {
@@ -6004,7 +6004,7 @@ int easycap_video_submit_urbs(struct easycap *peasycap )
       rc = ldv_usb_submit_urb_2(purb, 208U);
       if (rc != 0) {
         isbad = isbad + 1;
-        tmp___0 = strerror(rc);
+        tmp___0 = ldv_strerror(rc);
         printk("<7>easycap::%i%s: OLD_ERROR: usb_submit_urb() failed for urb with rc:-%s\n",
                peasycap->isdongle, "easycap_video_submit_urbs", tmp___0);
         if (rc == -28) {
@@ -8513,7 +8513,7 @@ static void easycap_complete(struct urb *purb )
     if (peasycap->video_isoc_streaming != 0) {
       rc = ldv_usb_submit_urb_5(purb, 32U);
       if (rc != 0) {
-        tmp = strerror(rc);
+        tmp = ldv_strerror(rc);
         printk("<7>easycap::%i%s: %s:%d ENOMEM\n", peasycap->isdongle, "easycap_complete",
                tmp, rc);
         if (rc != -19) {
@@ -8546,7 +8546,7 @@ static void easycap_complete(struct urb *purb )
     } else {
     }
     peasycap->field_buffer[peasycap->field_fill][0].kount = (u16 )((unsigned int )peasycap->field_buffer[peasycap->field_fill][0].kount | 32768U);
-    tmp___0 = strerror(purb->status);
+    tmp___0 = ldv_strerror(purb->status);
     printk("<7>easycap::%i%s: OLD_ERROR: bad urb status -%s: %d\n", peasycap->isdongle,
            "easycap_complete", tmp___0, purb->status);
   } else {
@@ -8555,7 +8555,7 @@ static void easycap_complete(struct urb *purb )
     ldv_33365: ;
     if (purb->iso_frame_desc[i].status != 0) {
       peasycap->field_buffer[peasycap->field_fill][0].kount = (u16 )((unsigned int )peasycap->field_buffer[peasycap->field_fill][0].kount | 32768U);
-      tmp___1 = strerror(purb->iso_frame_desc[i].status);
+      tmp___1 = ldv_strerror(purb->iso_frame_desc[i].status);
       strcpy((char *)(& errbuf), tmp___1);
     } else {
     }
@@ -8786,7 +8786,7 @@ static void easycap_complete(struct urb *purb )
   if (peasycap->video_isoc_streaming != 0) {
     rc = ldv_usb_submit_urb_6(purb, 32U);
     if (rc != 0) {
-      tmp___3 = strerror(rc);
+      tmp___3 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: %s: %d\n", peasycap->isdongle, "easycap_complete",
              tmp___3, rc);
       if (rc != -19) {
@@ -16272,7 +16272,7 @@ static int easycap_audio_submit_urbs(struct easycap *peasycap )
     rc = ldv_usb_submit_urb_23(purb, 208U);
     if (rc != 0) {
       isbad = isbad + 1;
-      tmp___0 = strerror(rc);
+      tmp___0 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: OLD_ERROR: usb_submit_urb() failed for urb with rc: -%s: %d\n",
              peasycap->isdongle, "easycap_audio_submit_urbs", tmp___0, rc);
     } else {
@@ -16452,7 +16452,7 @@ void easycap_alsa_complete(struct urb *purb )
       return;
     } else {
     }
-    tmp___0 = strerror(purb->status);
+    tmp___0 = ldv_strerror(purb->status);
     printk("<7>easycap::%i%s: OLD_ERROR: non-zero urb status: -%s: %d\n", peasycap->isdongle,
            "easycap_alsa_complete", tmp___0, purb->status);
     goto resubmit;
@@ -16463,7 +16463,7 @@ void easycap_alsa_complete(struct urb *purb )
   goto ldv_32588;
   ldv_32587: ;
   if (purb->iso_frame_desc[i].status < 0) {
-    tmp___1 = strerror(purb->iso_frame_desc[i].status);
+    tmp___1 = ldv_strerror(purb->iso_frame_desc[i].status);
     printk("<7>easycap::%i%s: -%s: %d\n", peasycap->isdongle, "easycap_alsa_complete",
            tmp___1, purb->iso_frame_desc[i].status);
   } else {
@@ -16619,7 +16619,7 @@ void easycap_alsa_complete(struct urb *purb )
   rc = ldv_usb_submit_urb_24(purb, 32U);
   if (rc != 0) {
     if (rc != -19 && rc != -2) {
-      tmp___2 = strerror(rc);
+      tmp___2 = ldv_strerror(rc);
       printk("<7>easycap::%i%s: OLD_ERROR: while %i=audio_idle, usb_submit_urb failed with rc: -%s :%d\n",
              peasycap->isdongle, "easycap_alsa_complete", peasycap->audio_idle, tmp___2,
              rc);


### PR DESCRIPTION
Several benchmarks provide custom definitions for these functions,
which causes name clashes with standard definitions. This commit
fixed that by renaming them by prefixing them with ldv_.
