### PR TITLE
Fix labelling of uthash tasks with property violation memtrack

### DIFF
--- a/c/uthash-2.0.2/uthash_BER_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_BER_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_BER_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_FNV_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_FNV_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_JEN_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_JEN_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_OAT_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_OAT_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SAX_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_SAX_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test1-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test1-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test10-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test10-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test2-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test2-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test3-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test3-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test4-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test4-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test5-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test5-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test8-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test8-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 

--- a/c/uthash-2.0.2/uthash_SFH_test9-1.yml
+++ b/c/uthash-2.0.2/uthash_SFH_test9-1.yml
@@ -10,7 +10,8 @@ properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-memtrack
   - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 


### PR DESCRIPTION
Some tasks in the uthash directory seem to contain property violation for memtrack.

Behaviour: After allocating 10 users, the main function is exited without proper cleanup.

All tasks of uthash are similar. However, some of them free the users as a last step and some do not.
