### PR TITLE
ntdrivers/floppy2 is not memory safe

### DIFF
--- a/c/ntdrivers/floppy2.i.cil.yml
+++ b/c/ntdrivers/floppy2.i.cil.yml
@@ -4,10 +4,9 @@ format_version: '2.0'
 input_files: 'floppy2.i.cil.c'
 
 properties:
-  - property_file: ../properties/termination.prp
-    expected_verdict: true
-  - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+  - property_file: ../properties/valid-memsafety.prp
+    expected_verdict: false
+    subproperty: valid-deref
   - property_file: ../properties/coverage-branches.prp
 
 options:


### PR DESCRIPTION
Much like floppy.i.cil-1.c, floppy2.i.cil.c uses `_SLAM_alloc_dummy` to
implement `malloc`, and thus memory safety cannot be ensured. Thus
change the verdict, removing termination and unreach-call, adding
valid-memsafety(false) instead.

Fixes: #1263
