### PR TITLE
Fix verdict of value-bounded freire1 tasks to 'true'

### DIFF
--- a/c/nla-digbench-scaling/freire1_valuebound1.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound1.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound1.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound10.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound10.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound10.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound100.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound100.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound100.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound2.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound2.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound2.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound20.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound20.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound20.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound5.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound5.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound5.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/freire1_valuebound50.yml
+++ b/c/nla-digbench-scaling/freire1_valuebound50.yml
@@ -2,7 +2,7 @@ format_version: '2.0'
 input_files: 'freire1_valuebound50.c'
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/no-overflow.prp
     expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp

--- a/c/nla-digbench-scaling/generate.py
+++ b/c/nla-digbench-scaling/generate.py
@@ -62,7 +62,7 @@ assert not re.search(p("hard2"), "hard-ll.c")
 assert not re.search(p("hard\."), "hard-u.c")
 
 # task patterns where the expected result should become true if the values are restricted:
-healed_by_valuebound = [p(x) for x in ["divbin", "hard-ll", "hard\.", "hard-u"]]
+healed_by_valuebound = [p(x) for x in ["divbin", "hard-ll", "hard\.", "hard-u", "freire1"]]
 # task patterns where the expected result should become true if the number of iterations is restricted:
 healed_by_unwindbound = [p("divbin")]
 # task patterns where the expected result should become false if the number of iterations is restricted:


### PR DESCRIPTION
The assertion in these tasks checks that,
for int r and double a,
r^2 - r - a + 2 * (a / 2 - sum(range(0, r))) == 0
(for range-end exclusive)

If there's no imprecisions due to floating-point arithmetics,
this equality is correct.

In the value-bounded tasks, a is restricted to 0 <= a <= 100.
In this value-range, no imprecision is introduced.
Thus, the tasks fulfill property unreach-call.

This PR adjusts the verdicts to match that expectation.