### PR TITLE
aws: initialize variables in two aws benchmarks

### DIFF
--- a/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness-1.i
+++ b/c/aws-c-common/aws_byte_buf_write_from_whole_buffer_harness-1.i
@@ -8980,8 +8980,10 @@ void aws_common_fatal_assert_library_initialized(void) {
 }
 void aws_byte_buf_write_from_whole_buffer_harness() {
 
-    struct aws_byte_buf buf;
-    struct aws_byte_buf src;
+    struct aws_byte_buf buf = {.len = nondet_size_t(),
+                               .capacity = nondet_size_t()};
+    struct aws_byte_buf src = {.len = nondet_size_t(),
+                               .capacity = nondet_size_t()};
 
 
     assume_abort_if_not(aws_byte_buf_is_bounded(&buf, 10));

--- a/c/aws-c-common/aws_priority_queue_init_dynamic_harness-1.i
+++ b/c/aws-c-common/aws_priority_queue_init_dynamic_harness-1.i
@@ -7911,8 +7911,8 @@ void aws_priority_queue_init_dynamic_harness() {
 
 
     struct aws_allocator *allocator = can_fail_allocator();
-    size_t item_size;
-    size_t initial_item_allocation;
+    size_t item_size = nondet_size_t();
+    size_t initial_item_allocation = nondet_size_t();
     size_t len;
 
 


### PR DESCRIPTION
Fixes #1280.
