### PR TITLE
Fix termination verdicts in seq-mthreaded

### DIFF
--- a/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.2.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4.3.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5.2.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.6_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.7_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_lcr.8_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_lcr.8_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.2.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4.3.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5.2.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:

--- a/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_overflow.ufo.UNBOUNDED.pals.yml
@@ -7,7 +7,7 @@ properties:
   - property_file: ../properties/unreach-call.prp
     expected_verdict: false
   - property_file: ../properties/termination.prp
-    expected_verdict: false
+    expected_verdict: true
   - property_file: ../properties/coverage-error-call.prp
 
 options:


### PR DESCRIPTION
The previous verdicts were introduced in #786 without any evidence. CBMC
reports these tasks to be terminating, see
https://sv-comp.sosy-lab.org/2021/results/results-verified/cbmc.2020-12-05_12-30-28.results.SV-COMP21_termination.Termination-Other.xml.bz2.merged.xml.bz2.table.html#/table?filter=0(0*status*(category(in(wrong)))).

Fixes: #1259
