### PR TITLE
aws-c-common: ensure allocation of sufficient size

### DIFF
--- a/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be16_harness.i
@@ -9097,8 +9097,9 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     assume_abort_if_not(aws_byte_cursor_is_valid(&cur));
-    assume_abort_if_not(cur.ptr);
-    assume_abort_if_not(((((sizeof(*(dest)))) == 0) || (((dest)))));
+    assume_abort_if_not(cur.len >= 2);
+    assume_abort_if_not(dest);
+    assume_abort_if_not(length >= 2);
 
 
     struct aws_byte_cursor old_cur = cur;

--- a/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be32_harness.i
@@ -9097,8 +9097,9 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     assume_abort_if_not(aws_byte_cursor_is_valid(&cur));
-    assume_abort_if_not(cur.ptr);
-    assume_abort_if_not(((((sizeof(*(dest)))) == 0) || (((dest)))));
+    assume_abort_if_not(cur.len >= 4);
+    assume_abort_if_not(dest);
+    assume_abort_if_not(length >= 4);
 
 
     struct aws_byte_cursor old_cur = cur;

--- a/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_be64_harness.i
@@ -9097,8 +9097,9 @@ void aws_byte_cursor_read_common_harness() {
 
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     assume_abort_if_not(aws_byte_cursor_is_valid(&cur));
-    assume_abort_if_not(cur.ptr);
-    assume_abort_if_not(((((sizeof(*(dest)))) == 0) || (((dest)))));
+    assume_abort_if_not(cur.len >= 8);
+    assume_abort_if_not(dest);
+    assume_abort_if_not(length >= 8);
 
 
     struct aws_byte_cursor old_cur = cur;

--- a/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
+++ b/c/aws-c-common/aws_byte_cursor_read_u8_harness.i
@@ -9098,8 +9098,9 @@ void aws_byte_cursor_read_u8_harness() {
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     assume_abort_if_not(aws_byte_cursor_is_valid(&cur));
 
-    
+    assume_abort_if_not(cur.len >= 1);
     assume_abort_if_not(dest);
+    assume_abort_if_not(length >= 1);
 
 
     struct aws_byte_cursor old_cur = cur;


### PR DESCRIPTION
These benchmarks were not memory safe as the assumptions to constrain
the allocation size were missing or non-sensical.
