### PR TITLE
Initializing local variables to fix undefined behaviors

### DIFF
--- a/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
+++ b/c/aws-c-common/aws_priority_queue_s_sift_down_harness.i
@@ -8453,7 +8453,8 @@ size_t aws_priority_queue_capacity(const struct aws_priority_queue *queue) {
 
 void aws_priority_queue_s_sift_down_harness() {
 
-    struct aws_priority_queue queue;
+    struct aws_priority_queue queue = {0, {0, nondet_size_t(), nondet_size_t(), nondet_size_t(), 0},
+        {0, nondet_size_t(), nondet_size_t(), nondet_size_t(), 0}};
 
 
     assume_abort_if_not(aws_priority_queue_is_bounded(&queue, 5, 2));
@@ -8461,7 +8462,7 @@ void aws_priority_queue_s_sift_down_harness() {
 
 
     assume_abort_if_not(aws_priority_queue_is_valid(&queue));
-    size_t root;
+    size_t root = nondet_size_t();
     assume_abort_if_not(root < queue.container.length);
 
     if (queue.backpointers.data) {


### PR DESCRIPTION
This pull request initializes two local variables to avoid undefined behaviors that
happen because the subsequent code is accessing them without initializing
them.