### PR TITLE
Do not perform pointer comparison over distinct objects

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--misc--sgi-gru--gru.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--usb--s2255--s2255drv.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--wireless--prism54--prism54.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--digi_acceleport.ko-entry_point.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--digi_acceleport.ko-entry_point.cil.out.c
@@ -5,7 +5,7 @@ void reach_error() { assert(0); }
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--digi_acceleport.ko-entry_point.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--usb--serial--digi_acceleport.ko-entry_point.cil.out.i
@@ -13,7 +13,7 @@ void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; els
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/todo/linux-4.2-rc1.tar.xz-43_2a-drivers--net--appletalk--ipddp.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/todo/linux-4.2-rc1.tar.xz-43_2a-drivers--net--appletalk--ipddp.ko-entry_point_true-unreach-call.cil.out.c
@@ -4,7 +4,7 @@ void reach_error(){}
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ldv-linux-4.2-rc1/todo/linux-4.2-rc1.tar.xz-43_2a-drivers--net--appletalk--ipddp.ko-entry_point_true-unreach-call.cil.out.i
+++ b/c/ldv-linux-4.2-rc1/todo/linux-4.2-rc1.tar.xz-43_2a-drivers--net--appletalk--ipddp.ko-entry_point_true-unreach-call.cil.out.i
@@ -3,7 +3,7 @@ void reach_error(){}
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned long int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ntdrivers/diskperf.i.cil-1.c
+++ b/c/ntdrivers/diskperf.i.cil-1.c
@@ -11,7 +11,7 @@ extern long __VERIFIER_nondet_long(void);
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ntdrivers/floppy.i.cil-3.c
+++ b/c/ntdrivers/floppy.i.cil-3.c
@@ -10,7 +10,7 @@ extern long __VERIFIER_nondet_long(void);
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ntdrivers/floppy2.i.cil.c
+++ b/c/ntdrivers/floppy2.i.cil.c
@@ -9,7 +9,7 @@ extern long __VERIFIER_nondet_long(void);
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, const void* p2, unsigned int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }

--- a/c/ntdrivers/parport.i.cil-2.c
+++ b/c/ntdrivers/parport.i.cil-2.c
@@ -15,7 +15,7 @@ extern unsigned long __VERIFIER_nondet_ulong(void);
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 void memcpy_guard(void* p1, void* p2, unsigned int n)
 {
-    if ((char*)p1 + n <= (char*)p2 || (char*)p2 + n <= (char*)p1)
+    if ((unsigned long)p1 + n <= (unsigned long)p2 || (unsigned long)p2 + n <= (unsigned long)p1)
         return;
     abort();
 }


### PR DESCRIPTION
Comparing pointers pointing to distinct objects is undefined behaviour.
Instead, perform the comparison over integers, which is
implementation-defined behaviour.

This fix also contributes to addressing #1266, but several more tasks have this problem. Thus I instead opted to fix it for all of them.
