### PR TITLE
seq-* benchmarks: Remove use of function without definition

### DIFF
--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.BOUNDED-10.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.1.ufo.UNBOUNDED.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.BOUNDED-10.pals.c
@@ -410,7 +410,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_1.ufo.UNBOUNDED.pals.c
@@ -410,7 +410,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.BOUNDED-10.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.4_2.ufo.UNBOUNDED.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.BOUNDED-10.pals.c
@@ -414,7 +414,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.5.ufo.UNBOUNDED.pals.c
@@ -414,7 +414,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.BOUNDED-10.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_ActiveStandby.ufo.UNBOUNDED.pals.c
@@ -418,7 +418,6 @@ void Pendulum_prism_task_each_pals_period(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & Console_task_each_pals_period,      & Side1_activestandby_task_each_pals_period,      & Side2_activestandby_task_each_pals_period,      & Pendulum_prism_task_each_pals_period};
 int check(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.BOUNDED-10.pals.c
@@ -471,7 +471,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.1.ufo.UNBOUNDED.pals.c
@@ -474,7 +474,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.BOUNDED-10.pals.c
@@ -467,7 +467,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.2.ufo.UNBOUNDED.pals.c
@@ -470,7 +470,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.BOUNDED-10.pals.c
@@ -475,7 +475,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_STARTPALS_Triplicated.ufo.UNBOUNDED.pals.c
@@ -478,7 +478,6 @@ void voter(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & gate1_each_pals_period,      & gate2_each_pals_period,      & gate3_each_pals_period,      & voter};
 int main(void) 
 { 
   int c1 ;

--- a/c/seq-mthreaded/pals_floodmax.3.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.1.ufo.BOUNDED-6.pals.c
@@ -196,7 +196,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.1.ufo.UNBOUNDED.pals.c
@@ -209,7 +209,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.BOUNDED-6.pals.c
@@ -196,7 +196,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.2.ufo.UNBOUNDED.pals.c
@@ -206,7 +206,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.3.ufo.BOUNDED-6.pals.c
@@ -196,7 +196,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.3.ufo.UNBOUNDED.pals.c
@@ -209,7 +209,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.4.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.4.ufo.BOUNDED-6.pals.c
@@ -196,7 +196,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.4.ufo.UNBOUNDED.pals.c
@@ -209,7 +209,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.ufo.BOUNDED-6.pals.c
@@ -196,7 +196,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3.ufo.UNBOUNDED.pals.c
@@ -209,7 +209,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.3_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_overflow.ufo.UNBOUNDED.pals.c
@@ -200,7 +200,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.1.ufo.BOUNDED-8.pals.c
@@ -313,7 +313,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.1.ufo.UNBOUNDED.pals.c
@@ -326,7 +326,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.2.ufo.BOUNDED-8.pals.c
@@ -313,7 +313,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.c
@@ -326,7 +326,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.3.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.3.ufo.BOUNDED-8.pals.c
@@ -313,7 +313,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.c
@@ -326,7 +326,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.4.ufo.BOUNDED-8.pals.c
@@ -313,7 +313,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.4.ufo.UNBOUNDED.pals.c
@@ -326,7 +326,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.ufo.BOUNDED-8.pals.c
@@ -313,7 +313,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4.ufo.UNBOUNDED.pals.c
@@ -326,7 +326,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.c
@@ -314,7 +314,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.1.ufo.BOUNDED-10.pals.c
@@ -455,8 +455,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.1.ufo.UNBOUNDED.pals.c
@@ -471,8 +471,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.2.ufo.BOUNDED-10.pals.c
@@ -455,8 +455,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.c
@@ -471,8 +471,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.3.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.3.ufo.BOUNDED-10.pals.c
@@ -455,8 +455,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.3.ufo.UNBOUNDED.pals.c
@@ -471,8 +471,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.4.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.4.ufo.BOUNDED-10.pals.c
@@ -455,8 +455,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.4.ufo.UNBOUNDED.pals.c
@@ -471,8 +471,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.ufo.BOUNDED-10.pals.c
@@ -455,8 +455,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5.ufo.UNBOUNDED.pals.c
@@ -471,8 +471,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.c
@@ -456,8 +456,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.BOUNDED-6.pals.c
@@ -153,7 +153,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.1.ufo.UNBOUNDED.pals.c
@@ -159,7 +159,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.BOUNDED-6.pals.c
@@ -148,7 +148,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.2.ufo.UNBOUNDED.pals.c
@@ -154,7 +154,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.BOUNDED-6.pals.c
@@ -151,7 +151,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3.ufo.UNBOUNDED.pals.c
@@ -157,7 +157,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.BOUNDED-8.pals.c
@@ -195,7 +195,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.1.ufo.UNBOUNDED.pals.c
@@ -201,7 +201,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.BOUNDED-8.pals.c
@@ -190,7 +190,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.2.ufo.UNBOUNDED.pals.c
@@ -196,7 +196,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.BOUNDED-8.pals.c
@@ -193,7 +193,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4.ufo.UNBOUNDED.pals.c
@@ -199,7 +199,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.BOUNDED-10.pals.c
@@ -240,8 +240,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.1.ufo.UNBOUNDED.pals.c
@@ -243,8 +243,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.BOUNDED-10.pals.c
@@ -235,8 +235,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.2.ufo.UNBOUNDED.pals.c
@@ -238,8 +238,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.BOUNDED-10.pals.c
@@ -238,8 +238,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5.ufo.UNBOUNDED.pals.c
@@ -241,8 +241,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.BOUNDED-12.pals.c
@@ -282,8 +282,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.1.ufo.UNBOUNDED.pals.c
@@ -285,8 +285,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.BOUNDED-12.pals.c
@@ -277,8 +277,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.2.ufo.UNBOUNDED.pals.c
@@ -280,8 +280,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.BOUNDED-12.pals.c
@@ -280,8 +280,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6.ufo.UNBOUNDED.pals.c
@@ -283,8 +283,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.3.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3.1.ufo.BOUNDED-6.pals.c
@@ -123,7 +123,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.3.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3.1.ufo.UNBOUNDED.pals.c
@@ -129,7 +129,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3.ufo.BOUNDED-6.pals.c
@@ -121,7 +121,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3.ufo.UNBOUNDED.pals.c
@@ -127,7 +127,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.3_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_overflow.ufo.UNBOUNDED.pals.c
@@ -126,7 +126,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.4.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4.1.ufo.BOUNDED-8.pals.c
@@ -155,7 +155,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.4.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4.1.ufo.UNBOUNDED.pals.c
@@ -161,7 +161,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4.ufo.BOUNDED-8.pals.c
@@ -153,7 +153,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4.ufo.UNBOUNDED.pals.c
@@ -159,7 +159,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.4_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_overflow.ufo.UNBOUNDED.pals.c
@@ -158,7 +158,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.5.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5.1.ufo.BOUNDED-10.pals.c
@@ -190,8 +190,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.5.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5.1.ufo.UNBOUNDED.pals.c
@@ -193,8 +193,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5.ufo.BOUNDED-10.pals.c
@@ -188,8 +188,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5.ufo.UNBOUNDED.pals.c
@@ -191,8 +191,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.5_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_overflow.ufo.UNBOUNDED.pals.c
@@ -190,8 +190,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.6.1.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6.1.ufo.BOUNDED-12.pals.c
@@ -222,8 +222,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.6.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6.1.ufo.UNBOUNDED.pals.c
@@ -225,8 +225,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.6.ufo.BOUNDED-12.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6.ufo.BOUNDED-12.pals.c
@@ -220,8 +220,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.6.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6.ufo.UNBOUNDED.pals.c
@@ -223,8 +223,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.c
@@ -222,8 +222,6 @@ void node6(void)
   return;
 }
 }
-void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.7.1.ufo.BOUNDED-14.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7.1.ufo.BOUNDED-14.pals.c
@@ -254,8 +254,6 @@ void node7(void)
   return;
 }
 }
-void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.7.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7.1.ufo.UNBOUNDED.pals.c
@@ -257,8 +257,6 @@ void node7(void)
   return;
 }
 }
-void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.7.ufo.BOUNDED-14.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7.ufo.BOUNDED-14.pals.c
@@ -252,8 +252,6 @@ void node7(void)
   return;
 }
 }
-void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.7.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7.ufo.UNBOUNDED.pals.c
@@ -255,8 +255,6 @@ void node7(void)
   return;
 }
 }
-void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.c
@@ -254,8 +254,6 @@ void node7(void)
   return;
 }
 }
-void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.BOUNDED-6.pals.c
@@ -223,7 +223,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.1.ufo.UNBOUNDED.pals.c
@@ -236,7 +236,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.BOUNDED-6.pals.c
@@ -226,7 +226,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.2.ufo.UNBOUNDED.pals.c
@@ -236,7 +236,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.BOUNDED-6.pals.c
@@ -226,7 +226,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.3.ufo.UNBOUNDED.pals.c
@@ -236,7 +236,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.BOUNDED-6.pals.c
@@ -226,7 +226,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.4.ufo.UNBOUNDED.pals.c
@@ -236,7 +236,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.ufo.BOUNDED-6.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.ufo.BOUNDED-6.pals.c
@@ -226,7 +226,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3.ufo.UNBOUNDED.pals.c
@@ -236,7 +236,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_overflow.ufo.UNBOUNDED.pals.c
@@ -227,7 +227,6 @@ void node3(void)
   return;
 }
 }
-void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.BOUNDED-8.pals.c
@@ -361,7 +361,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.1.ufo.UNBOUNDED.pals.c
@@ -374,7 +374,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.BOUNDED-8.pals.c
@@ -361,7 +361,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.c
@@ -374,7 +374,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.BOUNDED-8.pals.c
@@ -361,7 +361,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.c
@@ -374,7 +374,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.BOUNDED-8.pals.c
@@ -361,7 +361,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.4.ufo.UNBOUNDED.pals.c
@@ -374,7 +374,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.ufo.BOUNDED-8.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.ufo.BOUNDED-8.pals.c
@@ -361,7 +361,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.ufo.UNBOUNDED.pals.c
@@ -377,7 +377,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.c
@@ -362,7 +362,6 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.BOUNDED-10.pals.c
@@ -530,8 +530,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.1.ufo.UNBOUNDED.pals.c
@@ -546,8 +546,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.BOUNDED-10.pals.c
@@ -530,8 +530,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.c
@@ -546,8 +546,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.BOUNDED-10.pals.c
@@ -530,8 +530,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.3.ufo.UNBOUNDED.pals.c
@@ -546,8 +546,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.BOUNDED-10.pals.c
@@ -530,8 +530,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.4.ufo.UNBOUNDED.pals.c
@@ -546,8 +546,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.ufo.BOUNDED-10.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.ufo.BOUNDED-10.pals.c
@@ -530,8 +530,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.ufo.UNBOUNDED.pals.c
@@ -546,8 +546,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.c
@@ -531,8 +531,6 @@ void node5(void)
   return;
 }
 }
-void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
-        & node5};
 int init(void) 
 { 
   _Bool r121 ;


### PR DESCRIPTION
These benchmarks include a definition of a `nodes` variable that is
initialized with pointers to functions that are declared, but not
defined. This is undefined behaviour, and makes linking (and thus
running) those benchmarks impossible.

The changes were done using the following command:
```
for f in c/seq-*/*.c
do
perl -i -e \
  '$i = 0;
   while(<>) {
     if($i == 0 && /^void\s*\(\*nodes\[\d+\]\)\(void\)\s*=\s*\{/) {
       $i = 1 unless(/\}\s*;/);
       next;
     }
     elsif($i == 1) {
       $i = 0 if(/\}\s*;/);
       next;
     }
     print;
   }' $f
done
```


