### PR TITLE
change labelling for some Juliet tasks.

### DIFF
--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_b
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_b
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_b
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_b
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
 
 options:

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_bad.i
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_bad.i
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_bad.i
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_bad.i
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_bad.
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_bad.
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruc
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_callo
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_callo
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_mallo
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_mallo
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_reall
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_bad.yml
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_bad.yml
@@ -4,6 +4,8 @@ input_files: 'CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_reall
 
 properties:
   - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: true
+  - property_file: ../properties/valid-memcleanup.prp
     expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 


### PR DESCRIPTION
Those tasks all contain the same behaviour:
They allocate some memory and store a reference to it
in a global static variable `CWE401_Memory_Leak__TASKNAME_badData`
that is never freed and remains reachable beyond the exit of the main function.

Found by CPAchecker (SMG analysis).