### PR TITLE
memsafety openbsd: add violated subproperty

### DIFF
--- a/c/openbsd-6.2/if_etherip-double-free.yml
+++ b/c/openbsd-6.2/if_etherip-double-free.yml
@@ -5,6 +5,7 @@ input_files: 'if_etherip-double-free.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
+    subproperty: valid-free
   - property_file: ../properties/coverage-branches.prp
 
 options:

--- a/c/openbsd-6.2/if_etherip-fixed-double-free-invalid-deref1.yml
+++ b/c/openbsd-6.2/if_etherip-fixed-double-free-invalid-deref1.yml
@@ -5,6 +5,7 @@ input_files: 'if_etherip-fixed-double-free-invalid-deref1.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
+    subproperty: valid-deref
 
 options:
   language: C

--- a/c/openbsd-6.2/if_etherip-fixed-double-free-invalid-deref2.yml
+++ b/c/openbsd-6.2/if_etherip-fixed-double-free-invalid-deref2.yml
@@ -5,6 +5,7 @@ input_files: 'if_etherip-fixed-double-free-invalid-deref2.i'
 properties:
   - property_file: ../properties/valid-memsafety.prp
     expected_verdict: false
+    subproperty: valid-deref
 
 options:
   language: C


### PR DESCRIPTION
Part of a fix of #1285.