### PR TITLE
termination-recursive-malloc/chunk3.c: remove double free

### DIFF
--- a/c/termination-recursive-malloc/chunk3.c
+++ b/c/termination-recursive-malloc/chunk3.c
@@ -57,9 +57,7 @@ int main() {
 	
 	
 	int *p1_new = (int*) data[1];
-	int *p2_new = (int*) data[2];
 	
 	free(p1_new);
-	free(p2_new);
 	
 }

--- a/c/termination-recursive-malloc/chunk3.i
+++ b/c/termination-recursive-malloc/chunk3.i
@@ -60,9 +60,7 @@ int main() {
 	
 	
 	int *p1_new = (int*) data[1];
-	int *p2_new = (int*) data[2];
 	
 	free(p1_new);
-	free(p2_new);
 	
 }


### PR DESCRIPTION
The two pointers that were being passed to `free` hold the same value on
all execution paths, thus 1) resulting in a double-free and 2) making
the fix as simple as removing the second call to `free`.

Fixes: #1257
