### PR TITLE
nla-digibench: fix function declaration

### DIFF
--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound1.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound1.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound10.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound10.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound100.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound100.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound2.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound2.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound20.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound20.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound5.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound5.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_unwindbound50.c
+++ b/c/nla-digbench-scaling/cohencu-ll_unwindbound50.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,7 +23,7 @@ int counter = 0;
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound1.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound1.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=1);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound10.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound10.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=10);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound100.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound100.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=100);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound2.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound2.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=2);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound20.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound20.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=20);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound5.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound5.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=5);
 
     n = 0;

--- a/c/nla-digbench-scaling/cohencu-ll_valuebound50.c
+++ b/c/nla-digbench-scaling/cohencu-ll_valuebound50.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
     assume_abort_if_not(a>=0 && a<=50);
 
     n = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound1.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound1.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound10.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound10.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound100.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound100.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound2.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound2.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound20.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound20.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound5.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound5.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_unwindbound50.c
+++ b/c/nla-digbench-scaling/dijkstra-u_unwindbound50.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,7 +20,7 @@ int counter = 0;
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound1.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound1.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=1);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound10.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound10.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=10);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound100.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound100.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=100);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound2.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound2.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=2);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound20.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound20.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=20);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound5.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound5.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=5);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/dijkstra-u_valuebound50.c
+++ b/c/nla-digbench-scaling/dijkstra-u_valuebound50.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=50);
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 

--- a/c/nla-digbench-scaling/divbin2_unwindbound1.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound1.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound1.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound10.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound10.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound10.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound100.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound100.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound100.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound2.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound2.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound2.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound20.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound20.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound20.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound5.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound5.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound5.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_unwindbound50.c
+++ b/c/nla-digbench-scaling/divbin2_unwindbound50.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_unwindbound50.i
+++ b/c/nla-digbench-scaling/divbin2_unwindbound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,7 +26,7 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench-scaling/divbin2_valuebound1.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound1.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound1.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound10.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound10.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound10.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound100.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound100.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound100.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound2.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound2.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound2.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound20.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound20.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound20.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound5.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound5.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound5.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin2_valuebound50.c
+++ b/c/nla-digbench-scaling/divbin2_valuebound50.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
     B = 1;
 

--- a/c/nla-digbench-scaling/divbin2_valuebound50.i
+++ b/c/nla-digbench-scaling/divbin2_valuebound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
     B = 1;
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound1.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound1.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound1.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound10.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound10.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound100.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound100.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound2.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound2.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound2.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound20.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound20.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound5.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound5.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound5.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_unwindbound50.c
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/divbin_unwindbound50.i
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ int counter = 0;
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench-scaling/divbin_valuebound1.c
+++ b/c/nla-digbench-scaling/divbin_valuebound1.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=1);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound1.i
+++ b/c/nla-digbench-scaling/divbin_valuebound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=1);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound10.c
+++ b/c/nla-digbench-scaling/divbin_valuebound10.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=10);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound10.i
+++ b/c/nla-digbench-scaling/divbin_valuebound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=10);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound100.c
+++ b/c/nla-digbench-scaling/divbin_valuebound100.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=100);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound100.i
+++ b/c/nla-digbench-scaling/divbin_valuebound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=100);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound2.c
+++ b/c/nla-digbench-scaling/divbin_valuebound2.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=2);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound2.i
+++ b/c/nla-digbench-scaling/divbin_valuebound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=2);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound20.c
+++ b/c/nla-digbench-scaling/divbin_valuebound20.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=20);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound20.i
+++ b/c/nla-digbench-scaling/divbin_valuebound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=20);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound5.c
+++ b/c/nla-digbench-scaling/divbin_valuebound5.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=5);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound5.i
+++ b/c/nla-digbench-scaling/divbin_valuebound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=5);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound50.c
+++ b/c/nla-digbench-scaling/divbin_valuebound50.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,9 +24,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=50);
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/divbin_valuebound50.i
+++ b/c/nla-digbench-scaling/divbin_valuebound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,9 +25,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=50);
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);

--- a/c/nla-digbench-scaling/geo1-u_unwindbound1.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound1.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound10.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound10.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound100.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound100.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound2.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound2.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound20.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound20.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound5.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound5.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_unwindbound50.c
+++ b/c/nla-digbench-scaling/geo1-u_unwindbound50.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench-scaling/geo1-u_valuebound1.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound1.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=1);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=1);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound10.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound10.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=10);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=10);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound100.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound100.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=100);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=100);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound2.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound2.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=2);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=2);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound20.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound20.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=20);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=20);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound5.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound5.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=5);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=5);
 
     x = 1;

--- a/c/nla-digbench-scaling/geo1-u_valuebound50.c
+++ b/c/nla-digbench-scaling/geo1-u_valuebound50.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
     assume_abort_if_not(z>=0 && z<=50);
-    k = __VERIFIER_nondet_unsigned_int();
+    k = __VERIFIER_nondet_uint();
     assume_abort_if_not(k>=0 && k<=50);
 
     x = 1;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound1.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound10.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound100.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound2.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound20.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound5.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_unwindbound50.c
+++ b/c/nla-digbench-scaling/hard-ll_unwindbound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-ll_valuebound1.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=1);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound10.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=10);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound100.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=100);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound2.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound20.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=20);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound5.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=5);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-ll_valuebound50.c
+++ b/c/nla-digbench-scaling/hard-ll_valuebound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=50);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_unwindbound1.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound10.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound100.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound2.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound20.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound5.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_unwindbound50.c
+++ b/c/nla-digbench-scaling/hard-u_unwindbound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench-scaling/hard-u_valuebound1.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=1);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=1);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound10.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=10);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=10);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound100.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=100);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=100);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound2.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=2);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound20.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=20);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=20);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound5.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=5);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=5);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/hard-u_valuebound50.c
+++ b/c/nla-digbench-scaling/hard-u_valuebound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     assume_abort_if_not(A>=0 && A<=50);
-    B = __VERIFIER_nondet_unsigned_int();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B>=0 && B<=50);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound1.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound1.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound1.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound10.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound10.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound10.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound100.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound100.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound100.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound2.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound2.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound2.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound20.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound20.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound20.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound5.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound5.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound5.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_unwindbound50.c
+++ b/c/nla-digbench-scaling/knuth_unwindbound50.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench-scaling/knuth_unwindbound50.i
+++ b/c/nla-digbench-scaling/knuth_unwindbound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -27,8 +27,8 @@ int counter = 0;
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench-scaling/knuth_valuebound1.c
+++ b/c/nla-digbench-scaling/knuth_valuebound1.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=1);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=1);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound1.i
+++ b/c/nla-digbench-scaling/knuth_valuebound1.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=1);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=1);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound10.c
+++ b/c/nla-digbench-scaling/knuth_valuebound10.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=10);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=10);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound10.i
+++ b/c/nla-digbench-scaling/knuth_valuebound10.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=10);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=10);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound100.c
+++ b/c/nla-digbench-scaling/knuth_valuebound100.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=100);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=100);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound100.i
+++ b/c/nla-digbench-scaling/knuth_valuebound100.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=100);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=100);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound2.c
+++ b/c/nla-digbench-scaling/knuth_valuebound2.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=2);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=2);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound2.i
+++ b/c/nla-digbench-scaling/knuth_valuebound2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=2);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=2);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound20.c
+++ b/c/nla-digbench-scaling/knuth_valuebound20.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=20);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=20);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound20.i
+++ b/c/nla-digbench-scaling/knuth_valuebound20.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=20);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=20);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound5.c
+++ b/c/nla-digbench-scaling/knuth_valuebound5.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=5);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=5);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound5.i
+++ b/c/nla-digbench-scaling/knuth_valuebound5.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=5);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=5);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound50.c
+++ b/c/nla-digbench-scaling/knuth_valuebound50.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,9 +23,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=50);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=50);
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/knuth_valuebound50.i
+++ b/c/nla-digbench-scaling/knuth_valuebound50.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,9 +26,9 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n>=0 && n<=50);
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=50);
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);

--- a/c/nla-digbench-scaling/lcm1_unwindbound1.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound10.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound100.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound2.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound20.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound5.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_unwindbound50.c
+++ b/c/nla-digbench-scaling/lcm1_unwindbound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm1_valuebound1.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=1);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=1);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound10.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound10.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=10);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=10);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound100.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound100.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=100);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=100);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound2.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound2.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=2);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=2);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound20.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound20.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=20);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=20);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound5.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound5.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=5);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=5);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm1_valuebound50.c
+++ b/c/nla-digbench-scaling/lcm1_valuebound50.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,9 +22,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=50);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=50);
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_unwindbound1.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound1.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound10.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound10.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound100.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound100.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound2.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound2.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound20.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound20.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound5.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound5.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_unwindbound50.c
+++ b/c/nla-digbench-scaling/lcm2_unwindbound50.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -20,8 +20,8 @@ int counter = 0;
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench-scaling/lcm2_valuebound1.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound1.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=1);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=1);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound10.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound10.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=10);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=10);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound100.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound100.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=100);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=100);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound2.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound2.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=2);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=2);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound20.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound20.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=20);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=20);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound5.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound5.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=5);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=5);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench-scaling/lcm2_valuebound50.c
+++ b/c/nla-digbench-scaling/lcm2_valuebound50.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,9 +19,9 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(a>=0 && a<=50);
-    b = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(b>=0 && b<=50);
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);

--- a/c/nla-digbench/cohencu-ll.c
+++ b/c/nla-digbench/cohencu-ll.c
@@ -6,7 +6,7 @@ http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "cohencu-ll.c", 8, "reach_error"); }
-extern unsigned short __VERIFIER_nondet_unsigned_short(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,7 +22,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     short a;
     long long n, x, y, z;
-    a = __VERIFIER_nondet_unsigned_short();
+    a = __VERIFIER_nondet_ushort();
 
     n = 0;
     x = 0;

--- a/c/nla-digbench/dijkstra-u.c
+++ b/c/nla-digbench/dijkstra-u.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "dijkstra-u.c", 5, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,7 +19,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int n, p, q, r, h;
 
-    n = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < 4294967295 / 4);  // Avoid non-terminating loop
 
     p = 0;

--- a/c/nla-digbench/divbin.c
+++ b/c/nla-digbench/divbin.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,8 +24,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < UINT_MAX/2);
     assume_abort_if_not(B >= 1);
 

--- a/c/nla-digbench/divbin.i
+++ b/c/nla-digbench/divbin.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,8 +25,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B < (0x7fffffff * 2U + 1U)/2);
     assume_abort_if_not(B >= 1);
     q = 0;

--- a/c/nla-digbench/divbin2.c
+++ b/c/nla-digbench/divbin2.c
@@ -8,7 +8,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -24,7 +24,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
 
     q = 0;

--- a/c/nla-digbench/divbin2.i
+++ b/c/nla-digbench/divbin2.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "divbin2.c", 10, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -25,7 +25,7 @@ void __VERIFIER_assert(int cond) {
 int main() {
   unsigned A, B;
   unsigned q, r, b;
-    A = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
     B = 1;
     q = 0;
     r = A;

--- a/c/nla-digbench/geo1-u.c
+++ b/c/nla-digbench/geo1-u.c
@@ -7,7 +7,7 @@ returns 1+x-y == 0
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "geo1-u.c", 9, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,8 +22,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int z, k;
     long long x, y, c;
-    z = __VERIFIER_nondet_unsigned_int();
-    k = __VERIFIER_nondet_unsigned_int();
+    z = __VERIFIER_nondet_uint();
+    k = __VERIFIER_nondet_uint();
 
     x = 1;
     y = z;

--- a/c/nla-digbench/hard-ll.c
+++ b/c/nla-digbench/hard-ll.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-ll.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,8 +22,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     long long r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench/hard-u.c
+++ b/c/nla-digbench/hard-u.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "hard-u.c", 8, "reach_error"); }
-extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,8 +22,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned int A, B;
     unsigned int r, d, p, q;
-    A = __VERIFIER_nondet_unsigned_int();
-    B = __VERIFIER_nondet_unsigned_int();
+    A = __VERIFIER_nondet_uint();
+    B = __VERIFIER_nondet_uint();
     assume_abort_if_not(B >= 1);
 
     r = A;

--- a/c/nla-digbench/knuth.c
+++ b/c/nla-digbench/knuth.c
@@ -5,7 +5,7 @@
 extern void abort(void);
 #include <assert.h>
 void reach_error() { assert(0); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -23,8 +23,8 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < UINT_MAX/8);
     assume_abort_if_not(a > 2);
 

--- a/c/nla-digbench/knuth.i
+++ b/c/nla-digbench/knuth.i
@@ -10,7 +10,7 @@ extern void __assert (const char *__assertion, const char *__file, int __line)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "knuth.c", 7, __extension__ __PRETTY_FUNCTION__); })); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -26,8 +26,8 @@ extern double sqrt(double);
 int main() {
     unsigned n, a;
     unsigned r, k, q, d, s, t;
-    n = __VERIFIER_nondet_unsigned_int();
-    a = __VERIFIER_nondet_unsigned_int();
+    n = __VERIFIER_nondet_uint();
+    a = __VERIFIER_nondet_uint();
     assume_abort_if_not(n < (0x7fffffff * 2U + 1U)/8);
     assume_abort_if_not(a > 2);
     d = a;

--- a/c/nla-digbench/lcm1.c
+++ b/c/nla-digbench/lcm1.c
@@ -6,7 +6,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm1.c", 8, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -22,8 +22,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1);  //infinite loop if remove
     assume_abort_if_not(b >= 1);
 

--- a/c/nla-digbench/lcm2.c
+++ b/c/nla-digbench/lcm2.c
@@ -3,7 +3,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "lcm2.c", 5, "reach_error"); }
-extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern unsigned __VERIFIER_nondet_uint(void);
 extern void abort(void);
 void assume_abort_if_not(int cond) {
   if(!cond) {abort();}
@@ -19,8 +19,8 @@ void __VERIFIER_assert(int cond) {
 int main() {
     unsigned a, b;
     unsigned x, y, u, v;
-    a = __VERIFIER_nondet_unsigned_int();
-    b = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_uint();
+    b = __VERIFIER_nondet_uint();
     assume_abort_if_not(a >= 1); //inf loop if remove
     assume_abort_if_not(b >= 1);
 


### PR DESCRIPTION
The benchmarks used `__VERIFIER_nondet_unsigend_int`, but the rules define either `__VERIFIER_nondet_unsigned` or `__VERIFIER_nondet_uint`. Change to the latter.
