### PR TITLE
Fix verdicts for bounded divbin tasks

### DIFF
--- a/c/nla-digbench-scaling/divbin_unwindbound10.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound10.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
 

--- a/c/nla-digbench-scaling/divbin_unwindbound100.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound100.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
 

--- a/c/nla-digbench-scaling/divbin_unwindbound20.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound20.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
 

--- a/c/nla-digbench-scaling/divbin_unwindbound50.yml
+++ b/c/nla-digbench-scaling/divbin_unwindbound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'divbin_unwindbound50.i'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
 

--- a/c/nla-digbench-scaling/generate.py
+++ b/c/nla-digbench-scaling/generate.py
@@ -82,6 +82,7 @@ broken_by_unwindbound = [
         "ps4",
         "ps5",
         "ps6",
+        "divbin",      # only with bound >=10
         "dijkstra-u",  # only with bound >=5
         "fermat1-ll",  # CEX e.g. with A=11; R=4;
         "fermat2-ll",  # CEX e.g. with A=11; R=4;
@@ -92,6 +93,7 @@ broken_by_unwindbound = [
 ]
 broken_by_unwindbound_ge = {}
 broken_by_unwindbound_ge[p("dijkstra-u")] = 5
+broken_by_unwindbound_ge[p("divbin")] = 10
 
 REACH = "../properties/unreach-call.prp\n    expected_verdict: "
 skiplist = []


### PR DESCRIPTION
This fixes issue #1238 by updating the task generation script.

We do not add "fixed" versions of the tasks since these are derived, bounded versions of the tasks in `nla-digbench`.  
There are already bounded versions of this task anyway where the verdict is `true(unreach-call)` (plus the original unbounded version in `nla-digbench`), so this should be covered.

Thanks to @mchalupa for finding this issue.