### PR TITLE
Add CI job that checks links in all markdown files of the repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,13 @@ java-format:
     paths:
       - "java/*.jar"
 
+check-links:
+    stage: checks
+    image:
+        name: ghcr.io/tcort/markdown-link-check:stable
+        entrypoint: [""]
+    script: "find . -name '*.md' | xargs -n 1 /src/markdown-link-check"
+
 .build-docker:
   image:
     name: gcr.io/kaniko-project/executor:debug


### PR DESCRIPTION
This PR adds a Gitlab-CI check for links referenced in Markdown files.
It uses the tool [markdown-link-check](https://github.com/tcort/markdown-link-check) and its official Docker image for this.

Example output of the CI check: https://gitlab.com/lemberger/sv-benchmarks/-/jobs/1046665217