### PR TITLE
MemSafety: fix labelling of three busybox benchmarks

### DIFF
--- a/c/busybox-1.22.0/mkdir-2.yml
+++ b/c/busybox-1.22.0/mkdir-2.yml
@@ -4,10 +4,9 @@ format_version: '2.0'
 input_files: 'mkdir-2.i'
 
 properties:
-  - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-deref
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/seq-1.yml
+++ b/c/busybox-1.22.0/seq-1.yml
@@ -4,10 +4,9 @@ format_version: '2.0'
 input_files: 'seq-1.i'
 
 properties:
-  - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-deref
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp
   - property_file: ../properties/coverage-statements.prp

--- a/c/busybox-1.22.0/touch-2.yml
+++ b/c/busybox-1.22.0/touch-2.yml
@@ -4,12 +4,9 @@ format_version: '2.0'
 input_files: 'touch-2.i'
 
 properties:
-  - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
-  - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
   - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
+    expected_verdict: false
+    subproperty: valid-deref
   - property_file: ../properties/coverage-error-call.prp
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp


### PR DESCRIPTION
This fixes issue #1246. I also added the C files of the relabelled benchmarks into the `todo` directory that was created in the past to keep track of benchmarks that we would like to fix in the future. However, I can remove that commit if it is not desirable.