### PR TITLE
ldv-races/race-4_1-thread_local_vars has a data race

### DIFF
--- a/c/ldv-races/race-4_1-thread_local_vars.yml
+++ b/c/ldv-races/race-4_1-thread_local_vars.yml
@@ -5,7 +5,7 @@ input_files: 'race-4_1-thread_local_vars.i'
 
 properties:
   - property_file: ../properties/unreach-call.prp
-    expected_verdict: true
+    expected_verdict: false
   - property_file: ../properties/coverage-branches.prp
 
 options:


### PR DESCRIPTION
thread_usb and ath9k_flush read/write pdev without any synchronisation
mechanism between them. For example, thread_usb's `ldv_assert(pdev ==
8)` can be violated by ath8k_flush's `pdev = 6`.

The file name and comments suggest that there be some thread-local
variables, but none of the global variables is actually marked
thread-local.
