### PR TITLE
busybox: initialize a variable in getlogin_r model

### DIFF
--- a/c/busybox-1.22.0/busybox_sv_comp-getlogin_r.h
+++ b/c/busybox-1.22.0/busybox_sv_comp-getlogin_r.h
@@ -12,7 +12,7 @@ int getlogin_r(char *buf, size_t bufsize)
 
     int size = __VERIFIER_nondet_int();
     assume_abort_if_not(size > 0 && size < bufsize);
-    for (int i; i < size; ++i) {
+    for (int i = 0; i < size; ++i) {
         buf[i] = __VERIFIER_nondet_char();
     }
     buf[size] = '\0';

--- a/c/busybox-1.22.0/logname-1.i
+++ b/c/busybox-1.22.0/logname-1.i
@@ -2412,7 +2412,7 @@ int getlogin_r(char *buf, size_t bufsize)
     }
     int size = __VERIFIER_nondet_int();
     assume_abort_if_not(size > 0 && size < bufsize);
-    for (int i; i < size; ++i) {
+    for (int i = 0; i < size; ++i) {
         buf[i] = __VERIFIER_nondet_char();
     }
     buf[size] = '\0';

--- a/c/busybox-1.22.0/logname-2.i
+++ b/c/busybox-1.22.0/logname-2.i
@@ -2412,7 +2412,7 @@ int getlogin_r(char *buf, size_t bufsize)
     }
     int size = __VERIFIER_nondet_int();
     assume_abort_if_not(size > 0 && size < bufsize);
-    for (int i; i < size; ++i) {
+    for (int i = 0; i < size; ++i) {
         buf[i] = __VERIFIER_nondet_char();
     }
     buf[size] = '\0';


### PR DESCRIPTION
getlogin_r model in busybox benchmarks uses an uninitialized loop counter which leads to undefined behavior. This PR fixes the model and files where it is used.
