### PR TITLE
Adjust some links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The parameters of a verification task are needed to make additional information
 about the verification task available to the verification run.
 The most prominent parameter is the machine model;
 currently, there are verification tasks for the ILP32 (32-bit) and the LP64 (64-bit) architecture
-(cf. http://www.unix.org/whitepapers/64bit.html).
+(cf. https://www.unix.org/whitepapers/64bit.html).
 
 ### Task Definitions
 
@@ -165,7 +165,7 @@ For each program, the repository contains a .yml file that specifies the followi
   - `options`: parameters that are relevant for verification or give extra information:
     - `language`: programming language that the program is written in (`C` or `Java`)
     - `data_model` data model of the computer architecture
-      (`ILP32`, `LP64`, see http://www.unix.org/whitepapers/64bit.html, only for `C` programs)
+      (`ILP32`, `LP64`, see https://www.unix.org/whitepapers/64bit.html, only for `C` programs)
 
 Optional items are explicitly marked as optional, all other items are mandatory.
 The dictionary `options` can contain additional data that are not mentioned above.


### PR DESCRIPTION
The two commits in this PR seem to have been pushed directly to the repository mirror on gitlab.com on 2021-01-29. Parts of these improvements have also been pushed to GitHub a few minutes later with 3d1593c549f1983370cf88c51b5a4743c8dcc479, but not everything.