### PR TITLE
Fix possible undefined behavior and intent of loops/linear_search and loops/linear_sea.ch

### DIFF
--- a/c/loops/linear_sea.ch.c
+++ b/c/loops/linear_sea.ch.c
@@ -21,7 +21,6 @@ int linear_search(int *a, int n, int q) {
   else return 0;
 }
 int main() { 
-  unsigned int j;
   SIZE=(__VERIFIER_nondet_uint()/8)+1;
 
   if (SIZE > 1 && SIZE < MAX) {

--- a/c/loops/linear_sea.ch.c
+++ b/c/loops/linear_sea.ch.c
@@ -21,10 +21,13 @@ int linear_search(int *a, int n, int q) {
   else return 0;
 }
 int main() { 
+  unsigned int j;
   SIZE=(__VERIFIER_nondet_uint()/8)+1;
 
   if (SIZE > 1 && SIZE < MAX) {
     int *a = malloc(sizeof(int)*SIZE);
+    for (j=0; j<SIZE; j++)
+      a[j]=0;
     a[SIZE/2]=3;
     __VERIFIER_assert(linear_search(a,SIZE,3));
   }

--- a/c/loops/linear_sea.ch.c
+++ b/c/loops/linear_sea.ch.c
@@ -1,7 +1,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "linear_sea.ch.c", 3, "reach_error"); }
-void *malloc(unsigned int size);
+extern void *calloc(unsigned int num, unsigned int size);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -25,9 +25,7 @@ int main() {
   SIZE=(__VERIFIER_nondet_uint()/8)+1;
 
   if (SIZE > 1 && SIZE < MAX) {
-    int *a = malloc(sizeof(int)*SIZE);
-    for (j=0; j<SIZE; j++)
-      a[j]=0;
+    int *a = calloc(SIZE,sizeof(int));
     a[SIZE/2]=3;
     __VERIFIER_assert(linear_search(a,SIZE,3));
   }

--- a/c/loops/linear_search.c
+++ b/c/loops/linear_search.c
@@ -1,7 +1,7 @@
 extern void abort(void);
 extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void reach_error() { __assert_fail("0", "linear_search.c", 3, "reach_error"); }
-void *malloc(unsigned int size);
+extern void *calloc(unsigned int num, unsigned int size);
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -26,9 +26,7 @@ int main() {
   SIZE=(__VERIFIER_nondet_uint()/2)+1;
 
   if (SIZE > 1 && SIZE < MAX) {
-    int *a = malloc(sizeof(int)*SIZE);
-    for (j=0; j<SIZE; j++)
-      a[j]=0;
+    int *a = calloc(SIZE,sizeof(int));
     a[SIZE/2]=3;
     __VERIFIER_assert(linear_search(a,SIZE,3));
   }

--- a/c/loops/linear_search.c
+++ b/c/loops/linear_search.c
@@ -22,7 +22,6 @@ int linear_search(int *a, int n, int q) {
   else return 0;
 }
 int main() { 
-  unsigned int j;
   SIZE=(__VERIFIER_nondet_uint()/2)+1;
 
   if (SIZE > 1 && SIZE < MAX) {

--- a/c/loops/linear_search.c
+++ b/c/loops/linear_search.c
@@ -22,10 +22,13 @@ int linear_search(int *a, int n, int q) {
   else return 0;
 }
 int main() { 
+  unsigned int j;
   SIZE=(__VERIFIER_nondet_uint()/2)+1;
 
   if (SIZE > 1 && SIZE < MAX) {
     int *a = malloc(sizeof(int)*SIZE);
+    for (j=0; j<SIZE; j++)
+      a[j]=0;
     a[SIZE/2]=3;
     __VERIFIER_assert(linear_search(a,SIZE,3));
   }


### PR DESCRIPTION
See issue #1241 for previous discussion, which didn't get the attention it deserves.

### Possible undefined behavior
As discussed in #1241, reading `malloc`-ed memory without initializing it first is possibly undefined behavior, depending on whether to follow the C standard or the GCC implementation. [It was also pointed out](https://github.com/sosy-lab/sv-benchmarks/issues/1241#issuecomment-734003163) that there exists precedent for handling it here either way. Clearly there is a lack of consensus in this regard. Since this affects SV-COMP more widely than just these two tasks, it would be great to hear more opinions in the issue and hopefully this PR brings more peoples' attention to it.

This PR adds explicit `malloc` array initialization to these tasks, avoiding the problem altogether. I believe this change should be made now and thus the two tasks excluded from SV-COMP 2021, because with conflicting past opinions it has so far been unclear what the verifiers can assume about such memory.

### Intent of the benchmarks
By adding explicit initialization, the question follows what should the array be initialized to. Initializing elements with `__VERIFIER_nondet_int()` would most closely match what could be assumed about the memory, if this isn't considered undefined behavior.

However, [it was already pointed out](https://github.com/sosy-lab/sv-benchmarks/issues/1241#issuecomment-734003163) that such nondeterministic initialization (explicit or implicit) very likely misses the original intent of the programs, which are searching for the specially inserted middle value 3 from the array, because the same value could've been nondeterministically added to any position. Therefore this PR zero-initializes the array, which makes their logic much more logical and realistic.

And as explicit initialization is required anyway to fix the intent of these anyway, then the possible undefined behavior question shouldn't matter for these tasks. Of course if it is agreed, that this isn't undefined behavior then it might be good to have benchmarks which also check hat but those should probably be separate and more thought-through than having an unrelated loops benchmark, whose intent it never was (the benchmarks used VLAs previously), accidentally depend on it. That would be something for future years when a clear consensus on the issue exists ahead of time.