### PR TITLE
Remove property for task with undefined behavior (Collatz.yml)

### DIFF
--- a/c/termination-crafted/Collatz.yml
+++ b/c/termination-crafted/Collatz.yml
@@ -6,7 +6,6 @@ input_files: 'Collatz.c'
 properties:
   - property_file: ../properties/no-overflow.prp
     expected_verdict: false
-  - property_file: ../properties/termination.prp
 
 options:
   language: C


### PR DESCRIPTION
This task contains an overflow, so stating the termination
property makes no sense, especially since no verdict is given.