### PR TITLE
Remove dead link from XCSP Readme

### DIFF
--- a/c/xcsp/README.md
+++ b/c/xcsp/README.md
@@ -19,7 +19,5 @@ Run `make tasks` to recreate the tasks.
   * OS: Ubuntu 18.04
   * g++: version 7.4.0
 
-[License](License)
-
 [1]: https://github.com/vsahil/XCSP3_to_C/tree/master/benchmarks
 [2]: https://github.com/vsahil/XCSP3_to_C


### PR DESCRIPTION
Licenses are stored as SPDX, and the license files referenced doesn't exist anymore.