### PR TITLE
busybox date-1: label as undefined

### DIFF
--- a/c/busybox-1.22.0/date-1.yml
+++ b/c/busybox-1.22.0/date-1.yml
@@ -4,12 +4,8 @@ format_version: '2.0'
 input_files: 'date-1.i'
 
 properties:
-  - property_file: ../properties/no-overflow.prp
-    expected_verdict: true
-  - property_file: ../properties/unreach-call.prp
+  - property_file: ../properties/def-behavior.prp
     expected_verdict: false
-  - property_file: ../properties/valid-memsafety.prp
-    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
   - property_file: ../properties/coverage-branches.prp
   - property_file: ../properties/coverage-conditions.prp


### PR DESCRIPTION
I didn't know how to fix the issue on all paths, so I relabelled the benchmark to false(def-behavior).
Fixes #1250.
